### PR TITLE
Guardian auto-approvals (--approval auto) and memory isolation for created threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ codex-collab is a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-
 - **Event-driven progress** — Streams progress lines as Codex works, so Claude sees what's happening in real time.
 - **Review automation** — One command to run code reviews for PRs, uncommitted changes, or specific commits in a read-only sandbox.
 - **Thread reuse** — Resume existing threads to send follow-up prompts, build on previous responses, or steer the work in a new direction.
-- **Approval control** — Configurable approval policies for tool calls: auto-approve, interactive, or deny.
+- **Approval control** — Configurable approval policies for tool calls: auto-approve, interactive, deny, or Codex's Guardian auto-reviewer (`--approval auto`).
+- **Memory isolation** — Threads created by codex-collab are excluded from Codex's memory feature by default (`thread/memoryMode/set mode=disabled`), so agent-driven sessions don't shape Codex's learned picture of how *you* work. Opt back in per-run with `--memory` or persistently with `config memory true`. Resumed threads are never touched — the flag is persistent per-thread, and a thread you created yourself should keep feeding your memory. Scope note: this governs Codex's *local* memory consolidation (`~/.codex/memories`); the `personality` feature is explicit user config (not learned) and unaffected, and anything learned server-side from API traffic is outside any client's control.
 
 ## Installation
 
@@ -137,7 +138,8 @@ codex-collab run --resume <id> "now check error handling" --content-only
 | `--mode <mode>` | Review mode: pr, uncommitted, commit, custom |
 | `--ref <hash>` | Commit ref for `--mode commit` |
 | `--resume <id>` | Resume existing thread |
-| `--approval <policy>` | Approval policy: never, on-request, on-failure, untrusted (default: never) |
+| `--approval <policy>` | Approval policy: never, on-request, on-failure, untrusted, auto (default: never). `auto` routes requests to Codex's Guardian reviewer; only escalations need `approve`/`decline` |
+| `--memory` | Let Codex's memory feature learn from threads this run creates (default: excluded) |
 | `--template <name>` | Prompt template for run command (user `~/.codex-collab/templates/` or built-in) |
 | `--json` | JSON output for supported commands (`threads`, `peek`) |
 | `--all` | List all threads with no display limit |
@@ -174,7 +176,7 @@ codex-collab config model --unset
 codex-collab config --unset
 ```
 
-Available keys: `model`, `reasoning`, `sandbox`, `approval`, `timeout`
+Available keys: `model`, `reasoning`, `sandbox`, `approval`, `timeout`, `memory`
 
 CLI flags always take precedence over config, and config takes precedence over auto-detection:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -128,9 +128,18 @@ By default, Codex auto-approves all actions (`--approval never`). For stricter c
 ```bash
 # Require approval for Codex-initiated actions
 codex-collab run "refactor the auth module" --approval on-request --content-only
+
+# Let Codex's Guardian subagent review requests autonomously; only its
+# escalations surface as interactive approvals (best for background runs —
+# no silent block waiting on a human)
+codex-collab run "refactor the auth module" --approval auto --content-only
 ```
 
-When an approval is needed, the progress output will show:
+With `--approval auto`, Guardian decisions appear in the progress stream
+(`Guardian approved: …` / `Guardian rejected: …`) and the full payloads land
+in the thread log for auditing.
+
+When an approval is needed (or Guardian escalates), the progress output will show:
 ```
 [codex] APPROVAL NEEDED
 [codex]   Command: rm -rf node_modules
@@ -210,7 +219,8 @@ codex-collab health                     # Check prerequisites
 | `-d, --dir <path>` | Working directory (default: cwd) |
 | `--resume <id>` | Resume existing thread (run and review) |
 | `--timeout <sec>` | Turn timeout in seconds (default: 1200). Do not lower this — Codex tasks routinely take 5-15 minutes. Increase for large reviews or complex tasks. |
-| `--approval <policy>` | Approval policy: never, on-request, on-failure, untrusted (default: never) |
+| `--approval <policy>` | Approval policy: never, on-request, on-failure, untrusted, auto (default: never). `auto` routes requests to Codex's Guardian reviewer; only escalations reach `approve`/`decline` |
+| `--memory` | Let Codex's memory feature learn from threads this run creates (default: created threads are excluded so agent-driven sessions don't shape Codex's picture of the user) |
 | `--mode <mode>` | Review mode: pr, uncommitted, commit, custom |
 | `--ref <hash>` | Commit ref for --mode commit |
 | `--base <branch>` | Base branch for PR review (default: auto-detected default branch) |

--- a/src/broker-client.ts
+++ b/src/broker-client.ts
@@ -324,7 +324,10 @@ export async function connectToBroker(opts: BrokerClientOptions): Promise<AppSer
         version: config.clientVersion,
       },
       capabilities: {
-        experimentalApi: false,
+        // The broker handles this initialize locally (the app-server sees the
+        // broker's own handshake from client.ts), but keep the declared
+        // capabilities in lockstep with the direct path.
+        experimentalApi: true,
         optOutNotificationMethods: ["item/reasoning/textDelta"],
       },
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,7 +118,11 @@ Options:
   -d, --dir <path>        Working directory (default: cwd)
   --resume <id>           Resume existing thread
   --timeout <sec>         Turn timeout in seconds (default: ${config.defaultTimeout})
-  --approval <policy>     Approval: ${config.approvalPolicies.join(", ")} (default: ${config.defaultApprovalPolicy})
+  --approval <policy>     Approval: ${config.approvalModes.join(", ")} (default: ${config.defaultApprovalPolicy})
+                          "auto" routes requests to Codex's Guardian reviewer;
+                          only its escalations reach approve/decline
+  --memory                Let Codex's memory feature learn from threads this
+                          run creates (default: created threads are excluded)
   --mode <mode>           Review mode: ${VALID_REVIEW_MODES.join(", ")}
   --ref <hash>            Commit ref for --mode commit
   --base <branch>         Base branch for PR review (default: auto-detected default branch)
