### PR TITLE
feat: auto-select model/reasoning and add persistent user config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ codex-collab health
 - Communicates with Codex via `codex app-server` JSON-RPC protocol over stdio
 - Threads stored in `~/.codex-collab/threads.json` as short ID → full ID mapping
 - Logs stored in `~/.codex-collab/logs/` per thread
+- User defaults stored in `~/.codex-collab/config.json` (model, reasoning, sandbox, approval, timeout)
 - Approval requests use file-based IPC in `~/.codex-collab/approvals/`
 - Short IDs are 8-char hex, support prefix resolution
 - Bun is the TypeScript runtime — never use npm/yarn/pnpm for running

--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ codex-collab config model gpt-5.3-codex
 # Set default reasoning effort
 codex-collab config reasoning high
 
-# Unset (return to auto-detection)
+# Unset a key (return to auto-detection)
 codex-collab config model --unset
+
+# Unset all keys
+codex-collab config --unset
 ```
 
 Available keys: `model`, `reasoning`, `sandbox`, `approval`, `timeout`

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ codex-collab run --resume <id> "now check error handling" --content-only
 | Flag | Description |
 |------|-------------|
 | `-d, --dir <path>` | Working directory |
-| `-m, --model <model>` | Model name |
-| `-r, --reasoning <level>` | low, medium, high, xhigh (default: xhigh) |
+| `-m, --model <model>` | Model name (default: auto — latest available) |
+| `-r, --reasoning <level>` | low, medium, high, xhigh (default: auto — highest for model) |
 | `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
 | `--mode <mode>` | Review mode: pr, uncommitted, commit, custom |
 | `--ref <hash>` | Commit ref for `--mode commit` |
@@ -117,6 +117,36 @@ codex-collab run --resume <id> "now check error handling" --content-only
 | `--base <branch>` | Base branch for PR review (default: main) |
 
 </details>
+
+## Defaults & Configuration
+
+By default, codex-collab auto-selects the **latest model** (preferring `-codex` variants) and the **highest reasoning effort** supported by that model. No configuration needed — it stays current as new models are released.
+
+To override defaults persistently, use `codex-collab config`:
+
+```bash
+# Show current config
+codex-collab config
+
+# Set a preferred model
+codex-collab config model gpt-5.3-codex
+
+# Set default reasoning effort
+codex-collab config reasoning high
+
+# Unset (return to auto-detection)
+codex-collab config model --unset
+```
+
+Available keys: `model`, `reasoning`, `sandbox`, `approval`, `timeout`
+
+CLI flags always take precedence over config, and config takes precedence over auto-detection:
+
+```
+CLI flag  >  config file  >  auto-detected
+```
+
+Config is stored in `~/.codex-collab/config.json`.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,8 +105,8 @@ codex-collab run --resume <id> "现在检查错误处理" --content-only
 | 参数 | 说明 |
 |------|------|
 | `-d, --dir <path>` | 工作目录 |
-| `-m, --model <model>` | 模型名称 |
-| `-r, --reasoning <level>` | low, medium, high, xhigh（默认: xhigh） |
+| `-m, --model <model>` | 模型名称（默认: 自动选择最新可用模型） |
+| `-r, --reasoning <level>` | low, medium, high, xhigh（默认: 自动选择模型支持的最高级别） |
 | `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access（默认: workspace-write；review 始终使用 read-only） |
 | `--mode <mode>` | 审查模式: pr, uncommitted, commit, custom |
 | `--ref <hash>` | 指定 commit 哈希（配合 `--mode commit`） |
@@ -117,6 +117,25 @@ codex-collab run --resume <id> "现在检查错误处理" --content-only
 | `--base <branch>` | PR 审查的基准分支（默认: main） |
 
 </details>
+
+## 默认值与配置
+
+默认情况下，codex-collab 自动选择**最新模型**（优先选择 `-codex` 变体）及该模型支持的**最高推理级别**。无需配置——新模型发布后自动更新。
+
+使用 `codex-collab config` 持久化覆盖默认值：
+
+```bash
+codex-collab config                     # 查看当前配置
+codex-collab config model gpt-5.3-codex # 设置默认模型
+codex-collab config reasoning high      # 设置默认推理级别
+codex-collab config model --unset       # 取消设置（恢复自动检测）
+```
+
+可配置项: `model`、`reasoning`、`sandbox`、`approval`、`timeout`
+
+优先级: `CLI 参数 > 配置文件 > 自动检测`
+
+配置存储于 `~/.codex-collab/config.json`。
 
 ## 参与贡献
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,7 +128,8 @@ codex-collab run --resume <id> "现在检查错误处理" --content-only
 codex-collab config                     # 查看当前配置
 codex-collab config model gpt-5.3-codex # 设置默认模型
 codex-collab config reasoning high      # 设置默认推理级别
-codex-collab config model --unset       # 取消设置（恢复自动检测）
+codex-collab config model --unset       # 取消单个设置（恢复自动检测）
+codex-collab config --unset             # 取消所有设置
 ```
 
 可配置项: `model`、`reasoning`、`sandbox`、`approval`、`timeout`

--- a/SKILL.md
+++ b/SKILL.md
@@ -106,7 +106,7 @@ codex-collab progress <id>
 
 Progress lines stream in real-time during execution:
 ```
-[codex] Thread a1b2c3d4 started (gpt-5.3-codex, workspace-write)
+[codex] Thread a1b2c3d4 started (gpt-5.4, workspace-write)
 [codex] Turn started
 [codex] Running: npm test
 [codex] Edited: src/auth.ts (update)
@@ -177,6 +177,9 @@ codex-collab clean                      # Delete old logs and stale mappings
 ### Utility
 
 ```bash
+codex-collab config                     # Show persistent defaults
+codex-collab config model gpt-5.3-codex # Set default model
+codex-collab config model --unset       # Unset (return to auto)
 codex-collab models                     # List available models
 codex-collab approve <id>              # Approve a pending request
 codex-collab decline <id>              # Decline a pending request