@@ -180,6 +184,7 @@ const BOOLEAN_FLAGS = new Set([
   "--discover",
   "--full",
   "--unset",
+  "--memory",
 ]);
 
 function extractCommand(args: string[]): { command: string; rest: string[] } {

--- a/src/client.ts
+++ b/src/client.ts
@@ -522,7 +522,9 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   const initParams: InitializeParams = {
     clientInfo: { name: config.clientName, title: null, version: config.clientVersion },
     capabilities: {
-      experimentalApi: false,
+      // Required for thread/memoryMode/set (memory isolation of created
+      // threads). Guardian (approvalsReviewer) does NOT need it.
+      experimentalApi: true,
       optOutNotificationMethods: ["item/reasoning/textDelta"],
     },
   };

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -23,8 +23,9 @@ export async function handleConfig(args: string[]): Promise<void> {
     model:     { validate: v => v.length > 0 && !/[^a-zA-Z0-9._\-\/:]/.test(v), hint: "model name (e.g. gpt-5.4, gpt-5.3-codex)" },
     reasoning: { validate: v => (config.reasoningEfforts as readonly string[]).includes(v), hint: config.reasoningEfforts.join(", ") },
     sandbox:   { validate: v => (config.sandboxModes as readonly string[]).includes(v), hint: config.sandboxModes.join(", ") },
-    approval:  { validate: v => (config.approvalPolicies as readonly string[]).includes(v), hint: config.approvalPolicies.join(", ") },
+    approval:  { validate: v => (config.approvalModes as readonly string[]).includes(v), hint: config.approvalModes.join(", ") },
     timeout:   { validate: v => { const n = Number(v); return Number.isFinite(n) && n > 0 && n <= MAX_TIMEOUT_SECONDS; }, hint: `seconds, 1-${MAX_TIMEOUT_SECONDS} (e.g. 1200)` },
+    memory:    { validate: v => v === "true" || v === "false", hint: "true, false (let Codex memory learn from created threads)" },
   };
 
   const cfg = loadUserConfig();
@@ -83,7 +84,8 @@ export async function handleConfig(args: string[]): Promise<void> {
     die(`Invalid value for ${key}: ${value}\nValid: ${spec.hint}`);
   }
 
-  (cfg as Record<string, unknown>)[key] = key === "timeout" ? Number(value) : value;
+  (cfg as Record<string, unknown>)[key] =
+    key === "timeout" ? Number(value) : key === "memory" ? value === "true" : value;
   saveUserConfig(cfg);
   console.log(`Set ${key}: ${value}`);
 }

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -731,9 +731,12 @@ describe("resolveApproval", () => {
     });
   });
 
-  test("server policies pass through with no reviewer key", () => {
+  test("server policies pass through with the user reviewer (reversibility)", () => {
+    // approvalsReviewer persists per-thread, so an explicit non-auto mode
+    // must actively reset it — otherwise a thread once run with "auto" keeps
+    // Guardian even after the user asks for interactive control.
     for (const mode of ["never", "on-request", "on-failure", "untrusted"] as const) {
-      expect(resolveApproval(mode)).toEqual({ approvalPolicy: mode });
+      expect(resolveApproval(mode)).toEqual({ approvalPolicy: mode, approvalsReviewer: "user" });
     }
   });
 });
@@ -1253,6 +1256,7 @@ describe("startOrResumeThread", () => {
         model: "gpt-5",
         cwd: "/tmp/review-project",
         approvalPolicy: "on-request",
+        approvalsReviewer: "user",
         sandbox: "read-only",
       },
     });
@@ -1364,6 +1368,7 @@ describe("turnOverrides", () => {
     expect(overrides).toEqual({
       cwd: "/tmp/test",
       approvalPolicy: "on-request",
+      approvalsReviewer: "user",
       model: "gpt-5",
       effort: "high",
     });
@@ -1378,6 +1383,7 @@ describe("turnOverrides", () => {
     expect(overrides).toEqual({
       cwd: opts.dir,
       approvalPolicy: opts.approval,
+      approvalsReviewer: "user",
     });
     expect("model" in overrides).toBe(false);
     expect("effort" in overrides).toBe(false);
@@ -1430,6 +1436,9 @@ describe("turnOverrides", () => {
       effort: "low",
       cwd: "/tmp/proj",
       approvalPolicy: "on-failure",
+      // Explicit non-auto selection resets a possibly-persisted Guardian
+      // reviewer back to interactive routing (reversibility).
+      approvalsReviewer: "user",
       sandboxPolicy: { type: "dangerFullAccess" },
     });
   });

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -10,6 +10,7 @@ import {
   applyUserConfig,
   startOrResumeThread,
   turnOverrides,
+  resolveApproval,
   formatDuration,
   isThreadProcessAlive,
   defaultOptions,
@@ -703,6 +704,40 @@ describe("parseOptions: --full and explicit --limit", () => {
 
 // ─── pickBestModel ────────────────────────────────────────────────────────
 
+describe("parseOptions: --approval auto and --memory", () => {
+  test("--approval auto is accepted and marked explicit", () => {
+    const { options } = parseOptions(["run", "task", "--approval", "auto"]);
+    expect(options.approval).toBe("auto");
+    expect(options.explicit.has("approval")).toBe(true);
+  });
+
+  test("--memory opts in and is marked explicit", () => {
+    const { options } = parseOptions(["run", "task", "--memory"]);
+    expect(options.memory).toBe(true);
+    expect(options.explicit.has("memory")).toBe(true);
+  });
+
+  test("memory defaults to false (created threads excluded from Codex memory)", () => {
+    const { options } = parseOptions(["run", "task"]);
+    expect(options.memory).toBe(false);
+  });
+});
+
+describe("resolveApproval", () => {
+  test("auto maps to on-request reviewed by the Guardian subagent", () => {
+    expect(resolveApproval("auto")).toEqual({
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+    });
+  });
+
+  test("server policies pass through with no reviewer key", () => {
+    for (const mode of ["never", "on-request", "on-failure", "untrusted"] as const) {
+      expect(resolveApproval(mode)).toEqual({ approvalPolicy: mode });
+    }
+  });
+});
+
 describe("pickBestModel", () => {
   const m = (id: string, opts: { upgrade?: string; isDefault?: boolean } = {}): Model => ({
     id,
@@ -1135,6 +1170,29 @@ console.log("should not reach here");
     expect(result.stderr.toString()).toContain("config.json");
     expect(result.stdout.toString()).not.toContain("should not reach here");
   });
+
+  test("approval: auto and memory: true from config populate options", () => {
+    const { stdout, exitCode } = runApplyConfig(
+      JSON.stringify({ approval: "auto", memory: true }),
+      [],
+      `{ approval: opts.approval, memory: opts.memory }`,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.approval).toBe("auto");
+    expect(result.memory).toBe(true);
+  });
+
+  test("non-boolean memory in config is ignored with a warning", () => {
+    const { stdout, exitCode, stderr } = runApplyConfig(
+      JSON.stringify({ memory: "yes" }),
+      [],
+      `{ memory: opts.memory }`,
+    );
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).memory).toBe(false);
+    expect(stderr).toContain("invalid memory");
+  });
 });
 
 // ─── startOrResumeThread ───────────────────────────────────────────────────
@@ -1184,6 +1242,8 @@ describe("startOrResumeThread", () => {
 
     expect(result.threadId).toBe(forkedThreadId);
     expect(result.shortId).not.toBe(sourceThreadId);
+    // Exactly one RPC: ephemeral review threads never hit disk, so no
+    // thread/memoryMode/set (the server rejects metadata updates on them).
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({
       method: "thread/fork",
@@ -1196,6 +1256,95 @@ describe("startOrResumeThread", () => {
         sandbox: "read-only",
       },
     });
+  });
+
+  /** Mock client that records calls and answers from a method→response map.
+   *  Unlisted methods resolve to {} so incidental RPCs (thread/name/set)
+   *  don't need enumerating in every test. */
+  function recordingClient(
+    calls: Array<{ method: string; params: unknown }>,
+    respond: Record<string, (params: unknown) => unknown>,
+  ): AppServerClient {
+    return {
+      request: async <T,>(method: string, params?: unknown): Promise<T> => {
+        calls.push({ method, params });
+        const handler = respond[method];
+        return (handler ? handler(params) : {}) as T;
+      },
+      notify: () => {},
+      on: () => () => {},
+      onAny: () => () => {},
+      onRequest: () => () => {},
+      respond: () => {},
+      onClose: () => () => {},
+      close: async () => {},
+      userAgent: "mock",
+      brokerBusy: false,
+    };
+  }
+
+  const newThreadId = "01900000000070008000000000000010";
+
+  test("new thread: disables Codex memory by default, with Guardian reviewer under --approval auto", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = recordingClient(calls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+    opts.approval = "auto";
+
+    await startOrResumeThread(client, opts, freshWorkspace("new-thread-memory"), undefined, "task", false);
+
+    const start = calls.find(c => c.method === "thread/start");
+    expect(start?.params).toMatchObject({
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+    });
+    const memory = calls.find(c => c.method === "thread/memoryMode/set");
+    expect(memory?.params).toEqual({ threadId: newThreadId, mode: "disabled" });
+  });
+
+  test("new thread with --memory: no memoryMode call", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = recordingClient(calls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+    opts.memory = true;
+
+    await startOrResumeThread(client, opts, freshWorkspace("new-thread-memory-optin"), undefined, "task", false);
+
+    expect(calls.some(c => c.method === "thread/memoryMode/set")).toBe(false);
+  });
+
+  test("memoryMode/set failure is non-fatal (older Codex / capability missing)", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = recordingClient(calls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+      "thread/memoryMode/set": () => { throw new Error("requires experimentalApi capability"); },
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+
+    const result = await startOrResumeThread(client, opts, freshWorkspace("new-thread-memory-fail"), undefined, "task", false);
+    expect(result.threadId).toBe(newThreadId);
+  });
+
+  test("resume: never touches memoryMode on a user-owned thread", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = recordingClient(calls, {
+      "thread/resume": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+    opts.resumeId = newThreadId;
+
+    await startOrResumeThread(client, opts, freshWorkspace("resume-no-memory"), undefined, "task", false);
+
+    expect(calls.some(c => c.method === "thread/resume")).toBe(true);
+    expect(calls.some(c => c.method === "thread/memoryMode/set")).toBe(false);
   });
 });
 
@@ -1316,6 +1465,41 @@ describe("turnOverrides", () => {
 
     const overrides = turnOverrides(opts);
     expect("sandboxPolicy" in overrides).toBe(false);
+  });
+});
+
+describe("turnOverrides: Guardian auto mode", () => {
+  test("new thread with approval auto sends on-request + auto_review per turn", () => {
+    const opts = defaultOptions();
+    opts.approval = "auto";
+    opts.dir = "/tmp/test";
+    opts.resumeId = null;
+
+    expect(turnOverrides(opts)).toEqual({
+      cwd: "/tmp/test",
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+    });
+  });
+
+  test("resumed thread with explicit approval auto forwards both wire params", () => {
+    const opts = defaultOptions();
+    opts.approval = "auto";
+    opts.resumeId = "abc123";
+    opts.explicit.add("approval");
+
+    expect(turnOverrides(opts)).toEqual({
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+    });
+  });
+
+  test("resumed thread without explicit approval forwards neither", () => {
+    const opts = defaultOptions();
+    opts.approval = "auto"; // e.g. from config — not explicit, so not forwarded
+    opts.resumeId = "abc123";
+
+    expect(turnOverrides(opts)).toEqual({});
   });
 });
 

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -851,13 +851,18 @@ export async function startOrResumeThread(
  *  approval requests like "on-request" but routes them to Codex's Guardian
  *  subagent (approvalsReviewer "auto_review"), which permits/rejects
  *  autonomously and escalates to this client only when unsure — the
- *  file-based interactive flow stays as that escalation path. */
+ *  file-based interactive flow stays as that escalation path.
+ *
+ *  Non-auto modes explicitly send approvalsReviewer "user" so selecting them
+ *  is reversible: approvalsReviewer persists on the thread, and without the
+ *  reset a thread once run with "auto" would keep routing approvals through
+ *  Guardian even after the user explicitly asked for interactive control. */
 export function resolveApproval(mode: ApprovalMode): {
   approvalPolicy: ApprovalPolicy;
-  approvalsReviewer?: ApprovalsReviewer;
+  approvalsReviewer: ApprovalsReviewer;
 } {
   if (mode === "auto") return { approvalPolicy: "on-request", approvalsReviewer: "auto_review" };
-  return { approvalPolicy: mode };
+  return { approvalPolicy: mode, approvalsReviewer: "user" };
 }
 
 /** Map a kebab-case sandbox mode to the app-server's sandboxPolicy wire shape. */

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -8,6 +8,7 @@ import {
   type ReasoningEffort,
   type SandboxMode,
   type ApprovalPolicy,
+  type ApprovalMode,
 } from "../config";
 import { type AppServerClient, connectDirect } from "../client";
 import { ensureConnection, getCurrentSessionId, isBrokerBusyError } from "../broker";
@@ -44,6 +45,7 @@ import type {
   Model,
   TurnResult,
   RunRecord,
+  ApprovalsReviewer,
 } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -90,7 +92,10 @@ export interface Options {
   reasoning: ReasoningEffort | undefined;
   model: string | undefined;
   sandbox: SandboxMode;
-  approval: ApprovalPolicy;
+  approval: ApprovalMode;
+  /** Opt-in: let Codex's memory feature learn from threads this run creates.
+   *  Default off — created threads get thread/memoryMode/set mode=disabled. */
+  memory: boolean;
   dir: string;
   contentOnly: boolean;
   json: boolean;
@@ -165,6 +170,7 @@ export function defaultOptions(): Options {
     model: undefined,
     sandbox: config.defaultSandbox,
     approval: config.defaultApprovalPolicy,
+    memory: false,
     dir: process.cwd(),
     contentOnly: false,
     json: false,
@@ -275,11 +281,11 @@ export function parseOptions(args: string[]): { positional: string[]; options: O
         console.error("Error: --approval requires a value");
         process.exit(1);
       }
-      const policy = argv[++i] as ApprovalPolicy;
-      if (!config.approvalPolicies.includes(policy)) {
+      const policy = argv[++i] as ApprovalMode;
+      if (!config.approvalModes.includes(policy)) {
         console.error(`Error: Invalid approval policy: ${policy}`);
         console.error(
-          `Valid options: ${config.approvalPolicies.join(", ")}`
+          `Valid options: ${config.approvalModes.join(", ")}`
         );
         process.exit(1);
       }
@@ -292,6 +298,9 @@ export function parseOptions(args: string[]): { positional: string[]; options: O
       }
       options.dir = resolve(argv[++i]);
       options.explicit.add("dir");
+    } else if (arg === "--memory") {
+      options.memory = true;
+      options.explicit.add("memory");
     } else if (arg === "--content-only") {
       options.contentOnly = true;
     } else if (arg === "--json") {
@@ -390,8 +399,9 @@ export interface UserConfig {
   model?: string;
   reasoning?: ReasoningEffort;
   sandbox?: SandboxMode;
-  approval?: ApprovalPolicy;
+  approval?: ApprovalMode;
   timeout?: number;
+  memory?: boolean;
 }
 
 export function loadUserConfig(): UserConfig {
@@ -454,11 +464,18 @@ export function applyUserConfig(options: Options): void {
     }
   }
   if (!options.explicit.has("approval") && typeof cfg.approval === "string") {
-    if (cfg.approval && config.approvalPolicies.includes(cfg.approval)) {
+    if (cfg.approval && config.approvalModes.includes(cfg.approval)) {
       options.approval = cfg.approval;
       options.configured.add("approval");
     } else {
       console.error(`[codex] Warning: ignoring invalid approval in config: ${cfg.approval}`);
+    }
+  }
+  if (!options.explicit.has("memory") && cfg.memory !== undefined) {
+    if (typeof cfg.memory === "boolean") {
+      options.memory = cfg.memory;
+    } else {
+      console.error(`[codex] Warning: ignoring invalid memory in config: ${cfg.memory}`);
     }
   }
   if (!options.explicit.has("timeout") && cfg.timeout !== undefined) {
@@ -689,7 +706,7 @@ export async function startOrResumeThread(
       };
       if (opts.explicit.has("model")) forkParams.model = opts.model;
       if (opts.explicit.has("dir")) forkParams.cwd = opts.dir;
-      if (opts.explicit.has("approval")) forkParams.approvalPolicy = opts.approval;
+      if (opts.explicit.has("approval")) Object.assign(forkParams, resolveApproval(opts.approval));
       // Reviews must run in read-only mode. `thread/resume.sandbox` is not
       // reliable for already-loaded broker threads, and `review/start` has no
       // per-turn sandbox override, so fork the resumed context into a fresh
@@ -715,7 +732,7 @@ export async function startOrResumeThread(
       // Only forward flags that were explicitly provided on the command line
       if (opts.explicit.has("model")) resumeParams.model = opts.model;
       if (opts.explicit.has("dir")) resumeParams.cwd = opts.dir;
-      if (opts.explicit.has("approval")) resumeParams.approvalPolicy = opts.approval;
+      if (opts.explicit.has("approval")) Object.assign(resumeParams, resolveApproval(opts.approval));
       if (opts.explicit.has("sandbox")) resumeParams.sandbox = opts.sandbox;
       // Forced overrides from caller (e.g., review forces sandbox to read-only)
       if (extraStartParams) Object.assign(resumeParams, extraStartParams);
@@ -740,7 +757,7 @@ export async function startOrResumeThread(
   } else {
     const startParams: Record<string, unknown> = {
       cwd: opts.dir,
-      approvalPolicy: opts.approval,
+      ...resolveApproval(opts.approval),
       sandbox: opts.sandbox,
       experimentalRawEvents: false,
       persistExtendedHistory: false,
@@ -763,6 +780,24 @@ export async function startOrResumeThread(
     if (!resolvedShortId) die(`Internal error: thread ${threadId.slice(0, 12)}... registered but not found in mapping`);
     shortId = resolvedShortId;
     isNewThread = true;
+  }
+
+  // Keep threads codex-collab creates out of Codex's memory consolidation
+  // (~/.codex/memories) unless the user opts in with --memory: an agent
+  // driving Codex on the user's behalf shouldn't shape Codex's learned
+  // picture of how the user works. Only ever set on threads WE create —
+  // memoryMode is a persistent per-thread flag, so setting it on a resumed
+  // user-owned thread would silently exclude that thread from the user's
+  // own memory. Review threads are skipped: they're ephemeral (never
+  // written to disk, so structurally outside memory ingestion) and the
+  // server rejects metadata updates on them. Non-fatal: requires the
+  // experimentalApi capability and Codex ≥ 0.142.
+  if (isNewThread && !isReview && !opts.memory) {
+    try {
+      await client.request("thread/memoryMode/set", { threadId, mode: "disabled" });
+    } catch (e) {
+      console.error(`[codex] Warning: could not exclude thread from Codex memory: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   // Name new threads (non-fatal on failure)
@@ -812,6 +847,19 @@ export async function startOrResumeThread(
 // Turn overrides and result printing
 // ---------------------------------------------------------------------------
 
+/** Map a CLI approval mode to the app-server's wire params. "auto" generates
+ *  approval requests like "on-request" but routes them to Codex's Guardian
+ *  subagent (approvalsReviewer "auto_review"), which permits/rejects
+ *  autonomously and escalates to this client only when unsure — the
+ *  file-based interactive flow stays as that escalation path. */
+export function resolveApproval(mode: ApprovalMode): {
+  approvalPolicy: ApprovalPolicy;
+  approvalsReviewer?: ApprovalsReviewer;
+} {
+  if (mode === "auto") return { approvalPolicy: "on-request", approvalsReviewer: "auto_review" };
+  return { approvalPolicy: mode };
+}
+
 /** Map a kebab-case sandbox mode to the app-server's sandboxPolicy wire shape. */
 export function sandboxPolicyFor(mode: SandboxMode): { type: string } {
   switch (mode) {
@@ -824,7 +872,7 @@ export function sandboxPolicyFor(mode: SandboxMode): { type: string } {
 /** Per-turn parameter overrides: all values for new threads, explicit-only for resume. */
 export function turnOverrides(opts: Options) {
   if (!opts.resumeId) {
-    const o: Record<string, unknown> = { cwd: opts.dir, approvalPolicy: opts.approval };
+    const o: Record<string, unknown> = { cwd: opts.dir, ...resolveApproval(opts.approval) };
     if (opts.model) o.model = opts.model;
     if (opts.reasoning) o.effort = opts.reasoning;
     return o;
@@ -833,7 +881,7 @@ export function turnOverrides(opts: Options) {
   if (opts.explicit.has("dir")) o.cwd = opts.dir;
   if (opts.explicit.has("model")) o.model = opts.model;
   if (opts.explicit.has("reasoning")) o.effort = opts.reasoning;
-  if (opts.explicit.has("approval")) o.approvalPolicy = opts.approval;
+  if (opts.explicit.has("approval")) Object.assign(o, resolveApproval(opts.approval));
   // thread/resume's `sandbox` is ignored once the thread is loaded in a
   // long-lived (broker) app-server, so carry an explicit -s as a per-turn
   // sandboxPolicy override — the only path that re-applies the new mode.

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,11 @@ export const config = {
 
   // Approval policies accepted by the Codex app server
   approvalPolicies: ["never", "on-request", "on-failure", "untrusted"] as const,
+  // CLI/config approval modes: server policies plus "auto", which maps to
+  // approvalPolicy "on-request" reviewed by Codex's Guardian subagent
+  // (approvalsReviewer "auto_review") with the interactive flow as the
+  // escalation path.
+  approvalModes: ["never", "on-request", "on-failure", "untrusted", "auto"] as const,
   defaultApprovalPolicy: "never" as const,
 
   // Timeouts
@@ -107,6 +112,7 @@ Object.freeze(config);
 export type ReasoningEffort = (typeof config.reasoningEfforts)[number];
 export type SandboxMode = (typeof config.sandboxModes)[number];
 export type ApprovalPolicy = (typeof config.approvalPolicies)[number];
+export type ApprovalMode = (typeof config.approvalModes)[number];
 
 // ─── Pure utility functions ─────────────────────────────────────────────────
 

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -208,3 +208,87 @@ describe("EventDispatcher", () => {
     expect(dispatcher.getFilesChanged()).toHaveLength(1);
   });
 });
+
+describe("Guardian auto-approval review events", () => {
+  test("started event renders a progress line with the command", () => {
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher("guardian1", TEST_LOG_DIR, (line) => lines.push(line));
+
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/started", {
+      threadId: "t1", turnId: "turn1", itemId: "i1", command: "touch /tmp/file",
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("Guardian reviewing");
+    expect(lines[0]).toContain("touch /tmp/file");
+  });
+
+  test("completed event renders the decision", () => {
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher("guardian2", TEST_LOG_DIR, (line) => lines.push(line));
+
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      threadId: "t1", turnId: "turn1", itemId: "i1", decision: "approved", command: "touch /tmp/file",
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("Guardian approved");
+    expect(lines[0]).toContain("touch /tmp/file");
+  });
+
+  test("observed 0.142 shape: action.command + review.status/riskLevel", () => {
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher("guardian-live", TEST_LOG_DIR, (line) => lines.push(line));
+
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/started", {
+      threadId: "t1", turnId: "turn1", reviewId: "r1", targetItemId: "call_1",
+      review: { status: "inProgress", riskLevel: null, userAuthorization: null, rationale: null },
+      action: { type: "command", source: "unifiedExec", command: "/bin/zsh -lc 'touch canary.txt'", cwd: "/tmp" },
+    });
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      threadId: "t1", turnId: "turn1", reviewId: "r1", targetItemId: "call_1", decisionSource: "agent",
+      review: { status: "approved", riskLevel: "low", userAuthorization: "unknown", rationale: "Auto-review returned a low-risk allow decision." },
+      action: { type: "command", source: "unifiedExec", command: "/bin/zsh -lc 'touch canary.txt'", cwd: "/tmp" },
+    });
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("Guardian reviewing approval request: /bin/zsh -lc 'touch canary.txt'");
+    expect(lines[1]).toBe("Guardian approved (low risk): /bin/zsh -lc 'touch canary.txt'");
+  });
+
+  test("enum-shaped decision objects use their type discriminant", () => {
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher("guardian3", TEST_LOG_DIR, (line) => lines.push(line));
+
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      decision: { type: "rejected" },
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("Guardian rejected");
+  });
+
+  test("degrades to a generic line on an unrecognized payload (UNSTABLE protocol)", () => {
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher("guardian4", TEST_LOG_DIR, (line) => lines.push(line));
+
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/started", {});
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {});
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("Guardian reviewing approval request");
+    expect(lines[1]).toContain("Guardian review completed");
+  });
+
+  test("full payload is written to the log for auditability", () => {
+    const dispatcher = new EventDispatcher("guardian5", TEST_LOG_DIR);
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      decision: "approved", command: "rm -rf node_modules",
+    });
+    dispatcher.flush();
+
+    const log = readFileSync(join(TEST_LOG_DIR, "guardian5.log"), "utf-8");
+    expect(log).toContain("guardian review completed");
+    expect(log).toContain("rm -rf node_modules");
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import {
   isKnownItem,
   type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
-  type ErrorNotificationParams,
+  type ErrorNotificationParams, type AutoApprovalReviewParams,
   type FileChange, type CommandExec,
 } from "./types";
 
@@ -121,6 +121,49 @@ export class EventDispatcher {
     // No per-character logging — accumulated text is logged at flush
   }
 
+  /** Surface Guardian (auto_review) approval reviews in the progress stream
+   *  so autonomous permit/reject decisions stay auditable. Observed 0.142
+   *  payload: `action.command` (what's under review) and `review.{status,
+   *  riskLevel, rationale}` (the verdict) — but the protocol is [UNSTABLE],
+   *  so extraction is best-effort with flat-field fallbacks and degrades to
+   *  a generic line rather than dropping the event. */
+  handleAutoApprovalReview(method: string, params: AutoApprovalReviewParams): void {
+    const str = (v: unknown): string | null => {
+      if (typeof v === "string" && v.length > 0) return v;
+      // Enum-shaped objects like { type: "approved" }
+      if (v !== null && typeof v === "object" && typeof (v as { type?: unknown }).type === "string") {
+        return (v as { type: string }).type;
+      }
+      return null;
+    };
+    const pick = (obj: Record<string, unknown> | undefined, ...keys: string[]): string | null => {
+      for (const key of keys) {
+        const found = str(obj?.[key]);
+        if (found) return found;
+      }
+      return null;
+    };
+    const action = params.action as Record<string, unknown> | undefined;
+    const review = params.review as Record<string, unknown> | undefined;
+
+    const subject = pick(action, "command", "description") ?? pick(params, "command", "reason", "summary");
+    const clipped = subject && subject.length > 120 ? subject.slice(0, 117) + "..." : subject;
+
+    if (method.endsWith("/completed")) {
+      const decision = pick(review, "status") ?? pick(params, "decision", "verdict", "outcome", "status");
+      const risk = pick(review, "riskLevel");
+      const verdict = `${decision ?? "review completed"}${risk ? ` (${risk} risk)` : ""}`;
+      this.progress(`Guardian ${verdict}${clipped ? `: ${clipped}` : ""}`);
+      // Full payload in the log — the progress line is lossy and the exact
+      // decision trail (rationale, decisionSource) matters for auditing an
+      // autonomous approval.
+      this.log(`guardian review completed: ${safeStringify(params)}`);
+    } else {
+      this.progress(`Guardian reviewing approval request${clipped ? `: ${clipped}` : ""}`);
+      this.log(`guardian review started: ${safeStringify(params)}`);
+    }
+  }
+
   handleError(params: ErrorNotificationParams): void {
     const retry = params.willRetry ? " (will retry)" : "";
     this.progress(`Error: ${params.error.message}${retry}`);
@@ -187,5 +230,17 @@ export class EventDispatcher {
     this.logBuffer.push(`${ts} ${entry}`);
     // Auto-flush every 20 entries
     if (this.logBuffer.length >= 20) this.flush();
+  }
+}
+
+/** JSON.stringify that never throws (circular refs) and bounds entry size —
+ *  used for logging unstable payloads whose shape we don't control. */
+function safeStringify(value: unknown): string {
+  try {
+    const s = JSON.stringify(value);
+    if (s === undefined) return String(value);
+    return s.length > 2000 ? s.slice(0, 2000) + "…" : s;
+  } catch {
+    return "[unserializable]";
   }
 }

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1403,3 +1403,42 @@ describe("structured capture from item/completed", () => {
     expect(result.filesChanged).toHaveLength(1);
   });
 });
+
+describe("Guardian event routing", () => {
+  test("autoApprovalReview notifications reach the dispatcher; foreign-turn ones are filtered", async () => {
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("item/autoApprovalReview/started", {
+            threadId: "thr-1", turnId: "turn-1", itemId: "i1", command: "touch guard.txt",
+          });
+          emit("item/autoApprovalReview/completed", {
+            threadId: "thr-1", turnId: "turn-1", itemId: "i1", decision: "approved", command: "touch guard.txt",
+          });
+          // Orphaned turn on the shared app-server — must not surface here
+          emit("item/autoApprovalReview/completed", {
+            threadId: "thr-other", turnId: "turn-other", itemId: "i9", decision: "rejected", command: "rm -rf /",
+          });
+        }, 20);
+        setTimeout(() => emit("turn/completed", completedTurn("turn-1")), 50);
+        return inProgressTurn("turn-1");
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher("guardian-routing", TEST_LOG_DIR, (line) => lines.push(line));
+
+    const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
+      dispatcher,
+      approvalHandler: autoApproveHandler,
+      timeoutMs: 5000,
+      killSignalsDir: TEST_KILL_DIR,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(lines.some(l => l.includes("Guardian reviewing") && l.includes("touch guard.txt"))).toBe(true);
+    expect(lines.some(l => l.includes("Guardian approved"))).toBe(true);
+    expect(lines.some(l => l.includes("rm -rf /"))).toBe(false);
+  });
+});

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1442,3 +1442,33 @@ describe("Guardian event routing", () => {
     expect(lines.some(l => l.includes("rm -rf /"))).toBe(false);
   });
 });
+
+describe("per-turn approvalsReviewer forwarding", () => {
+  test("runTurn forwards approvalsReviewer into turn/start params", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const { client, emit } = buildMockClient((method, params) => {
+      if (method === "turn/start") {
+        captured = params as Record<string, unknown>;
+        setTimeout(() => emit("turn/completed", completedTurn("turn-1")), 20);
+        return inProgressTurn("turn-1");
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const dispatcher = new EventDispatcher("reviewer-fwd", TEST_LOG_DIR, () => {});
+    await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
+      dispatcher,
+      approvalHandler: autoApproveHandler,
+      timeoutMs: 5000,
+      killSignalsDir: TEST_KILL_DIR,
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+    });
+
+    // Guardian routing must reach the wire: on a thread already loaded in the
+    // long-lived broker app-server, the per-turn param is the reliable path
+    // (thread/resume-level settings can be ignored, like sandbox).
+    expect(captured?.approvalsReviewer).toBe("auto_review");
+    expect(captured?.approvalPolicy).toBe("on-request");
+  });
+});

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -8,7 +8,7 @@ import {
   type UserInput, type TurnStartParams, type TurnStartResponse, type TurnCompletedParams,
   type ReviewTarget, type ReviewStartParams, type ReviewDelivery,
   type TurnResult, type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
-  type ErrorNotificationParams,
+  type ErrorNotificationParams, type AutoApprovalReviewParams,
   type CommandApprovalRequest, type FileChangeApprovalRequest,
   type ApprovalPolicy, type ReasoningEffort,
 } from "./types";
@@ -264,6 +264,10 @@ async function executeTurn(
       case "item/commandExecution/outputDelta":
         opts.dispatcher.handleDelta(method, params as DeltaParams);
         break;
+      case "item/autoApprovalReview/started":
+      case "item/autoApprovalReview/completed":
+        opts.dispatcher.handleAutoApprovalReview(method, params as AutoApprovalReviewParams);
+        break;
       case "error":
         opts.dispatcher.handleError(params as ErrorNotificationParams);
         break;
@@ -275,6 +279,8 @@ async function executeTurn(
     "item/completed",
     "item/agentMessage/delta",
     "item/commandExecution/outputDelta",
+    "item/autoApprovalReview/started",
+    "item/autoApprovalReview/completed",
     "error",
   ]) {
     unsubs.push(

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -10,7 +10,7 @@ import {
   type TurnResult, type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
   type ErrorNotificationParams, type AutoApprovalReviewParams,
   type CommandApprovalRequest, type FileChangeApprovalRequest,
-  type ApprovalPolicy, type ReasoningEffort,
+  type ApprovalPolicy, type ApprovalsReviewer, type ReasoningEffort,
 } from "./types";
 import type { EventDispatcher } from "./events";
 import type { ApprovalHandler } from "./approvals";
@@ -65,6 +65,10 @@ export interface TurnOptions {
   model?: string;
   effort?: ReasoningEffort;
   approvalPolicy?: ApprovalPolicy;
+  /** Per-turn approval reviewer override ("auto_review" = Guardian). Like
+   *  sandboxPolicy below, per-turn is the reliable application path when the
+   *  thread is already loaded in the long-lived (broker) app-server. */
+  approvalsReviewer?: ApprovalsReviewer;
   /** Per-turn sandbox override (wire shape, e.g. {type:"workspaceWrite"}).
    *  Re-applies the sandbox on resume, where thread/resume's `sandbox` is
    *  ignored for a thread already loaded in the long-lived app-server. */
@@ -101,6 +105,7 @@ export async function runTurn(
     model: opts.model,
     effort: opts.effort,
     approvalPolicy: opts.approvalPolicy,
+    approvalsReviewer: opts.approvalsReviewer,
     sandboxPolicy: opts.sandboxPolicy,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,12 @@ export interface InitializeResponse {
 
 export type { ApprovalPolicy, SandboxMode, ReasoningEffort } from "./config";
 
+/** Where the app-server routes approval requests for review. "auto_review"
+ *  is the Guardian subagent (risk-based auto-permit/reject; escalates to the
+ *  client only when unsure). Accepted on thread/start, thread/fork,
+ *  thread/resume, and turn/start — no experimentalApi needed. */
+export type ApprovalsReviewer = "user" | "auto_review";
+
 export interface Thread {
   id: string;
   preview: string;
@@ -95,6 +101,7 @@ export interface ThreadForkParams {
   model?: string;
   cwd?: string;
   approvalPolicy?: ApprovalPolicy;
+  approvalsReviewer?: ApprovalsReviewer;
   sandbox?: string | null;
   config?: Record<string, unknown>;
   ephemeral?: boolean;
@@ -113,6 +120,7 @@ export interface TurnStartParams {
   input: UserInput[];
   cwd?: string;
   approvalPolicy?: ApprovalPolicy;
+  approvalsReviewer?: ApprovalsReviewer;
   sandboxPolicy?: unknown;
   model?: string;
   effort?: ReasoningEffort;
@@ -368,6 +376,17 @@ export interface FileChangeApprovalRequest {
 }
 
 export type ApprovalDecision = "accept" | "acceptForSession" | "decline" | "cancel";
+
+/** item/autoApprovalReview/started|completed notification payloads (Guardian
+ *  reviewing an approval request). Marked [UNSTABLE] in Codex 0.142 and
+ *  "expected to change soon" — every field is optional and consumers must
+ *  parse defensively, degrading to a generic progress line. */
+export interface AutoApprovalReviewParams {
+  threadId?: string;
+  turnId?: string;
+  itemId?: string;
+  [key: string]: unknown;
+}
 
 // --- Model list ---
 


### PR DESCRIPTION
Implements sections **1** (Guardian auto-review) and **6** (memory/personalization isolation) of #11. Everything below was verified live against Codex 0.142.3, not just unit-tested.

## Guardian auto-approvals

- `--approval auto` (also settable via `codex-collab config approval auto`) maps to `approvalPolicy: "on-request"` + `approvalsReviewer: "auto_review"` on `thread/start`, `thread/fork`, `thread/resume`, and as per-turn overrides on resumed threads. No experimentalApi gate needed for this param.
- Guardian decisions are forwarded into the progress stream via `item/autoApprovalReview/started|completed` (routed through the same active-turn filter as other events, so orphaned-turn reviews on a shared broker don't contaminate output):
  ```
  [codex] Guardian reviewing approval request: /bin/zsh -lc 'touch guardian-canary.txt'
  [codex] Guardian approved (low risk): /bin/zsh -lc 'touch guardian-canary.txt'
  ```
  Full payloads (rationale, decisionSource, userAuthorization) land in the thread log for auditing. The payload is marked `[UNSTABLE]` upstream, so extraction prefers the observed shape (`action.command`, `review.{status,riskLevel}`) with flat-field fallbacks and degrades to a generic line rather than dropping events.
- The file-based interactive approve/decline flow is unchanged and remains the escalation path.

## Memory isolation

- `initialize` now declares `experimentalApi: true` (required for `thread/memoryMode/set`; multiple live runs through both broker and direct paths showed no side effects).
- Every non-ephemeral thread codex-collab **creates** gets `thread/memoryMode/set mode=disabled` — verified in the state DB (`threads.memory_mode = 'disabled'` for created threads, memory ingestion filters `WHERE memory_mode = 'enabled'`). Opt back in per-run with `--memory` or persistently with `config memory true`.
- **Resumed** threads are never touched: the flag is persistent per-thread, and disabling it on a user-owned thread would silently exclude that thread from the user's own memory.
- Review threads are skipped: they're `ephemeral` (never materialized on disk → structurally outside ingestion) and the server rejects metadata updates on them with `-32600 "ephemeral thread does not support metadata updates"` (found in live testing).
- README documents the honest boundary: this governs local memory consolidation only; `personality` is user config (not learned) and unaffected; server-side learning from API traffic is outside any client's control.

## Live E2E performed

- Normal run → thread `memory_mode = 'disabled'` in `~/.codex/state_5.sqlite`; older threads untouched.
- `--approval auto` + read-only sandbox + `touch` → Guardian reviewed and approved; file created; zero human round-trips.
- Risky-looking commands (`rm -rf <nonexistent>`, `sudo -n whoami`) → approved at low/medium risk with risk levels rendered.
- Resume with `--approval auto` → per-turn Guardian routing works; no memoryMode call on the resume path.
- Review (ephemeral) → runs clean with no memory warning after the skip fix.

## Residual notes (left on #11)

- Could not force a Guardian **escalation** with safe commands (it approved everything tried, including sudo). The escalation transport is assumed to be the existing `item/*/requestApproval` methods the broker already forwards; worth confirming when a real escalation occurs.
- Guardian's own review subthreads are server-created with `memory_mode = 'enabled'` (`thread_source = 'subagent'`) and embed the reviewed thread's history. The static ingestion SQL shows no source filter, so there's a theoretical leak path outside client control; runtime evidence (only user-source threads in `memories_1.sqlite`) suggests subagent threads aren't ingested. Upstream question for Codex.

Closes nothing yet — #11 tracks the remaining sections.