@@ -187,8 +190,8 @@ codex-collab health                     # Check prerequisites
 
 | Flag | Description |
 |------|-------------|
-| `-m, --model <model>` | Model name (default: gpt-5.3-codex) |
-| `-r, --reasoning <level>` | Reasoning effort: low, medium, high, xhigh (default: xhigh) |
+| `-m, --model <model>` | Model name (default: auto — latest available) |
+| `-r, --reasoning <level>` | Reasoning effort: low, medium, high, xhigh (default: auto — highest for model) |
 | `-s, --sandbox <mode>` | Sandbox: read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
 | `-d, --dir <path>` | Working directory (default: cwd) |
 | `--resume <id>` | Resume existing thread (run and review) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -179,7 +179,8 @@ codex-collab clean                      # Delete old logs and stale mappings
 ```bash
 codex-collab config                     # Show persistent defaults
 codex-collab config model gpt-5.3-codex # Set default model
-codex-collab config model --unset       # Unset (return to auto)
+codex-collab config model --unset       # Unset a key (return to auto)
+codex-collab config --unset             # Unset all keys (return to auto)
 codex-collab models                     # List available models
 codex-collab approve <id>              # Approve a pending request
 codex-collab decline <id>              # Decline a pending request

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
   loadThreadMapping,
   removeThread,
   saveThreadMapping,
+  updateThreadMeta,
   updateThreadStatus,
   withThreadLock,
 } from "./threads";
@@ -435,25 +436,31 @@ function createDispatcher(shortId: string, opts: Options): EventDispatcher {
   );
 }
 
-/** Pick the best model from a list: latest (no upgrade), prefer -codex variant.
- *  Does NOT filter hidden models — some latest models (e.g. -codex variants)
- *  may be hidden in the catalog but still usable via the API. */
+/** Pick the best model by following the upgrade chain from the server default,
+ *  then preferring a -codex variant if one exists at the latest generation. */
 function pickBestModel(models: Model[]): string | undefined {
-  // Models with no upgrade are the latest generation; sort descending by ID
-  // so higher version numbers (e.g. gpt-5.4 > gpt-5.3) are preferred
-  const latest = models.filter(m => m.upgrade === null)
-    .sort((a, b) => b.id.localeCompare(a.id));
-  if (latest.length > 0) {
-    const codex = latest.find(m => m.id.endsWith("-codex"));
-    if (codex) return codex.id;
-    return latest[0].id;
+  const byId = new Map(models.map(m => [m.id, m]));
+
+  // Start from the server's default model
+  let current = models.find(m => m.isDefault);
+  if (!current) return undefined;
+
+  // Follow the upgrade chain to the latest generation
+  const visited = new Set<string>();
+  while (current.upgrade && !visited.has(current.id)) {
+    visited.add(current.id);
+    const next = byId.get(current.upgrade);
+    if (!next) break; // upgrade target not in the list
+    current = next;
   }
 
-  // Fall back to server default
-  const serverDefault = models.find(m => m.isDefault);
-  if (serverDefault) return serverDefault.id;
+  // Prefer -codex variant if available at this generation
+  if (!current.id.endsWith("-codex")) {
+    const codexVariant = byId.get(current.id + "-codex");
+    if (codexVariant && codexVariant.upgrade === null) return codexVariant.id;
+  }
 
-  return undefined;
+  return current.id;
 }
 
 /** Pick the highest reasoning effort a model supports. */
@@ -650,6 +657,12 @@ async function startOrResumeThread(
     // Forced overrides from caller (e.g., review forces sandbox to read-only)
     if (extraStartParams) Object.assign(resumeParams, extraStartParams);
     const effective = await client.request<ThreadStartResponse>("thread/resume", resumeParams);
+    // Refresh stored metadata so `jobs` stays accurate after resume
+    updateThreadMeta(config.threadsFile, threadId, {
+      model: effective.model,
+      ...(opts.explicit.has("dir") ? { cwd: opts.dir } : {}),
+      ...(preview ? { preview } : {}),
+    });
     return { threadId, shortId, effective };
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,6 @@ import {
 import { resolve, join } from "path";
 import type {
   ReviewTarget,
-  Thread,
   ThreadStartResponse,
   Model,
   TurnResult,
@@ -59,17 +58,34 @@ interface UserConfig {
 
 function loadUserConfig(): UserConfig {
   try {
-    return JSON.parse(readFileSync(config.configFile, "utf-8")) as UserConfig;
-  } catch {
+    const parsed = JSON.parse(readFileSync(config.configFile, "utf-8"));
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      console.error(`[codex] Warning: config file is not a JSON object — ignoring: ${config.configFile}`);
+      return {};
+    }
+    return parsed as UserConfig;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return {};
+    if (e instanceof SyntaxError) {
+      console.error(`[codex] Warning: invalid JSON in ${config.configFile} — ignoring config`);
+    } else {
+      console.error(`[codex] Warning: could not read config: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {};
   }
 }
 
 function saveUserConfig(cfg: UserConfig): void {
-  writeFileSync(config.configFile, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
+  try {
+    writeFileSync(config.configFile, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
+  } catch (e) {
+    die(`Could not save config to ${config.configFile}: ${e instanceof Error ? e.message : String(e)}`);
+  }
 }
 
-/** Apply user config to parsed options — only for fields not set via CLI flags. */
+/** Apply user config to parsed options — only for fields not set via CLI flags.
+ *  Config values are added to `configured` (not `explicit`) so they suppress
+ *  auto-detection but are NOT forwarded as overrides on thread resume. */
 function applyUserConfig(options: Options): void {
   const cfg = loadUserConfig();
 
@@ -78,13 +94,13 @@ function applyUserConfig(options: Options): void {
       console.error(`[codex] Warning: ignoring invalid model in config: ${cfg.model}`);
     } else {
       options.model = cfg.model;
-      options.explicit.add("model");
+      options.configured.add("model");
     }
   }
   if (!options.explicit.has("reasoning") && typeof cfg.reasoning === "string") {
     if (config.reasoningEfforts.includes(cfg.reasoning as any)) {
       options.reasoning = cfg.reasoning as ReasoningEffort;
-      options.explicit.add("reasoning");
+      options.configured.add("reasoning");
     } else {
       console.error(`[codex] Warning: ignoring invalid reasoning in config: ${cfg.reasoning}`);
     }
@@ -92,7 +108,7 @@ function applyUserConfig(options: Options): void {
   if (!options.explicit.has("sandbox") && typeof cfg.sandbox === "string") {
     if (config.sandboxModes.includes(cfg.sandbox as any)) {
       options.sandbox = cfg.sandbox as SandboxMode;
-      options.explicit.add("sandbox");
+      options.configured.add("sandbox");
     } else {
       console.error(`[codex] Warning: ignoring invalid sandbox in config: ${cfg.sandbox}`);
     }
@@ -100,13 +116,17 @@ function applyUserConfig(options: Options): void {
   if (!options.explicit.has("approval") && typeof cfg.approval === "string") {
     if (config.approvalPolicies.includes(cfg.approval as any)) {
       options.approval = cfg.approval as ApprovalPolicy;
-      options.explicit.add("approval");
+      options.configured.add("approval");
     } else {
       console.error(`[codex] Warning: ignoring invalid approval in config: ${cfg.approval}`);
     }
   }
-  if (typeof cfg.timeout === "number" && Number.isFinite(cfg.timeout) && cfg.timeout > 0) {
-    options.timeout = cfg.timeout;
+  if (!options.explicit.has("timeout") && cfg.timeout !== undefined) {
+    if (typeof cfg.timeout === "number" && Number.isFinite(cfg.timeout) && cfg.timeout > 0) {
+      options.timeout = cfg.timeout;
+    } else {
+      console.error(`[codex] Warning: ignoring invalid timeout in config: ${cfg.timeout}`);
+    }
   }
 }
 
@@ -178,8 +198,10 @@ interface Options {
   reviewRef: string | null;
   base: string;
   resumeId: string | null;
-  /** Flags explicitly provided on the command line. */
+  /** Flags explicitly provided on the command line (forwarded on resume). */
   explicit: Set<string>;
+  /** Flags set by user config file (suppress auto-detection but NOT forwarded on resume). */
+  configured: Set<string>;
 }
 
 function parseArgs(args: string[]): ParsedArgs {
@@ -198,6 +220,7 @@ function parseArgs(args: string[]): ParsedArgs {
     base: "main",
     resumeId: null,
     explicit: new Set<string>(),
+    configured: new Set<string>(),
   };
 
   const positional: string[] = [];
@@ -288,6 +311,7 @@ function parseArgs(args: string[]): ParsedArgs {
         process.exit(1);
       }
       options.timeout = val;
+      options.explicit.add("timeout");
     } else if (arg === "--limit") {
       if (i + 1 >= args.length) {
         console.error("Error: --limit requires a value");
@@ -411,12 +435,12 @@ function createDispatcher(shortId: string, opts: Options): EventDispatcher {
   );
 }
 
-/** Pick the best model from a list: latest (no upgrade), prefer -codex variant. */
+/** Pick the best model from a list: latest (no upgrade), prefer -codex variant.
+ *  Does NOT filter hidden models — some latest models (e.g. -codex variants)
+ *  may be hidden in the catalog but still usable via the API. */
 function pickBestModel(models: Model[]): string {
-  const visible = models.filter(m => !m.hidden);
-
   // Models with no upgrade are the latest generation
-  const latest = visible.filter(m => m.upgrade === null);
+  const latest = models.filter(m => m.upgrade === null);
   if (latest.length > 0) {
     const codex = latest.find(m => m.id.endsWith("-codex"));
     if (codex) return codex.id;
@@ -424,9 +448,10 @@ function pickBestModel(models: Model[]): string {
   }
 
   // Fall back to server default
-  const serverDefault = visible.find(m => m.isDefault);
+  const serverDefault = models.find(m => m.isDefault);
   if (serverDefault) return serverDefault.id;
 
+  console.error(`[codex] Warning: no latest or default model found in catalog. Using fallback: ${config.fallbackModel}`);
   return config.fallbackModel;
 }
 
@@ -436,20 +461,26 @@ function pickHighestEffort(supported: Array<{ reasoningEffort: string }>): Reaso
   for (let i = config.reasoningEfforts.length - 1; i >= 0; i--) {
     if (available.has(config.reasoningEfforts[i])) return config.reasoningEfforts[i];
   }
+  console.error(`[codex] Warning: model supports [${[...available].join(", ")}] but none match known levels. Defaulting to ${config.defaultReasoningEffort}.`);
   return config.defaultReasoningEffort;
 }
 
-/** Auto-resolve model and/or reasoning effort for non-explicit options. */
+/** Auto-resolve model and/or reasoning effort when not set by CLI or config. */
 async function resolveDefaults(client: AppServerClient, opts: Options): Promise<void> {
-  const needModel = !opts.explicit.has("model");
-  const needReasoning = !opts.explicit.has("reasoning");
+  const isSet = (key: string) => opts.explicit.has(key) || opts.configured.has(key);
+  const needModel = !isSet("model");
+  const needReasoning = !isSet("reasoning");
   if (!needModel && !needReasoning) return;
 
   let models: Model[];
   try {
     models = await fetchAllPages<Model>(client, "model/list");
-    if (models.length === 0) return;
-  } catch {
+  } catch (e) {
+    console.error(`[codex] Warning: could not fetch model list (${e instanceof Error ? e.message : String(e)}). Using defaults.`);
+    return;
+  }
+  if (models.length === 0) {
+    console.error(`[codex] Warning: server returned no models. Using defaults.`);
     return;
   }
 
@@ -599,6 +630,7 @@ async function startOrResumeThread(
   client: AppServerClient,
   opts: Options,
   extraStartParams?: Record<string, unknown>,
+  preview?: string,
 ): Promise<{ threadId: string; shortId: string; effective: ThreadStartResponse }> {
   if (opts.resumeId) {
     const threadId = resolveThreadId(config.threadsFile, opts.resumeId);
@@ -635,6 +667,7 @@ async function startOrResumeThread(
   registerThread(config.threadsFile, threadId, {
     model: opts.model,
     cwd: opts.dir,
+    preview,
   });
   const shortId = findShortId(config.threadsFile, threadId);
   if (!shortId) die(`Internal error: thread ${threadId.slice(0, 12)}... registered but not found in mapping`);
@@ -670,7 +703,7 @@ async function cmdRun(positional: string[], opts: Options) {
   const exitCode = await withClient(async (client) => {
     await resolveDefaults(client, opts);
 
-    const { threadId, shortId, effective } = await startOrResumeThread(client, opts);
+    const { threadId, shortId, effective } = await startOrResumeThread(client, opts, undefined, prompt);
 
     if (opts.contentOnly) {
       console.error(`[codex] Running (thread ${shortId})...`);
@@ -724,8 +757,11 @@ async function cmdReview(positional: string[], opts: Options) {
   const exitCode = await withClient(async (client) => {
     await resolveDefaults(client, opts);
 
+    const reviewPreview = target.type === "custom"
+      ? target.instructions
+      : `Review ${target.type === "baseBranch" ? `PR (base: ${target.branch})` : target.type === "uncommittedChanges" ? "uncommitted changes" : `commit ${target.sha}`}`;
     const { threadId, shortId, effective } = await startOrResumeThread(
-      client, opts, { sandbox: "read-only" },
+      client, opts, { sandbox: "read-only" }, reviewPreview,
     );
 
     if (opts.contentOnly) {
@@ -790,62 +826,52 @@ async function fetchAllPages<T>(
 
 async function cmdJobs(opts: Options) {
   const mapping = loadThreadMapping(config.threadsFile);
-  const reverseMap = new Map<string, string>();
-  for (const [shortId, entry] of Object.entries(mapping)) {
-    reverseMap.set(entry.threadId, shortId);
-  }
 
-  // Fetch all pages from server — we filter to locally-known threads,
-  // so a single page could miss local threads buried behind non-local ones.
-  const allThreads = await withClient((client) =>
-    fetchAllPages<Thread>(client, "thread/list", { sortKey: "updated_at" }),
-  );
-
-  // Only show threads created by this CLI (those with a local short ID mapping)
-  let localThreads = allThreads.filter((t) => reverseMap.has(t.id));
+  // Build entries sorted by updatedAt (most recent first), falling back to createdAt
+  let entries = Object.entries(mapping)
+    .map(([shortId, entry]) => ({ shortId, ...entry }))
+    .sort((a, b) => {
+      const ta = new Date(a.updatedAt ?? a.createdAt).getTime();
+      const tb = new Date(b.updatedAt ?? b.createdAt).getTime();
+      return tb - ta;
+    });
 
   // Detect stale "running" status: if the owning process is dead, mark as interrupted.
-  for (const t of localThreads) {
-    const sid = reverseMap.get(t.id)!;
-    const entry = mapping[sid];
-    if (entry?.lastStatus === "running" && !isProcessAlive(sid)) {
-      updateThreadStatus(config.threadsFile, t.id, "interrupted");
-      entry.lastStatus = "interrupted";
-      removePidFile(sid);
+  for (const e of entries) {
+    if (e.lastStatus === "running" && !isProcessAlive(e.shortId)) {
+      updateThreadStatus(config.threadsFile, e.threadId, "interrupted");
+      e.lastStatus = "interrupted";
+      removePidFile(e.shortId);
     }
   }
 
-  if (opts.limit !== Infinity) localThreads = localThreads.slice(0, opts.limit);
+  if (opts.limit !== Infinity) entries = entries.slice(0, opts.limit);
 
   if (opts.json) {
-    const enriched = localThreads.map((t) => {
-      const sid = reverseMap.get(t.id)!;
-      const entry = mapping[sid];
-      return {
-        shortId: sid,
-        threadId: t.id,
-        status: entry.lastStatus ?? "unknown",
-        modelProvider: t.modelProvider,
-        cwd: t.cwd,
-        preview: t.preview || null,
-        createdAt: new Date(t.createdAt * 1000).toISOString(),
-        updatedAt: new Date(t.updatedAt * 1000).toISOString(),
-      };
-    });
+    const enriched = entries.map(e => ({
+      shortId: e.shortId,
+      threadId: e.threadId,
+      status: e.lastStatus ?? "unknown",
+      model: e.model ?? null,
+      cwd: e.cwd ?? null,
+      preview: e.preview ?? null,
+      createdAt: e.createdAt,
+      updatedAt: e.updatedAt ?? e.createdAt,
+    }));
     console.log(JSON.stringify(enriched, null, 2));
   } else {
-    if (localThreads.length === 0) {
+    if (entries.length === 0) {
       console.log("No threads found.");
       return;
     }
-    for (const t of localThreads) {
-      const sid = reverseMap.get(t.id)!;
-      const entry = mapping[sid];
-      const status = entry.lastStatus ?? "idle";
-      const age = formatAge(t.updatedAt);
-      const preview = t.preview ? ` ${t.preview.slice(0, 50)}` : "";
+    for (const e of entries) {
+      const status = e.lastStatus ?? "idle";
+      const ts = new Date(e.updatedAt ?? e.createdAt).getTime() / 1000;
+      const age = formatAge(ts);
+      const model = e.model ? ` (${e.model})` : "";
+      const preview = e.preview ? ` ${e.preview.slice(0, 50)}` : "";
       console.log(
-        `  ${sid}  ${status.padEnd(12)} ${age.padEnd(8)} ${t.cwd}${preview}`,
+        `  ${e.shortId}  ${status.padEnd(12)} ${age.padEnd(8)} ${e.cwd ?? ""}${model}${preview}`,
       );
     }
   }
@@ -1177,8 +1203,13 @@ async function cmdConfig(positional: string[], opts: Options) {
 
   const cfg = loadUserConfig();
 
-  // No args → show current config
+  // No args → show current config, or --unset to clear all
   if (positional.length === 0) {
+    if (opts.explicit.has("unset")) {
+      saveUserConfig({});
+      console.log("All config values cleared. Using auto-detected defaults.");
+      return;
+    }
     if (Object.keys(cfg).length === 0) {
       console.log("No user config set. Using auto-detected defaults.");
       console.log(`\nConfig file: ${config.configFile}`);
@@ -1195,7 +1226,7 @@ async function cmdConfig(positional: string[], opts: Options) {
   }
 
   const key = positional[0];
-  if (!(key in VALID_KEYS)) {
+  if (!Object.hasOwn(VALID_KEYS, key)) {
     die(`Unknown config key: ${key}\nValid keys: ${Object.keys(VALID_KEYS).join(", ")}`);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -439,8 +439,10 @@ function createDispatcher(shortId: string, opts: Options): EventDispatcher {
  *  Does NOT filter hidden models — some latest models (e.g. -codex variants)
  *  may be hidden in the catalog but still usable via the API. */
 function pickBestModel(models: Model[]): string {
-  // Models with no upgrade are the latest generation
-  const latest = models.filter(m => m.upgrade === null);
+  // Models with no upgrade are the latest generation; sort descending by ID
+  // so higher version numbers (e.g. gpt-5.4 > gpt-5.3) are preferred
+  const latest = models.filter(m => m.upgrade === null)
+    .sort((a, b) => b.id.localeCompare(a.id));
   if (latest.length > 0) {
     const codex = latest.find(m => m.id.endsWith("-codex"));
     if (codex) return codex.id;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -185,8 +185,8 @@ interface ParsedArgs {
 }
 
 interface Options {
-  reasoning: ReasoningEffort;
-  model: string;
+  reasoning: ReasoningEffort | undefined;
+  model: string | undefined;
   sandbox: SandboxMode;
   approval: ApprovalPolicy;
   dir: string;
@@ -206,8 +206,8 @@ interface Options {
 
 function parseArgs(args: string[]): ParsedArgs {
   const options: Options = {
-    reasoning: config.defaultReasoningEffort,
-    model: config.fallbackModel,
+    reasoning: undefined,
+    model: undefined,
     sandbox: config.defaultSandbox,
     approval: config.defaultApprovalPolicy,
     dir: process.cwd(),
@@ -438,7 +438,7 @@ function createDispatcher(shortId: string, opts: Options): EventDispatcher {
 /** Pick the best model from a list: latest (no upgrade), prefer -codex variant.
  *  Does NOT filter hidden models — some latest models (e.g. -codex variants)
  *  may be hidden in the catalog but still usable via the API. */
-function pickBestModel(models: Model[]): string {
+function pickBestModel(models: Model[]): string | undefined {
   // Models with no upgrade are the latest generation; sort descending by ID
   // so higher version numbers (e.g. gpt-5.4 > gpt-5.3) are preferred
   const latest = models.filter(m => m.upgrade === null)
@@ -453,18 +453,16 @@ function pickBestModel(models: Model[]): string {
   const serverDefault = models.find(m => m.isDefault);
   if (serverDefault) return serverDefault.id;
 
-  console.error(`[codex] Warning: no latest or default model found in catalog. Using fallback: ${config.fallbackModel}`);
-  return config.fallbackModel;
+  return undefined;
 }
 
 /** Pick the highest reasoning effort a model supports. */
-function pickHighestEffort(supported: Array<{ reasoningEffort: string }>): ReasoningEffort {
+function pickHighestEffort(supported: Array<{ reasoningEffort: string }>): ReasoningEffort | undefined {
   const available = new Set(supported.map(s => s.reasoningEffort));
   for (let i = config.reasoningEfforts.length - 1; i >= 0; i--) {
     if (available.has(config.reasoningEfforts[i])) return config.reasoningEfforts[i];
   }
-  console.error(`[codex] Warning: model supports [${[...available].join(", ")}] but none match known levels. Defaulting to ${config.defaultReasoningEffort}.`);
-  return config.defaultReasoningEffort;
+  return undefined;
 }
 
 /** Auto-resolve model and/or reasoning effort when not set by CLI or config. */
@@ -476,7 +474,7 @@ async function resolveDefaults(client: AppServerClient, opts: Options): Promise<
 
   let models: Model[];
   try {
-    models = await fetchAllPages<Model>(client, "model/list");
+    models = await fetchAllPages<Model>(client, "model/list", { includeHidden: true });
   } catch (e) {
     console.error(`[codex] Warning: could not fetch model list (${e instanceof Error ? e.message : String(e)}). Using defaults.`);
     return;
@@ -541,7 +539,10 @@ function resolveReviewTarget(positional: string[], opts: Options): ReviewTarget 
 /** Per-turn parameter overrides: all values for new threads, explicit-only for resume. */
 function turnOverrides(opts: Options) {
   if (!opts.resumeId) {
-    return { cwd: opts.dir, model: opts.model, effort: opts.reasoning, approvalPolicy: opts.approval };
+    const o: Record<string, unknown> = { cwd: opts.dir, approvalPolicy: opts.approval };
+    if (opts.model) o.model = opts.model;
+    if (opts.reasoning) o.effort = opts.reasoning;
+    return o;
   }
   const o: Record<string, unknown> = {};
   if (opts.explicit.has("dir")) o.cwd = opts.dir;
@@ -653,7 +654,6 @@ async function startOrResumeThread(
   }
 
   const startParams: Record<string, unknown> = {
-    model: opts.model,
     cwd: opts.dir,
     approvalPolicy: opts.approval,
     sandbox: opts.sandbox,
@@ -661,13 +661,14 @@ async function startOrResumeThread(
     persistExtendedHistory: false,
     ...extraStartParams,
   };
+  if (opts.model) startParams.model = opts.model;
   const effective = await client.request<ThreadStartResponse>(
     "thread/start",
     startParams,
   );
   const threadId = effective.thread.id;
   registerThread(config.threadsFile, threadId, {
-    model: opts.model,
+    model: effective.model,
     cwd: opts.dir,
     preview,
   });
@@ -1006,7 +1007,7 @@ async function cmdProgress(positional: string[]) {
 
 async function cmdModels() {
   const allModels = await withClient((client) =>
-    fetchAllPages<Model>(client, "model/list"),
+    fetchAllPages<Model>(client, "model/list", { includeHidden: true }),
   );
 
   for (const m of allModels) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -483,11 +483,11 @@ async function resolveDefaults(client: AppServerClient, opts: Options): Promise<
   try {
     models = await fetchAllPages<Model>(client, "model/list", { includeHidden: true });
   } catch (e) {
-    console.error(`[codex] Warning: could not fetch model list (${e instanceof Error ? e.message : String(e)}). Using defaults.`);
+    console.error(`[codex] Warning: could not fetch model list (${e instanceof Error ? e.message : String(e)}). Model and reasoning will be determined by the server.`);
     return;
   }
   if (models.length === 0) {
-    console.error(`[codex] Warning: server returned no models. Using defaults.`);
+    console.error(`[codex] Warning: server returned no models. Model and reasoning will be determined by the server.`);
     return;
   }
 
@@ -773,9 +773,13 @@ async function cmdReview(positional: string[], opts: Options) {
   const exitCode = await withClient(async (client) => {
     await resolveDefaults(client, opts);
 
-    const reviewPreview = target.type === "custom"
-      ? target.instructions
-      : `Review ${target.type === "baseBranch" ? `PR (base: ${target.branch})` : target.type === "uncommittedChanges" ? "uncommitted changes" : `commit ${target.sha}`}`;
+    let reviewPreview: string;
+    switch (target.type) {
+      case "custom": reviewPreview = target.instructions; break;
+      case "baseBranch": reviewPreview = `Review PR (base: ${target.branch})`; break;
+      case "uncommittedChanges": reviewPreview = "Review uncommitted changes"; break;
+      case "commit": reviewPreview = `Review commit ${target.sha}`; break;
+    }
     const { threadId, shortId, effective } = await startOrResumeThread(
       client, opts, { sandbox: "read-only" }, reviewPreview,
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,72 @@ import type {
 } from "./types";
 
 // ---------------------------------------------------------------------------
+// User config — persistent defaults from ~/.codex-collab/config.json
+// ---------------------------------------------------------------------------
+
+/** Fields users can set in ~/.codex-collab/config.json. */
+interface UserConfig {
+  model?: string;
+  reasoning?: string;
+  sandbox?: string;
+  approval?: string;
+  timeout?: number;
+}
+
+function loadUserConfig(): UserConfig {
+  try {
+    return JSON.parse(readFileSync(config.configFile, "utf-8")) as UserConfig;
+  } catch {
+    return {};
+  }
+}
+
+function saveUserConfig(cfg: UserConfig): void {
+  writeFileSync(config.configFile, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
+}
+
+/** Apply user config to parsed options — only for fields not set via CLI flags. */
+function applyUserConfig(options: Options): void {
+  const cfg = loadUserConfig();
+
+  if (!options.explicit.has("model") && typeof cfg.model === "string") {
+    if (/[^a-zA-Z0-9._\-\/:]/.test(cfg.model)) {
+      console.error(`[codex] Warning: ignoring invalid model in config: ${cfg.model}`);
+    } else {
+      options.model = cfg.model;
+      options.explicit.add("model");
+    }
+  }
+  if (!options.explicit.has("reasoning") && typeof cfg.reasoning === "string") {
+    if (config.reasoningEfforts.includes(cfg.reasoning as any)) {
+      options.reasoning = cfg.reasoning as ReasoningEffort;
+      options.explicit.add("reasoning");
+    } else {
+      console.error(`[codex] Warning: ignoring invalid reasoning in config: ${cfg.reasoning}`);
+    }
+  }
+  if (!options.explicit.has("sandbox") && typeof cfg.sandbox === "string") {
+    if (config.sandboxModes.includes(cfg.sandbox as any)) {
+      options.sandbox = cfg.sandbox as SandboxMode;
+      options.explicit.add("sandbox");
+    } else {
+      console.error(`[codex] Warning: ignoring invalid sandbox in config: ${cfg.sandbox}`);
+    }
+  }
+  if (!options.explicit.has("approval") && typeof cfg.approval === "string") {
+    if (config.approvalPolicies.includes(cfg.approval as any)) {
+      options.approval = cfg.approval as ApprovalPolicy;
+      options.explicit.add("approval");
+    } else {
+      console.error(`[codex] Warning: ignoring invalid approval in config: ${cfg.approval}`);
+    }
+  }
+  if (typeof cfg.timeout === "number" && Number.isFinite(cfg.timeout) && cfg.timeout > 0) {
+    options.timeout = cfg.timeout;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Signal handlers — clean up spawned app-server and update thread status
 // ---------------------------------------------------------------------------
 
@@ -119,7 +185,7 @@ interface Options {
 function parseArgs(args: string[]): ParsedArgs {
   const options: Options = {
     reasoning: config.defaultReasoningEffort,
-    model: config.model,
+    model: config.fallbackModel,
     sandbox: config.defaultSandbox,
     approval: config.defaultApprovalPolicy,
     dir: process.cwd(),
@@ -265,6 +331,8 @@ function parseArgs(args: string[]): ParsedArgs {
       options.resumeId = args[++i];
     } else if (arg === "--all") {
       options.limit = Infinity;
+    } else if (arg === "--unset") {
+      options.explicit.add("unset");
     } else if (arg.startsWith("-")) {
       console.error(`Error: Unknown option: ${arg}`);
       console.error("Run codex-collab --help for usage");
@@ -341,6 +409,60 @@ function createDispatcher(shortId: string, opts: Options): EventDispatcher {
     config.logsDir,
     opts.contentOnly ? () => {} : progress,
   );
+}
+
+/** Pick the best model from a list: latest (no upgrade), prefer -codex variant. */
+function pickBestModel(models: Model[]): string {
+  const visible = models.filter(m => !m.hidden);
+
+  // Models with no upgrade are the latest generation
+  const latest = visible.filter(m => m.upgrade === null);
+  if (latest.length > 0) {
+    const codex = latest.find(m => m.id.endsWith("-codex"));
+    if (codex) return codex.id;
+    return latest[0].id;
+  }
+
+  // Fall back to server default
+  const serverDefault = visible.find(m => m.isDefault);
+  if (serverDefault) return serverDefault.id;
+
+  return config.fallbackModel;
+}
+
+/** Pick the highest reasoning effort a model supports. */
+function pickHighestEffort(supported: Array<{ reasoningEffort: string }>): ReasoningEffort {
+  const available = new Set(supported.map(s => s.reasoningEffort));
+  for (let i = config.reasoningEfforts.length - 1; i >= 0; i--) {
+    if (available.has(config.reasoningEfforts[i])) return config.reasoningEfforts[i];
+  }
+  return config.defaultReasoningEffort;
+}
+
+/** Auto-resolve model and/or reasoning effort for non-explicit options. */
+async function resolveDefaults(client: AppServerClient, opts: Options): Promise<void> {
+  const needModel = !opts.explicit.has("model");
+  const needReasoning = !opts.explicit.has("reasoning");
+  if (!needModel && !needReasoning) return;
+
+  let models: Model[];
+  try {
+    models = await fetchAllPages<Model>(client, "model/list");
+    if (models.length === 0) return;
+  } catch {
+    return;
+  }
+
+  if (needModel) {
+    opts.model = pickBestModel(models);
+  }
+
+  if (needReasoning) {
+    const modelData = models.find(m => m.id === opts.model);
+    if (modelData?.supportedReasoningEfforts?.length) {
+      opts.reasoning = pickHighestEffort(modelData.supportedReasoningEfforts);
+    }
+  }
 }
 
 /** Try to archive a thread on the server. Returns status string. */
@@ -546,6 +668,8 @@ async function cmdRun(positional: string[], opts: Options) {
   const prompt = positional.join(" ");
 
   const exitCode = await withClient(async (client) => {
+    await resolveDefaults(client, opts);
+
     const { threadId, shortId, effective } = await startOrResumeThread(client, opts);
 
     if (opts.contentOnly) {
@@ -598,6 +722,8 @@ async function cmdReview(positional: string[], opts: Options) {
   const target = resolveReviewTarget(positional, opts);
 
   const exitCode = await withClient(async (client) => {
+    await resolveDefaults(client, opts);
+
     const { threadId, shortId, effective } = await startOrResumeThread(
       client, opts, { sandbox: "read-only" },
     );
@@ -1040,6 +1166,71 @@ async function cmdDelete(positional: string[]) {
   }
 }
 
+async function cmdConfig(positional: string[], opts: Options) {
+  const VALID_KEYS: Record<string, { validate: (v: string) => boolean; hint: string }> = {
+    model:     { validate: v => !/[^a-zA-Z0-9._\-\/:]/.test(v), hint: "model name (e.g. gpt-5.4, gpt-5.3-codex)" },
+    reasoning: { validate: v => (config.reasoningEfforts as readonly string[]).includes(v), hint: config.reasoningEfforts.join(", ") },
+    sandbox:   { validate: v => (config.sandboxModes as readonly string[]).includes(v), hint: config.sandboxModes.join(", ") },
+    approval:  { validate: v => (config.approvalPolicies as readonly string[]).includes(v), hint: config.approvalPolicies.join(", ") },
+    timeout:   { validate: v => { const n = Number(v); return Number.isFinite(n) && n > 0; }, hint: "seconds (e.g. 1200)" },
+  };
+
+  const cfg = loadUserConfig();
+
+  // No args → show current config
+  if (positional.length === 0) {
+    if (Object.keys(cfg).length === 0) {
+      console.log("No user config set. Using auto-detected defaults.");
+      console.log(`\nConfig file: ${config.configFile}`);
+      console.log(`\nAvailable keys: ${Object.keys(VALID_KEYS).join(", ")}`);
+      console.log("Set a value:   codex-collab config <key> <value>");
+      console.log("Unset a value: codex-collab config <key> --unset");
+    } else {
+      for (const [k, v] of Object.entries(cfg)) {
+        console.log(`  ${k}: ${v}`);
+      }
+      console.log(`\nConfig file: ${config.configFile}`);
+    }
+    return;
+  }
+
+  const key = positional[0];
+  if (!(key in VALID_KEYS)) {
+    die(`Unknown config key: ${key}\nValid keys: ${Object.keys(VALID_KEYS).join(", ")}`);
+  }
+
+  // Unset
+  if (opts.explicit.has("unset")) {
+    delete (cfg as Record<string, unknown>)[key];
+    saveUserConfig(cfg);
+    console.log(`Unset ${key} (will use auto-detected default)`);
+    return;
+  }
+
+  // Key only → show value
+  if (positional.length === 1) {
+    const val = (cfg as Record<string, unknown>)[key];
+    if (val !== undefined) {
+      console.log(`${key}: ${val}`);
+    } else {
+      console.log(`${key}: (not set — auto-detected)`);
+    }
+    return;
+  }
+
+  const value = positional[1];
+
+  // Validate and set
+  const spec = VALID_KEYS[key];
+  if (!spec.validate(value)) {
+    die(`Invalid value for ${key}: ${value}\nValid: ${spec.hint}`);
+  }
+
+  (cfg as Record<string, unknown>)[key] = key === "timeout" ? Number(value) : value;
+  saveUserConfig(cfg);
+  console.log(`Set ${key}: ${value}`);
+}
+
 async function cmdHealth() {
   const findCmd = process.platform === "win32" ? "where" : "which";
   const which = Bun.spawnSync([findCmd, "codex"]);
@@ -1080,6 +1271,7 @@ Commands:
   kill <id>               Stop a running thread
   output <id>             Read full log for thread
   progress <id>           Show recent activity for thread
+  config [key] [value]    Show or set persistent defaults
   models                  List available models
   approve <id>            Approve a pending request
   decline <id>            Decline a pending request
@@ -1088,8 +1280,8 @@ Commands:
   health                  Check prerequisites
 
 Options:
-  -m, --model <model>     Model name (default: ${config.model})
-  -r, --reasoning <lvl>   Reasoning: ${config.reasoningEfforts.join(", ")} (default: ${config.defaultReasoningEffort})
+  -m, --model <model>     Model name (default: auto — latest available)
+  -r, --reasoning <lvl>   Reasoning: ${config.reasoningEfforts.join(", ")} (default: auto — highest available)
   -s, --sandbox <mode>    Sandbox: ${config.sandboxModes.join(", ")}
                           (default: ${config.defaultSandbox})
   -d, --dir <path>        Working directory (default: cwd)
@@ -1138,7 +1330,7 @@ async function main() {
   // Keep in sync with the switch below.
   const knownCommands = new Set([
     "run", "review", "jobs", "kill", "output", "progress",
-    "models", "approve", "decline", "clean", "delete", "health",
+    "config", "models", "approve", "decline", "clean", "delete", "health",
   ]);
   if (!knownCommands.has(command)) {
     console.error(`Error: Unknown command: ${command}`);
@@ -1150,6 +1342,11 @@ async function main() {
   const noDataDirCommands = new Set(["health", "models"]);
   if (!noDataDirCommands.has(command)) {
     ensureDataDirs();
+  }
+
+  // Apply user config for commands that use options
+  if (command === "run" || command === "review") {
+    applyUserConfig(options);
   }
 
   switch (command) {
@@ -1165,6 +1362,8 @@ async function main() {
       return cmdOutput(positional, options);
     case "progress":
       return cmdProgress(positional);
+    case "config":
+      return cmdConfig(positional, options);
     case "models":
       return cmdModels();
     case "approve":

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,12 +11,8 @@ function getHome(): string {
 }
 
 export const config = {
-  // Fallback model — used only when auto-detection fails (server unreachable, no models returned)
-  fallbackModel: "gpt-5.4",
-
   // Reasoning effort levels
   reasoningEfforts: ["low", "medium", "high", "xhigh"] as const,
-  defaultReasoningEffort: "xhigh" as const,
 
   // Sandbox modes
   sandboxModes: ["read-only", "workspace-write", "danger-full-access"] as const,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,8 +11,8 @@ function getHome(): string {
 }
 
 export const config = {
-  // Default model
-  model: "gpt-5.3-codex",
+  // Fallback model — used only when auto-detection fails (server unreachable, no models returned)
+  fallbackModel: "gpt-5.4",
 
   // Reasoning effort levels
   reasoningEfforts: ["low", "medium", "high", "xhigh"] as const,
@@ -38,6 +38,7 @@ export const config = {
   get approvalsDir() { return join(this.dataDir, "approvals"); },
   get killSignalsDir() { return join(this.dataDir, "kill-signals"); },
   get pidsDir() { return join(this.dataDir, "pids"); },
+  get configFile() { return join(this.dataDir, "config.json"); },
 
   // Display
   jobsListLimit: 20,

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -195,6 +195,26 @@ export function updateThreadStatus(
   });
 }
 
+export function updateThreadMeta(
+  threadsFile: string,
+  threadId: string,
+  meta: { model?: string; cwd?: string; preview?: string },
+): void {
+  withThreadLock(threadsFile, () => {
+    const mapping = loadThreadMapping(threadsFile);
+    for (const entry of Object.values(mapping)) {
+      if (entry.threadId === threadId) {
+        if (meta.model !== undefined) entry.model = meta.model;
+        if (meta.cwd !== undefined) entry.cwd = meta.cwd;
+        if (meta.preview !== undefined) entry.preview = meta.preview;
+        entry.updatedAt = new Date().toISOString();
+        saveThreadMapping(threadsFile, mapping);
+        return;
+      }
+    }
+  });
+}
+
 export function removeThread(threadsFile: string, shortId: string): void {
   withThreadLock(threadsFile, () => {
     const mapping = loadThreadMapping(threadsFile);

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -212,6 +212,7 @@ export function updateThreadMeta(
         return;
       }
     }
+    console.error(`[codex] Warning: cannot update metadata for unknown thread ${threadId.slice(0, 12)}...`);
   });
 }
 

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -126,7 +126,7 @@ export function saveThreadMapping(threadsFile: string, mapping: ThreadMapping): 
 export function registerThread(
   threadsFile: string,
   threadId: string,
-  meta?: { model?: string; cwd?: string },
+  meta?: { model?: string; cwd?: string; preview?: string },
 ): ThreadMapping {
   validateId(threadId); // ensure safe for use as filename (kill signals, etc.)
   return withThreadLock(threadsFile, () => {
@@ -138,6 +138,7 @@ export function registerThread(
       createdAt: new Date().toISOString(),
       model: meta?.model,
       cwd: meta?.cwd,
+      preview: meta?.preview,
     };
     saveThreadMapping(threadsFile, mapping);
     return mapping;

--- a/src/types.ts
+++ b/src/types.ts
@@ -444,6 +444,7 @@ export interface ThreadMappingEntry {
   createdAt: string;
   model?: string;
   cwd?: string;
+  preview?: string;
   lastStatus?: "running" | "completed" | "failed" | "interrupted";
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary

- **Auto-model selection**: Follows the server's upgrade chain from the default model to the latest generation, preferring `-codex` variants when available. No version-string parsing — relies on the server's own succession metadata. Selects the highest supported reasoning effort for the chosen model.
- **Persistent user config**: `codex-collab config` command to set/unset defaults for model, reasoning, sandbox, approval, and timeout. Stored in `~/.codex-collab/config.json`. Three-tier precedence: `CLI flag > config file > auto-detected`.
- **Jobs command rewrite**: `codex-collab jobs` now reads from local thread mapping instead of spawning a new app-server, fixing the bug where running threads were invisible. Shows model and prompt preview in the listing. Metadata refreshed on resume to keep listings accurate.
- **Review fixes**: Config values use separate `configured` set (not forwarded on resume), `Object.hasOwn` for config key validation, robust error handling in config loading, and `updateThreadMeta()` to keep `jobs` accurate after resume.