### PR TITLE
refactor: shared RPC core, unified thread API/status, raw thread IDs, process-group shutdown

### DIFF
--- a/src/broker-client.ts
+++ b/src/broker-client.ts
@@ -4,16 +4,16 @@
  *
  * This allows callers to use the same interface whether connected directly
  * to `codex app-server` or through the broker multiplexer.
+ *
+ * The JSON-RPC plumbing lives in rpc.ts (shared with client.ts); this file
+ * owns the socket transport: connect, close, and the broker handshake.
  */
 
 import net from "node:net";
-import { parseMessage, formatNotification, formatResponse, isResponse, isError, isRequest, isNotification } from "./client";
-import type { AppServerClient, RequestId, PendingRequest, NotificationHandler, AnyNotificationHandler, ServerRequestHandler } from "./client";
-import { RpcError, type JsonRpcMessage } from "./types";
+import type { AppServerClient } from "./client";
 import { config } from "./config";
 import { parseEndpoint } from "./broker";
-
-const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+import { createRpcEndpoint } from "./rpc";
 
 export interface BrokerClientOptions {
   /** The broker endpoint (unix:/path or pipe:\path). */
@@ -29,13 +29,6 @@ export interface BrokerClientOptions {
 export async function connectToBroker(opts: BrokerClientOptions): Promise<AppServerClient> {
   const requestTimeout = opts.requestTimeout ?? config.requestTimeout;
   const target = parseEndpoint(opts.endpoint);
-
-  const pending = new Map<RequestId, PendingRequest>();
-  const notificationHandlers = new Map<string, Set<NotificationHandler>>();
-  const anyNotificationHandlers = new Set<AnyNotificationHandler>();
-  const requestHandlers = new Map<string, ServerRequestHandler>();
-  let closed = false;
-  let nextId = 1;
 
   // Connect to the socket
   const socket = await new Promise<net.Socket>((resolve, reject) => {
@@ -60,240 +53,46 @@ export async function connectToBroker(opts: BrokerClientOptions): Promise<AppSer
     sock.connect({ path: target.path });
   });
 
-  // Write to the socket
-  function write(data: string): void {
-    if (closed || socket.destroyed) return;
-    try {
+  let failed = false;
+
+  const endpoint = createRpcEndpoint({
+    label: "broker-client",
+    requestTimeout,
+    send: (data) => {
+      if (socket.destroyed) return;
       socket.write(data);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[broker-client] Failed to write: ${msg}`);
-      rejectAll("Socket write failed: " + msg);
-    }
-  }
-
-  function rejectAll(reason: string): void {
-    for (const entry of pending.values()) {
-      clearTimeout(entry.timer);
-      entry.reject(new Error(reason));
-    }
-    pending.clear();
-  }
-
-  // Dispatch incoming messages
-  function dispatch(msg: JsonRpcMessage): void {
-    if (isResponse(msg)) {
-      const entry = pending.get(msg.id);
-      if (entry) {
-        clearTimeout(entry.timer);
-        pending.delete(msg.id);
-        entry.resolve(msg.result);
-      }
-      return;
-    }
-
-    if (isError(msg)) {
-      const entry = pending.get(msg.id);
-      if (entry) {
-        clearTimeout(entry.timer);
-        pending.delete(msg.id);
-        const e = msg.error;
-        const err = new RpcError(
-          `JSON-RPC error ${e.code}: ${e.message}${e.data ? ` (${JSON.stringify(e.data)})` : ""}`,
-          e.code,
-        );
-        entry.reject(err);
-      }
-      return;
-    }
-
-    if (isRequest(msg)) {
-      const handler = requestHandlers.get(msg.method);
-      if (handler) {
-        Promise.resolve()
-          .then(() => handler(msg.params))
-          .then(
-            (res) => write(formatResponse(msg.id, res)),
-            (err) => {
-              const errMsg = err instanceof Error ? err.message : String(err);
-              // Preserve a structured code/data the handler attached to the
-              // Error, matching connectDirect — otherwise approval rejections
-              // through the broker path flatten to a generic -32603 while the
-              // direct path keeps the original error class.
-              const errAny = err as { code?: unknown; data?: unknown };
-              const code = typeof errAny?.code === "number" ? errAny.code : -32603;
-              const message = code === -32603 ? `Handler error: ${errMsg}` : errMsg;
-              console.error(`[broker-client] Error in request handler for "${msg.method}": ${errMsg}`);
-              const errBody: Record<string, unknown> = { code, message };
-              if (errAny?.data !== undefined) errBody.data = errAny.data;
-              write(JSON.stringify({ id: msg.id, error: errBody }) + "\n");
-            },
-          );
-      } else {
-        write(
-          JSON.stringify({
-            id: msg.id,
-            error: { code: -32601, message: `Method not found: ${msg.method}` },
-          }) + "\n",
-        );
-      }
-      return;
-    }
-
-    if (isNotification(msg)) {
-      for (const h of anyNotificationHandlers) {
-        try {
-          h(msg.method, msg.params);
-        } catch (e) {
-          console.error(
-            `[broker-client] Error in wildcard notification handler for "${msg.method}": ${e instanceof Error ? e.message : String(e)}`,
-          );
-        }
-      }
-      const handlers = notificationHandlers.get(msg.method);
-      if (handlers) {
-        for (const h of handlers) {
-          try {
-            h(msg.params);
-          } catch (e) {
-            console.error(
-              `[broker-client] Error in notification handler for "${msg.method}": ${e instanceof Error ? e.message : String(e)}`,
-            );
-          }
-        }
-      }
-    }
-  }
-
-  const closeHandlers = new Set<() => void>();
-  let unexpectedCloseNotified = false;
+    },
+    // Mirror connectDirect's exited guard: after an unexpected socket close,
+    // writes silently no-op on the dead socket — without this check a request
+    // would sit in `pending` for the full 30s timeout (e.g. blocking Ctrl-C
+    // shutdown's turn/interrupt on a dead broker).
+    downReason: () => (failed || socket.destroyed ? "Broker connection closed" : null),
+    overflowReason: "Broker response buffer exceeded maximum size",
+    onOverflow: () => socket.destroy(new Error("Broker response buffer exceeded maximum size")),
+    writeFailedPrefix: "Socket write failed: ",
+  });
 
   function notifyUnexpectedClose(reason: string): void {
-    if (closed || unexpectedCloseNotified) return;
-    unexpectedCloseNotified = true;
-    rejectAll(reason);
-    for (const handler of closeHandlers) {
-      try { handler(); } catch (e) {
-        console.error(`[codex] Warning: close handler error: ${e instanceof Error ? e.message : String(e)}`);
-      }
-    }
+    failed = true;
+    endpoint.fail(reason);
   }
 
-  // Read loop — parse newline-delimited JSON from socket
-  let buffer = "";
-  socket.on("data", (chunk: string) => {
-    buffer += chunk;
-    if (buffer.length > MAX_BUFFER_SIZE) {
-      notifyUnexpectedClose("Broker response buffer exceeded maximum size");
-      socket.destroy(new Error("Broker response buffer exceeded maximum size"));
-      return;
-    }
-    let newlineIdx: number;
-    while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-      const line = buffer.slice(0, newlineIdx).trim();
-      buffer = buffer.slice(newlineIdx + 1);
-      if (!line) continue;
-      const msg = parseMessage(line);
-      if (msg) dispatch(msg);
-    }
-  });
+  socket.on("data", (chunk: string) => endpoint.feed(chunk));
 
   socket.on("close", () => {
     notifyUnexpectedClose("Broker connection closed");
   });
 
   socket.on("error", (err) => {
-    if (!closed) {
+    if (!endpoint.isClosed()) {
       console.error(`[broker-client] Socket error: ${err.message}`);
       notifyUnexpectedClose("Broker socket error: " + err.message);
     }
   });
 
-  // Build the client interface
-  function request<T = unknown>(method: string, params?: unknown): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      if (closed) {
-        reject(new Error("Client is closed"));
-        return;
-      }
-      // Mirror connectDirect's `exited` guard: after an unexpected socket
-      // close, write() silently no-ops on the dead socket — without this
-      // check the request would sit in `pending` for the full 30s timeout
-      // (e.g. blocking Ctrl-C shutdown's turn/interrupt on a dead broker).
-      if (unexpectedCloseNotified || socket.destroyed) {
-        reject(new Error("Broker connection closed"));
-        return;
-      }
-
-      const id = nextId++;
-      const msg: Record<string, unknown> = { id, method };
-      if (params !== undefined) msg.params = params;
-      const line = JSON.stringify(msg) + "\n";
-
-      const timer = setTimeout(() => {
-        pending.delete(id);
-        reject(
-          new Error(
-            `Request ${method} (id=${id}) timed out after ${requestTimeout}ms`,
-          ),
-        );
-      }, requestTimeout);
-
-      pending.set(id, {
-        resolve: resolve as (value: unknown) => void,
-        reject,
-        timer,
-      });
-      write(line);
-    });
-  }
-
-  function notify(method: string, params?: unknown): void {
-    write(formatNotification(method, params));
-  }
-
-  function on(method: string, handler: NotificationHandler): () => void {
-    if (!notificationHandlers.has(method)) {
-      notificationHandlers.set(method, new Set());
-    }
-    notificationHandlers.get(method)!.add(handler);
-    return () => {
-      notificationHandlers.get(method)?.delete(handler);
-    };
-  }
-
-  function onAny(handler: AnyNotificationHandler): () => void {
-    anyNotificationHandlers.add(handler);
-    return () => { anyNotificationHandlers.delete(handler); };
-  }
-
-  function onRequest(method: string, handler: ServerRequestHandler): () => void {
-    if (requestHandlers.has(method)) {
-      console.error(
-        `[broker-client] Warning: replacing existing request handler for "${method}"`,
-      );
-    }
-    requestHandlers.set(method, handler);
-    return () => {
-      if (requestHandlers.get(method) === handler) {
-        requestHandlers.delete(method);
-      }
-    };
-  }
-
-  function respond(id: RequestId, result: unknown): void {
-    write(formatResponse(id, result));
-  }
-
-  function onClose(handler: () => void): () => void {
-    closeHandlers.add(handler);
-    return () => { closeHandlers.delete(handler); };
-  }
-
   async function close(): Promise<void> {
-    if (closed) return;
-    closed = true;
-    rejectAll("Client closed");
+    if (endpoint.isClosed()) return;
+    endpoint.markClosed();
     socket.end();
     // Wait for the socket to fully close. Clear the safety timer once the
     // close lands so a leftover armed timer can't keep the event loop alive.
@@ -317,7 +116,7 @@ export async function connectToBroker(opts: BrokerClientOptions): Promise<AppSer
   let userAgent: string;
   let brokerBusy = false;
   try {
-    const result = await request<{ userAgent: string; busy?: boolean }>("initialize", {
+    const result = await endpoint.request<{ userAgent: string; busy?: boolean }>("initialize", {
       clientInfo: {
         name: config.clientName,
         title: null,
@@ -333,20 +132,20 @@ export async function connectToBroker(opts: BrokerClientOptions): Promise<AppSer
     });
     brokerBusy = result.busy === true;
     userAgent = result.userAgent;
-    notify("initialized");
+    endpoint.notify("initialized");
   } catch (e) {
     await close();
     throw e;
   }
 
   return {
-    request,
-    notify,
-    on,
-    onAny,
-    onRequest,
-    respond,
-    onClose,
+    request: endpoint.request,
+    notify: endpoint.notify,
+    on: endpoint.on,
+    onAny: endpoint.onAny,
+    onRequest: endpoint.onRequest,
+    respond: endpoint.respond,
+    onClose: endpoint.onClose,
     close,
     userAgent,
     brokerBusy,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ async function handleShutdownSignal(exitCode: number): Promise<void> {
   // cleanup — ensures the mapping is written even if client.close() hangs.
   if (activeThreadId && activeWsPaths) {
     try {
-      updateThreadStatus(activeWsPaths.threadsFile, activeThreadId, "interrupted");
+      updateThreadStatus(activeWsPaths.stateDir, activeThreadId, "interrupted");
     } catch (e) {
       console.error(`[codex] Warning: could not update thread status during shutdown: ${e instanceof Error ? e.message : String(e)}`);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ async function handleShutdownSignal(exitCode: number): Promise<void> {
     if (activeRunId) {
       try {
         updateRun(activeWsPaths.stateDir, activeRunId, {
-          status: "cancelled",
+          status: "interrupted",
           completedAt: new Date().toISOString(),
           error: "Interrupted by signal",
           // Ctrl-C while blocked on an approval exits before the approval

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -34,6 +34,10 @@ const MOCK_SERVER_SOURCE = `#!/usr/bin/env bun
 function respond(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
 const exitEarly = process.env.MOCK_EXIT_EARLY === "1";
 const errorResponse = process.env.MOCK_ERROR_RESPONSE === "1";
+if (process.env.MOCK_SPAWN_GRANDCHILD) {
+  const child = Bun.spawn(["sleep", "300"]);
+  require("fs").writeFileSync(process.env.MOCK_SPAWN_GRANDCHILD, String(child.pid));
+}
 let buffer = "";
 process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => {
@@ -71,7 +75,7 @@ process.stdin.on("data", (chunk) => {
     }
   }
 });
-process.stdin.on("end", () => process.exit(0));
+process.stdin.on("end", () => { if (process.env.MOCK_IGNORE_STDIN_END !== "1") process.exit(0); });
 process.stdin.on("error", () => process.exit(1));
 `;
 
@@ -508,4 +512,45 @@ describe("AppServerClient", () => {
       await c.close();
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// close() must kill grandchildren (Unix process group)
+// ---------------------------------------------------------------------------
+
+describe("close() kills grandchildren", () => {
+  test("a grandchild of a hung server dies with the process group", async () => {
+    if (process.platform === "win32") return; // Windows tree kill is taskkill /T
+    const pidFile = join(TEST_DIR, `grandchild-${process.pid}-${Date.now()}.pid`);
+    const c = await connect({
+      command: ["bun", "run", MOCK_SERVER],
+      requestTimeout: 10000,
+      env: { MOCK_SPAWN_GRANDCHILD: pidFile, MOCK_IGNORE_STDIN_END: "1" },
+    });
+
+    const { existsSync, readFileSync, rmSync } = await import("fs");
+    let grandchildPid = 0;
+    for (let i = 0; i < 100 && !grandchildPid; i++) {
+      if (existsSync(pidFile)) grandchildPid = Number(readFileSync(pidFile, "utf-8").trim());
+      if (!grandchildPid) await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(grandchildPid).toBeGreaterThan(0);
+
+    try {
+      // The server ignores stdin EOF (hung server), so close() escalates to
+      // a group SIGTERM — which must take the grandchild down too. Before
+      // group signalling, only the direct child died and sleep(300) leaked.
+      await c.close();
+
+      let alive = true;
+      for (let i = 0; i < 20 && alive; i++) {
+        try { process.kill(grandchildPid, 0); } catch { alive = false; }
+        if (alive) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(alive).toBe(false);
+    } finally {
+      try { process.kill(grandchildPid, "SIGKILL"); } catch {}
+      rmSync(pidFile, { force: true });
+    }
+  }, 20000);
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -35,7 +35,10 @@ function respond(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
 const exitEarly = process.env.MOCK_EXIT_EARLY === "1";
 const errorResponse = process.env.MOCK_ERROR_RESPONSE === "1";
 if (process.env.MOCK_SPAWN_GRANDCHILD) {
-  const child = Bun.spawn(["sleep", "300"]);
+  const argv = process.env.MOCK_GRANDCHILD_STUBBORN === "1"
+    ? ["bun", "-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"]
+    : ["sleep", "300"];
+  const child = Bun.spawn(argv);
   require("fs").writeFileSync(process.env.MOCK_SPAWN_GRANDCHILD, String(child.pid));
 }
 let buffer = "";
@@ -554,15 +557,21 @@ describe("close() kills grandchildren", () => {
     }
   }, 20000);
 
-  test("a grandchild left behind by a GRACEFUL exit is swept too", async () => {
+  // Parameterized: a well-behaved grandchild dies from the sweep's SIGTERM;
+  // a SIGTERM-ignoring one must be caught by the sweep's SIGKILL escalation.
+  for (const stubborn of [false, true]) {
+    test(`a grandchild left behind by a GRACEFUL exit is swept (${stubborn ? "ignores SIGTERM" : "well-behaved"})`, async () => {
     if (process.platform === "win32") return;
-    const pidFile = join(TEST_DIR, `grandchild-graceful-${process.pid}-${Date.now()}.pid`);
-    // Default mock behavior: exits on stdin EOF — but the sleep(300) it
+    const pidFile = join(TEST_DIR, `grandchild-graceful-${stubborn}-${process.pid}-${Date.now()}.pid`);
+    // Default mock behavior: exits on stdin EOF — but the grandchild it
     // spawned survives that clean exit. close() must sweep the group.
     const c = await connect({
       command: ["bun", "run", MOCK_SERVER],
       requestTimeout: 10000,
-      env: { MOCK_SPAWN_GRANDCHILD: pidFile },
+      env: {
+        MOCK_SPAWN_GRANDCHILD: pidFile,
+        ...(stubborn ? { MOCK_GRANDCHILD_STUBBORN: "1" } : {}),
+      },
     });
 
     const { existsSync, readFileSync, rmSync } = await import("fs");
@@ -585,5 +594,6 @@ describe("close() kills grandchildren", () => {
       try { process.kill(grandchildPid, "SIGKILL"); } catch {}
       rmSync(pidFile, { force: true });
     }
-  }, 20000);
+    }, 20000);
+  }
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -553,4 +553,37 @@ describe("close() kills grandchildren", () => {
       rmSync(pidFile, { force: true });
     }
   }, 20000);
+
+  test("a grandchild left behind by a GRACEFUL exit is swept too", async () => {
+    if (process.platform === "win32") return;
+    const pidFile = join(TEST_DIR, `grandchild-graceful-${process.pid}-${Date.now()}.pid`);
+    // Default mock behavior: exits on stdin EOF — but the sleep(300) it
+    // spawned survives that clean exit. close() must sweep the group.
+    const c = await connect({
+      command: ["bun", "run", MOCK_SERVER],
+      requestTimeout: 10000,
+      env: { MOCK_SPAWN_GRANDCHILD: pidFile },
+    });
+
+    const { existsSync, readFileSync, rmSync } = await import("fs");
+    let grandchildPid = 0;
+    for (let i = 0; i < 100 && !grandchildPid; i++) {
+      if (existsSync(pidFile)) grandchildPid = Number(readFileSync(pidFile, "utf-8").trim());
+      if (!grandchildPid) await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(grandchildPid).toBeGreaterThan(0);
+
+    try {
+      await c.close();
+      let alive = true;
+      for (let i = 0; i < 20 && alive; i++) {
+        try { process.kill(grandchildPid, 0); } catch { alive = false; }
+        if (alive) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(alive).toBe(false);
+    } finally {
+      try { process.kill(grandchildPid, "SIGKILL"); } catch {}
+      rmSync(pidFile, { force: true });
+    }
+  }, 20000);
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -521,6 +521,17 @@ describe("AppServerClient", () => {
 // close() must kill grandchildren (Unix process group)
 // ---------------------------------------------------------------------------
 
+/** kill(pid, 0) succeeds for zombies: an orphaned grandchild stays STAT=Z
+ *  until PID 1 reaps it, which never happens promptly in containers with a
+ *  non-reaping init. Read the process state so "killed but unreaped" counts
+ *  as dead. */
+function grandchildAlive(pid: number): boolean {
+  try { process.kill(pid, 0); } catch { return false; }
+  const stat = Bun.spawnSync(["ps", "-o", "stat=", "-p", String(pid)])
+    .stdout.toString().trim();
+  return stat !== "" && !stat.startsWith("Z");
+}
+
 describe("close() kills grandchildren", () => {
   test("a grandchild of a hung server dies with the process group", async () => {
     if (process.platform === "win32") return; // Windows tree kill is taskkill /T
@@ -547,7 +558,7 @@ describe("close() kills grandchildren", () => {
 
       let alive = true;
       for (let i = 0; i < 20 && alive; i++) {
-        try { process.kill(grandchildPid, 0); } catch { alive = false; }
+        alive = grandchildAlive(grandchildPid);
         if (alive) await new Promise((r) => setTimeout(r, 100));
       }
       expect(alive).toBe(false);
@@ -586,7 +597,7 @@ describe("close() kills grandchildren", () => {
       await c.close();
       let alive = true;
       for (let i = 0; i < 20 && alive; i++) {
-        try { process.kill(grandchildPid, 0); } catch { alive = false; }
+        alive = grandchildAlive(grandchildPid);
         if (alive) await new Promise((r) => setTimeout(r, 100));
       }
       expect(alive).toBe(false);

--- a/src/client.ts
+++ b/src/client.ts
@@ -93,13 +93,16 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   // commands). The CLI's own pgroup is untouched. Not used on Windows, where
   // detached also detaches the console; tree termination there is taskkill /T.
   const detached = process.platform !== "win32";
-  const proc = childSpawn(command[0], command.slice(1), {
+  // On Windows, npm installs `codex` as a `codex.cmd` shim, which
+  // child_process.spawn refuses to launch without a shell (EINVAL since the
+  // CVE-2024-27980 hardening). Wrap with `cmd.exe /c` — the same thing
+  // Bun.spawn did implicitly; windowsHide keeps the console window away.
+  const argv = process.platform === "win32" ? ["cmd.exe", "/c", ...command] : command;
+  const proc = childSpawn(argv[0], argv.slice(1), {
     stdio: ["pipe", "pipe", "pipe"],
     cwd: opts?.cwd,
     env: opts?.env ? { ...process.env, ...opts.env } : undefined,
     detached,
-    // On Windows, `codex` resolves to `codex.cmd`, which would otherwise
-    // show a console window for the lifetime of the broker's app-server.
     windowsHide: true,
   });
 
@@ -229,8 +232,12 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
 
     // Unix: wait for graceful exit, then escalate — group signals, so
     // grandchildren (wrapper scripts, mid-turn shell commands) die with
-    // the app-server instead of being orphaned.
-    if (await waitForExit(5000)) return;
+    // the app-server instead of being orphaned. Even after a graceful
+    // exit, sweep the process group: a server that exits on stdin EOF can
+    // still leave a spawned command running, and the group id stays
+    // reserved while any member is alive (ESRCH on an empty group is
+    // swallowed by killTree).
+    if (await waitForExit(5000)) { killTree("SIGTERM"); return; }
     killTree("SIGTERM");
     if (await waitForExit(3000)) return;
     killTree("SIGKILL");

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,8 +5,7 @@
 // to the spawned child process: spawn, stdin/stdout wiring, stderr draining,
 // exit monitoring, platform-specific shutdown, and the initialize handshake.
 
-import { spawn } from "bun";
-import { spawnSync } from "child_process";
+import { spawn as childSpawn, spawnSync } from "child_process";
 import type { InitializeParams, InitializeResponse, RequestId } from "./types";
 import { config } from "./config";
 import {
@@ -67,7 +66,8 @@ export interface AppServerClient {
    *  (e.g. the app-server process exits). Not called on intentional close(). */
   onClose(handler: () => void): () => void;
   /** Close the connection and terminate the server process.
-   *  On Unix: close stdin -> wait 5s -> SIGTERM -> wait 3s -> SIGKILL.
+   *  On Unix: close stdin -> wait 5s -> SIGTERM -> wait 3s -> SIGKILL,
+   *  signalling the app-server's process group so grandchildren die too.
    *  On Windows: close stdin, then immediately terminate the process tree
    *  (no timed grace period, unlike Unix). */
   close(): Promise<void>;
@@ -86,89 +86,89 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   const command = opts?.command ?? ["codex", "app-server"];
   const requestTimeout = opts?.requestTimeout ?? config.requestTimeout;
 
-  // Spawn the child process
-  const proc = (() => {
-    try {
-      return spawn(command, {
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
-        cwd: opts?.cwd,
-        env: opts?.env ? { ...process.env, ...opts.env } : undefined,
-        // On Windows, `codex` resolves to `codex.cmd` and Bun.spawn wraps it
-        // with `cmd.exe /c`, which would otherwise show a console window for
-        // the lifetime of the broker's app-server.
-        windowsHide: true,
-      });
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      throw new Error(
-        `Failed to start app server (${command.join(" ")}): ${msg}\n` +
-        `Ensure codex CLI is installed: npm install -g @openai/codex`,
-      );
-    }
-  })();
+  // Spawn the child process. Node's child_process (not Bun.spawn, which has
+  // no `detached`) so the app-server gets its own process group on Unix —
+  // close() can then signal the whole tree (-pid) instead of only the direct
+  // child, which orphaned grandchildren (wrapper scripts, mid-turn shell
+  // commands). The CLI's own pgroup is untouched. Not used on Windows, where
+  // detached also detaches the console; tree termination there is taskkill /T.
+  const detached = process.platform !== "win32";
+  const proc = childSpawn(command[0], command.slice(1), {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: opts?.cwd,
+    env: opts?.env ? { ...process.env, ...opts.env } : undefined,
+    detached,
+    // On Windows, `codex` resolves to `codex.cmd`, which would otherwise
+    // show a console window for the lifetime of the broker's app-server.
+    windowsHide: true,
+  });
 
   let exited = false;
+
+  /** Signal the app-server's process group (Unix, detached) with a fallback
+   *  to the direct child; plain child kill elsewhere. */
+  function killTree(signal?: NodeJS.Signals): void {
+    if (detached && proc.pid) {
+      try {
+        process.kill(-proc.pid, signal ?? "SIGTERM");
+        return;
+      } catch {} // ESRCH (group gone) / EPERM — fall through to the child
+    }
+    try { proc.kill(signal); } catch (e) {
+      if (!exited) {
+        console.error(`[codex] Warning: proc.kill() failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
 
   const endpoint = createRpcEndpoint({
     label: "codex",
     requestTimeout,
-    send: (data) => proc.stdin.write(data),
+    send: (data) => {
+      if (!proc.stdin.writable) throw new Error("stdin is not writable");
+      proc.stdin.write(data);
+    },
     downReason: () => (exited ? "App server process exited unexpectedly" : null),
     overflowReason: "App server response buffer exceeded maximum size",
-    onOverflow: () => { try { proc.kill(); } catch {} },
+    onOverflow: () => killTree(),
     writeFailedPrefix: "App server stdin write failed: ",
   });
 
-  // Start the read loop — reads stdout line-by-line
-  const readLoop = (async () => {
-    const reader = proc.stdout.getReader();
-    const decoder = new TextDecoder();
+  // Feed stdout into the endpoint line parser
+  proc.stdout.setEncoding("utf8");
+  proc.stdout.on("data", (chunk: string) => endpoint.feed(chunk));
 
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        endpoint.feed(decoder.decode(value, { stream: true }));
-      }
-    } catch (e) {
-      if (!endpoint.isClosed() && !exited) {
-        console.error(`[codex] Read loop error: ${e instanceof Error ? e.message : String(e)}`);
-        endpoint.rejectAllPending("Read loop failed unexpectedly");
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  })();
+  // Async stdin errors (e.g. EPIPE racing process death) surface via the
+  // exit handler below; an unhandled 'error' event would crash the CLI.
+  proc.stdin.on("error", () => {});
 
-  // Monitor process exit: reject all pending requests and notify close handlers
-  proc.exited.then(() => {
-    exited = true;
-    endpoint.fail("App server process exited unexpectedly");
+  // Monitor process exit: reject all pending requests and notify close
+  // handlers. A spawn failure (ENOENT — codex not installed) emits 'error'
+  // and may never emit 'exit', so both settle the same state.
+  const procGone = new Promise<void>((resolveGone) => {
+    proc.once("exit", () => {
+      exited = true;
+      endpoint.fail("App server process exited unexpectedly");
+      resolveGone();
+    });
+    proc.once("error", (err) => {
+      exited = true;
+      endpoint.fail(
+        `Failed to start app server (${command.join(" ")}): ${err.message}\n` +
+        `Ensure codex CLI is installed: npm install -g @openai/codex`,
+      );
+      resolveGone();
+    });
   });
 
   // Drain stderr and log non-empty output
-  (async () => {
-    const reader = proc.stderr.getReader();
-    const decoder = new TextDecoder();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        const text = decoder.decode(value, { stream: true }).trim();
-        if (text) {
-          console.error(`[codex] app-server stderr: ${text}`);
-        }
-      }
-    } catch (e) {
-      if (!endpoint.isClosed() && !exited) {
-        console.error(`[codex] Warning: stderr reader failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
-    } finally {
-      reader.releaseLock();
+  proc.stderr.setEncoding("utf8");
+  proc.stderr.on("data", (chunk: string) => {
+    const text = chunk.trim();
+    if (text) {
+      console.error(`[codex] app-server stderr: ${text}`);
     }
-  })();
+  });
 
   /** Wait for the process to exit within the given timeout. The timer is
    *  cleared when the process wins the race — a leftover armed timer keeps
@@ -177,7 +177,7 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   function waitForExit(timeoutMs: number): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const timer = setTimeout(() => resolve(false), timeoutMs);
-      proc.exited.then(() => {
+      procGone.then(() => {
         clearTimeout(timer);
         resolve(true);
       });
@@ -220,20 +220,21 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
           console.error(`[codex] Warning: proc.kill() failed: ${e instanceof Error ? e.message : String(e)}`);
         }
       }
-      // Wait for the process to fully exit so dangling readLoop / proc.exited
-      // promises don't keep the event loop alive (which blocks background tasks
+      // Wait for the process to fully exit so a dangling exit listener
+      // doesn't keep the event loop alive (which blocks background tasks
       // from reporting completion).
-      if (await waitForExit(3000)) { await readLoop; }
+      await waitForExit(3000);
       return;
     }
 
-    // Unix: wait for graceful exit, then escalate
-    if (await waitForExit(5000)) { await readLoop; return; }
-    proc.kill("SIGTERM");
-    if (await waitForExit(3000)) { await readLoop; return; }
-    proc.kill("SIGKILL");
-    await proc.exited;
-    await readLoop;
+    // Unix: wait for graceful exit, then escalate — group signals, so
+    // grandchildren (wrapper scripts, mid-turn shell commands) die with
+    // the app-server instead of being orphaned.
+    if (await waitForExit(5000)) return;
+    killTree("SIGTERM");
+    if (await waitForExit(3000)) return;
+    killTree("SIGKILL");
+    await procGone;
   }
 
   // --- Perform initialize handshake ---

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,109 +1,37 @@
-// src/client.ts — JSON-RPC client for Codex app server
+// src/client.ts — direct stdio transport to the Codex app server
+//
+// The JSON-RPC plumbing (dispatch, pending tracking, line buffering) lives in
+// rpc.ts and is shared with broker-client.ts; this file owns what is specific
+// to the spawned child process: spawn, stdin/stdout wiring, stderr draining,
+// exit monitoring, platform-specific shutdown, and the initialize handshake.
 
 import { spawn } from "bun";
 import { spawnSync } from "child_process";
-import type {
-  JsonRpcMessage,
-  JsonRpcRequest,
-  JsonRpcResponse,
-  JsonRpcError,
-  JsonRpcNotification,
-  RequestId,
-  InitializeParams,
-  InitializeResponse,
-} from "./types";
-import { RpcError } from "./types";
+import type { InitializeParams, InitializeResponse, RequestId } from "./types";
 import { config } from "./config";
-
-const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+import {
+  createRpcEndpoint,
+  type NotificationHandler,
+  type AnyNotificationHandler,
+  type ServerRequestHandler,
+} from "./rpc";
 
 export type { RequestId } from "./types";
-
-/** Format a JSON-RPC-style notification (no id, no response). Returns newline-terminated JSON.
- *  Note: Codex app server protocol omits the standard `jsonrpc: "2.0"` field. */
-export function formatNotification(method: string, params?: unknown): string {
-  const msg: Record<string, unknown> = { method };
-  if (params !== undefined) msg.params = params;
-  return JSON.stringify(msg) + "\n";
-}
-
-/** Format a JSON-RPC response to a server request. Returns newline-terminated JSON. */
-export function formatResponse(id: RequestId, result: unknown): string {
-  return JSON.stringify({ id, result }) + "\n";
-}
-
-/** Parse a JSON-RPC message from a line. Returns null if unparseable or not a valid protocol message. */
-export function parseMessage(line: string): JsonRpcMessage | null {
-  try {
-    const raw = JSON.parse(line);
-    if (typeof raw !== "object" || raw === null) return null;
-
-    const hasMethod = "method" in raw && typeof raw.method === "string";
-    const hasId = "id" in raw && (typeof raw.id === "string" || typeof raw.id === "number");
-    const hasResult = "result" in raw;
-    const hasError = "error" in raw;
-
-    if (!hasMethod && !hasId) {
-      console.error(`[codex] Warning: ignoring non-protocol message: ${line.slice(0, 200)}`);
-      return null;
-    }
-
-    if (hasId && !hasMethod) {
-      if (hasResult === hasError) {
-        console.error(`[codex] Warning: ignoring malformed response: ${line.slice(0, 200)}`);
-        return null;
-      }
-      if (hasError) {
-        const error = (raw as { error?: unknown }).error;
-        if (
-          typeof error !== "object" ||
-          error === null ||
-          typeof (error as { code?: unknown }).code !== "number" ||
-          typeof (error as { message?: unknown }).message !== "string"
-        ) {
-          console.error(`[codex] Warning: ignoring malformed error response: ${line.slice(0, 200)}`);
-          return null;
-        }
-      }
-      return raw as JsonRpcMessage;
-    }
-
-    if (hasMethod && hasId && (hasResult || hasError)) {
-      console.error(`[codex] Warning: ignoring malformed request/response hybrid: ${line.slice(0, 200)}`);
-      return null;
-    }
-
-    if (hasMethod && !hasId && (hasResult || hasError)) {
-      console.error(`[codex] Warning: ignoring malformed notification/response hybrid: ${line.slice(0, 200)}`);
-      return null;
-    }
-
-    return raw as JsonRpcMessage;
-  } catch {
-    console.error(`[codex] Warning: unparseable message from app server: ${line.slice(0, 200)}`);
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// AppServerClient — spawn, handshake, request/response routing, shutdown
-// ---------------------------------------------------------------------------
-
-/** Pending request tracker. */
-export interface PendingRequest {
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}
-
-/** Handler for server-sent notifications. */
-export type NotificationHandler = (params: unknown) => void;
-
-/** Handler for any server-sent notification, including the method name. */
-export type AnyNotificationHandler = (method: string, params: unknown) => void;
-
-/** Handler for server-sent requests (e.g. approval requests). Returns the result to send back. */
-export type ServerRequestHandler = (params: unknown) => unknown | Promise<unknown>;
+// Protocol helpers historically lived here; broker-server.ts and tests import
+// them from this module.
+export {
+  formatNotification,
+  formatResponse,
+  parseMessage,
+  isResponse,
+  isError,
+  isRequest,
+  isNotification,
+  type PendingRequest,
+  type NotificationHandler,
+  type AnyNotificationHandler,
+  type ServerRequestHandler,
+} from "./rpc";
 
 /** Options for connectDirect(). */
 export interface ConnectOptions {
@@ -150,26 +78,6 @@ export interface AppServerClient {
   brokerBusy: boolean;
 }
 
-/** Type guard: message is a response (has id + result). */
-export function isResponse(msg: JsonRpcMessage): msg is JsonRpcResponse {
-  return "id" in msg && "result" in msg && !("method" in msg);
-}
-
-/** Type guard: message is an error response (has id + error). */
-export function isError(msg: JsonRpcMessage): msg is JsonRpcError {
-  return "id" in msg && "error" in msg && !("method" in msg);
-}
-
-/** Type guard: message is a request (has id + method). */
-export function isRequest(msg: JsonRpcMessage): msg is JsonRpcRequest {
-  return "id" in msg && "method" in msg && !("result" in msg) && !("error" in msg);
-}
-
-/** Type guard: message is a notification (has method, no id). */
-export function isNotification(msg: JsonRpcMessage): msg is JsonRpcNotification {
-  return "method" in msg && !("id" in msg);
-}
-
 /**
  * Spawn the Codex app-server process, perform the initialize handshake,
  * and return an AppServerClient for request/response communication.
@@ -201,148 +109,33 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
     }
   })();
 
-  // Internal state
-  const pending = new Map<RequestId, PendingRequest>();
-  const notificationHandlers = new Map<string, Set<NotificationHandler>>();
-  const anyNotificationHandlers = new Set<AnyNotificationHandler>();
-  const requestHandlers = new Map<string, ServerRequestHandler>();
-  let closed = false;
   let exited = false;
-  let connectionNextId = 1;
 
-  // Write a string to the child's stdin
-  function write(data: string): void {
-    if (closed) return;
-    try {
-      proc.stdin.write(data);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (!exited) {
-        console.error(`[codex] Failed to write to app server: ${msg}`);
-      }
-      rejectAll("App server stdin write failed: " + msg);
-    }
-  }
-
-  // Reject all pending requests (used on process exit or close)
-  function rejectAll(reason: string): void {
-    for (const entry of pending.values()) {
-      clearTimeout(entry.timer);
-      entry.reject(new Error(reason));
-    }
-    pending.clear();
-  }
-
-  // Dispatch a parsed message
-  function dispatch(msg: JsonRpcMessage): void {
-    if (isResponse(msg)) {
-      const entry = pending.get(msg.id);
-      if (entry) {
-        clearTimeout(entry.timer);
-        pending.delete(msg.id);
-        entry.resolve(msg.result);
-      }
-      return;
-    }
-
-    if (isError(msg)) {
-      const entry = pending.get(msg.id);
-      if (entry) {
-        clearTimeout(entry.timer);
-        pending.delete(msg.id);
-        const e = msg.error;
-        entry.reject(new RpcError(
-          `JSON-RPC error ${e.code}: ${e.message}${e.data ? ` (${JSON.stringify(e.data)})` : ""}`,
-          e.code,
-        ));
-      }
-      return;
-    }
-
-    if (isRequest(msg)) {
-      const handler = requestHandlers.get(msg.method);
-      if (handler) {
-        Promise.resolve()
-          .then(() => handler(msg.params))
-          .then(
-            (res) => write(formatResponse(msg.id, res)),
-            (err) => {
-              const errMsg = err instanceof Error ? err.message : String(err);
-              // Preserve a structured code/data the handler attached to the
-              // Error (e.g. a forwarded client rejection); fall back to the
-              // generic internal-error code otherwise.
-              const errAny = err as { code?: unknown; data?: unknown };
-              const code = typeof errAny?.code === "number" ? errAny.code : -32603;
-              const message = code === -32603 ? `Handler error: ${errMsg}` : errMsg;
-              console.error(`[codex] Error in request handler for "${msg.method}": ${errMsg}`);
-              const errBody: Record<string, unknown> = { code, message };
-              if (errAny?.data !== undefined) errBody.data = errAny.data;
-              write(JSON.stringify({ id: msg.id, error: errBody }) + "\n");
-            },
-          );
-      } else {
-        write(JSON.stringify({ id: msg.id, error: { code: -32601, message: `Method not found: ${msg.method}` } }) + "\n");
-      }
-      return;
-    }
-
-    if (isNotification(msg)) {
-      // Wildcard handlers fire first, regardless of method, so the broker
-      // forwards every notification — including new ones the protocol adds.
-      for (const h of anyNotificationHandlers) {
-        try {
-          h(msg.method, msg.params);
-        } catch (e) {
-          console.error(`[codex] Error in wildcard notification handler for "${msg.method}": ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-      const handlers = notificationHandlers.get(msg.method);
-      if (handlers) {
-        for (const h of handlers) {
-          try {
-            h(msg.params);
-          } catch (e) {
-            console.error(`[codex] Error in notification handler for "${msg.method}": ${e instanceof Error ? e.message : String(e)}`);
-          }
-        }
-      }
-    }
-  }
+  const endpoint = createRpcEndpoint({
+    label: "codex",
+    requestTimeout,
+    send: (data) => proc.stdin.write(data),
+    downReason: () => (exited ? "App server process exited unexpectedly" : null),
+    overflowReason: "App server response buffer exceeded maximum size",
+    onOverflow: () => { try { proc.kill(); } catch {} },
+    writeFailedPrefix: "App server stdin write failed: ",
+  });
 
   // Start the read loop — reads stdout line-by-line
   const readLoop = (async () => {
     const reader = proc.stdout.getReader();
     const decoder = new TextDecoder();
-    let buffer = "";
 
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        if (buffer.length > MAX_BUFFER_SIZE) {
-          console.error("[codex] App server response buffer exceeded maximum size");
-          rejectAll("App server response buffer exceeded maximum size");
-          try { proc.kill(); } catch {}
-          break;
-        }
-
-        let newlineIdx: number;
-        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, newlineIdx).trim();
-          buffer = buffer.slice(newlineIdx + 1);
-          if (!line) continue;
-
-          const msg = parseMessage(line);
-          if (msg) {
-            dispatch(msg);
-          }
-        }
+        endpoint.feed(decoder.decode(value, { stream: true }));
       }
     } catch (e) {
-      if (!closed && !exited) {
+      if (!endpoint.isClosed() && !exited) {
         console.error(`[codex] Read loop error: ${e instanceof Error ? e.message : String(e)}`);
-        rejectAll("Read loop failed unexpectedly");
+        endpoint.rejectAllPending("Read loop failed unexpectedly");
       }
     } finally {
       reader.releaseLock();
@@ -350,17 +143,9 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   })();
 
   // Monitor process exit: reject all pending requests and notify close handlers
-  const closeHandlers = new Set<() => void>();
   proc.exited.then(() => {
     exited = true;
-    if (!closed) {
-      rejectAll("App server process exited unexpectedly");
-      for (const handler of closeHandlers) {
-        try { handler(); } catch (e) {
-          console.error(`[codex] Warning: close handler error: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-    }
+    endpoint.fail("App server process exited unexpectedly");
   });
 
   // Drain stderr and log non-empty output
@@ -377,78 +162,13 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
         }
       }
     } catch (e) {
-      if (!closed && !exited) {
+      if (!endpoint.isClosed() && !exited) {
         console.error(`[codex] Warning: stderr reader failed: ${e instanceof Error ? e.message : String(e)}`);
       }
     } finally {
       reader.releaseLock();
     }
   })();
-
-  // --- Build the client object ---
-
-  function request<T = unknown>(method: string, params?: unknown): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      if (closed) { reject(new Error("Client is closed")); return; }
-      if (exited) { reject(new Error("App server process exited unexpectedly")); return; }
-
-      const id = connectionNextId++;
-      const msg: Record<string, unknown> = { id, method };
-      if (params !== undefined) msg.params = params;
-      const line = JSON.stringify(msg) + "\n";
-
-      const timer = setTimeout(() => {
-        pending.delete(id);
-        reject(new Error(`Request ${method} (id=${id}) timed out after ${requestTimeout}ms`));
-      }, requestTimeout);
-
-      pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
-      write(line);
-    });
-  }
-
-  function notify(method: string, params?: unknown): void {
-    write(formatNotification(method, params));
-  }
-
-  function on(method: string, handler: NotificationHandler): () => void {
-    if (!notificationHandlers.has(method)) {
-      notificationHandlers.set(method, new Set());
-    }
-    notificationHandlers.get(method)!.add(handler);
-    return () => {
-      notificationHandlers.get(method)?.delete(handler);
-    };
-  }
-
-  function onAny(handler: AnyNotificationHandler): () => void {
-    anyNotificationHandlers.add(handler);
-    return () => { anyNotificationHandlers.delete(handler); };
-  }
-
-  /** Register a handler for server-sent requests. Only one handler per method;
-   *  a new registration replaces the previous one (with a warning). */
-  function onRequest(method: string, handler: ServerRequestHandler): () => void {
-    if (requestHandlers.has(method)) {
-      console.error(`[codex] Warning: replacing existing request handler for "${method}"`);
-    }
-    requestHandlers.set(method, handler);
-    return () => {
-      // Only delete if this is still our handler
-      if (requestHandlers.get(method) === handler) {
-        requestHandlers.delete(method);
-      }
-    };
-  }
-
-  function respond(id: RequestId, result: unknown): void {
-    write(formatResponse(id, result));
-  }
-
-  function onClose(handler: () => void): () => void {
-    closeHandlers.add(handler);
-    return () => { closeHandlers.delete(handler); };
-  }
 
   /** Wait for the process to exit within the given timeout. The timer is
    *  cleared when the process wins the race — a leftover armed timer keeps
@@ -465,9 +185,8 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   }
 
   async function close(): Promise<void> {
-    if (closed) return;
-    closed = true;
-    rejectAll("Client closed");
+    if (endpoint.isClosed()) return;
+    endpoint.markClosed();
 
     // Close stdin to signal the server to exit
     try {
@@ -531,21 +250,21 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
 
   let initResult: InitializeResponse;
   try {
-    initResult = await request<InitializeResponse>("initialize", initParams);
-    notify("initialized");
+    initResult = await endpoint.request<InitializeResponse>("initialize", initParams);
+    endpoint.notify("initialized");
   } catch (e) {
     await close();
     throw e;
   }
 
   return {
-    request,
-    notify,
-    on,
-    onAny,
-    onRequest,
-    respond,
-    onClose,
+    request: endpoint.request,
+    notify: endpoint.notify,
+    on: endpoint.on,
+    onAny: endpoint.onAny,
+    onRequest: endpoint.onRequest,
+    respond: endpoint.respond,
+    onClose: endpoint.onClose,
     close,
     userAgent: initResult.userAgent,
     brokerBusy: false,

--- a/src/client.ts
+++ b/src/client.ts
@@ -124,6 +124,27 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
     }
   }
 
+  /** After the direct child is gone, its detached process group can still
+   *  hold descendants (the group id stays reserved while any member lives).
+   *  SIGTERM the group and, if members ignore it, escalate to SIGKILL —
+   *  bounded at ~500ms and zero-cost when the group is already empty, so
+   *  close() resolving really means the tree is gone. */
+  async function sweepGroup(): Promise<void> {
+    if (!detached || !proc.pid) return;
+    const pgid = proc.pid;
+    const groupAlive = () => {
+      try { process.kill(-pgid, 0); return true; } catch { return false; }
+    };
+    if (!groupAlive()) return;
+    try { process.kill(-pgid, "SIGTERM"); } catch { return; }
+    for (let i = 0; i < 10 && groupAlive(); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (groupAlive()) {
+      try { process.kill(-pgid, "SIGKILL"); } catch {}
+    }
+  }
+
   const endpoint = createRpcEndpoint({
     label: "codex",
     requestTimeout,
@@ -232,16 +253,16 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
 
     // Unix: wait for graceful exit, then escalate — group signals, so
     // grandchildren (wrapper scripts, mid-turn shell commands) die with
-    // the app-server instead of being orphaned. Even after a graceful
-    // exit, sweep the process group: a server that exits on stdin EOF can
-    // still leave a spawned command running, and the group id stays
-    // reserved while any member is alive (ESRCH on an empty group is
-    // swallowed by killTree).
-    if (await waitForExit(5000)) { killTree("SIGTERM"); return; }
+    // the app-server instead of being orphaned. Every exit path ends with
+    // a group sweep: the leader dying says nothing about descendants (a
+    // server exiting on stdin EOF can leave a spawned command running,
+    // and a straggler can ignore the group SIGTERM).
+    if (await waitForExit(5000)) { await sweepGroup(); return; }
     killTree("SIGTERM");
-    if (await waitForExit(3000)) return;
+    if (await waitForExit(3000)) { await sweepGroup(); return; }
     killTree("SIGKILL");
     await procGone;
+    await sweepGroup();
   }
 
   // --- Perform initialize handshake ---

--- a/src/commands/follow.test.ts
+++ b/src/commands/follow.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import { pickDefaultRun, nextUnseenRun } from "./follow";
-import { createRun } from "../threads";
+import { createRun, mutateThreadIndex } from "../threads";
 import type { RunRecord, RunStatus } from "../types";
 
 const tmpRoot = join(process.env.TMPDIR ?? "/tmp", "follow-test-" + process.pid);
@@ -14,6 +14,15 @@ function freshDirs(name: string): { stateDir: string; pidsDir: string } {
   const pidsDir = join(stateDir, "pids");
   mkdirSync(pidsDir, { recursive: true });
   return { stateDir, pidsDir };
+}
+
+/** createRun + a matching thread-index entry — the bare-follow pickers skip
+ *  runs whose thread is missing from the index (orphan protection). */
+function createIndexedRun(stateDir: string, rec: RunRecord): void {
+  createRun(stateDir, rec);
+  mutateThreadIndex(stateDir, (index) => {
+    index[rec.shortId] = { threadId: rec.threadId, createdAt: rec.startedAt };
+  });
 }
 
 function record(runId: string, shortId: string, status: RunStatus, startedAt: string): RunRecord {
@@ -29,8 +38,8 @@ function record(runId: string, shortId: string, status: RunStatus, startedAt: st
 describe("pickDefaultRun", () => {
   test("prefers the newest running run with a live process", () => {
     const { stateDir, pidsDir } = freshDirs("live-run");
-    createRun(stateDir, record("r-old", "aaaa0001", "completed", "2026-07-02T10:00:00.000Z"));
-    createRun(stateDir, record("r-live", "aaaa0002", "running", "2026-07-02T09:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-old", "aaaa0001", "completed", "2026-07-02T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-live", "aaaa0002", "running", "2026-07-02T09:00:00.000Z"));
     // Live PID for the running one (this test process)
     writeFileSync(join(pidsDir, "aaaa0002"), String(process.pid));
 
@@ -40,8 +49,8 @@ describe("pickDefaultRun", () => {
 
   test("skips a stale running record whose process is dead", () => {
     const { stateDir, pidsDir } = freshDirs("stale-run");
-    createRun(stateDir, record("r-stale", "bbbb0001", "running", "2026-07-02T11:00:00.000Z"));
-    createRun(stateDir, record("r-done", "bbbb0002", "completed", "2026-07-02T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-stale", "bbbb0001", "running", "2026-07-02T11:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-done", "bbbb0002", "completed", "2026-07-02T10:00:00.000Z"));
     // Dead PID for the "running" record (bun test never has PID ~2^22-ish reserved)
     writeFileSync(join(pidsDir, "bbbb0001"), "99999999");
 
@@ -52,8 +61,8 @@ describe("pickDefaultRun", () => {
 
   test("falls back to the newest run when nothing is running", () => {
     const { stateDir, pidsDir } = freshDirs("replay");
-    createRun(stateDir, record("r-1", "cccc0001", "completed", "2026-07-02T10:00:00.000Z"));
-    createRun(stateDir, record("r-2", "cccc0002", "failed", "2026-07-02T11:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-1", "cccc0001", "completed", "2026-07-02T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-2", "cccc0002", "failed", "2026-07-02T11:00:00.000Z"));
 
     expect(pickDefaultRun(stateDir, pidsDir)?.runId).toBe("r-2");
   });
@@ -67,9 +76,9 @@ describe("pickDefaultRun", () => {
 describe("nextUnseenRun (watch mode)", () => {
   test("returns unseen runs oldest-first so none are skipped under concurrency", () => {
     const { stateDir } = freshDirs("watch-order");
-    createRun(stateDir, record("r-1", "dddd0001", "completed", "2026-07-02T10:00:00.000Z"));
-    createRun(stateDir, record("r-2", "dddd0002", "completed", "2026-07-02T11:00:00.000Z"));
-    createRun(stateDir, record("r-3", "dddd0003", "running", "2026-07-02T12:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-1", "dddd0001", "completed", "2026-07-02T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-2", "dddd0002", "completed", "2026-07-02T11:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-3", "dddd0003", "running", "2026-07-02T12:00:00.000Z"));
 
     const seen = new Set<string>();
     // Two runs finished while we were attached elsewhere: both must surface,
@@ -85,8 +94,8 @@ describe("nextUnseenRun (watch mode)", () => {
 
   test("scoped watch only surfaces runs of that thread", () => {
     const { stateDir } = freshDirs("watch-scoped");
-    createRun(stateDir, record("r-mine", "eeee0001", "completed", "2026-07-02T10:00:00.000Z"));
-    createRun(stateDir, record("r-other", "eeee0002", "running", "2026-07-02T11:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-mine", "eeee0001", "completed", "2026-07-02T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-other", "eeee0002", "running", "2026-07-02T11:00:00.000Z"));
 
     const seen = new Set<string>();
     expect(nextUnseenRun(stateDir, seen, "eeee0001")?.runId).toBe("r-mine");
@@ -146,10 +155,10 @@ describe("replayBound: zero-byte runs (equal logOffset)", () => {
 describe("seedSeenRuns (watch startup)", () => {
   test("history is seeded; live concurrent runs stay unseen", () => {
     const { stateDir, pidsDir } = freshDirs("seed-seen");
-    createRun(stateDir, record("r-old", "1111aaaa", "completed", "2026-07-03T09:00:00.000Z"));
-    createRun(stateDir, record("r-picked", "2222aaaa", "running", "2026-07-03T10:00:00.000Z"));
-    createRun(stateDir, record("r-live2", "3333aaaa", "running", "2026-07-03T10:00:01.000Z"));
-    createRun(stateDir, record("r-stale", "4444aaaa", "running", "2026-07-03T10:00:02.000Z"));
+    createIndexedRun(stateDir, record("r-old", "1111aaaa", "completed", "2026-07-03T09:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-picked", "2222aaaa", "running", "2026-07-03T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-live2", "3333aaaa", "running", "2026-07-03T10:00:01.000Z"));
+    createIndexedRun(stateDir, record("r-stale", "4444aaaa", "running", "2026-07-03T10:00:02.000Z"));
     // r-picked and r-live2 have live runners; r-stale's is dead
     writeFileSync(join(pidsDir, "2222aaaa"), String(process.pid));
     writeFileSync(join(pidsDir, "3333aaaa"), String(process.pid));
@@ -168,9 +177,9 @@ describe("seedSeenRuns (watch startup)", () => {
 describe("pickWatchStartRun (start order with multiple live runs)", () => {
   test("picks the OLDEST live run so a blocked older run isn't hidden", () => {
     const { stateDir, pidsDir } = freshDirs("watch-start-order");
-    createRun(stateDir, record("r-done", "5555bbbb", "completed", "2026-07-03T08:00:00.000Z"));
-    createRun(stateDir, record("r-live-old", "6666bbbb", "running", "2026-07-03T09:00:00.000Z"));
-    createRun(stateDir, record("r-live-new", "7777bbbb", "running", "2026-07-03T10:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-done", "5555bbbb", "completed", "2026-07-03T08:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-live-old", "6666bbbb", "running", "2026-07-03T09:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-live-new", "7777bbbb", "running", "2026-07-03T10:00:00.000Z"));
     writeFileSync(join(pidsDir, "6666bbbb"), String(process.pid));
     writeFileSync(join(pidsDir, "7777bbbb"), String(process.pid));
 
@@ -180,8 +189,8 @@ describe("pickWatchStartRun (start order with multiple live runs)", () => {
 
   test("falls back to newest run overall when nothing is live", () => {
     const { stateDir, pidsDir } = freshDirs("watch-start-replay");
-    createRun(stateDir, record("r-1", "8888bbbb", "completed", "2026-07-03T08:00:00.000Z"));
-    createRun(stateDir, record("r-2", "9999bbbb", "failed", "2026-07-03T09:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-1", "8888bbbb", "completed", "2026-07-03T08:00:00.000Z"));
+    createIndexedRun(stateDir, record("r-2", "9999bbbb", "failed", "2026-07-03T09:00:00.000Z"));
 
     const { pickWatchStartRun } = require("./follow") as typeof import("./follow");
     expect(pickWatchStartRun(stateDir, pidsDir)?.runId).toBe("r-2");
@@ -202,9 +211,9 @@ describe("orphaned run records (deleted threads)", () => {
     createRun(stateDir, record("r-orphan", "gone2222", "running", "2026-07-03T10:00:00.000Z"));
 
     const { pickDefaultRun, pickWatchStartRun, nextUnseenRun } = require("./follow") as typeof import("./follow");
-    expect(pickDefaultRun(stateDir, pidsDir, threadsFile)?.runId).toBe("r-kept");
-    expect(pickWatchStartRun(stateDir, pidsDir, threadsFile)?.runId).toBe("r-kept");
-    expect(nextUnseenRun(stateDir, new Set(), null, threadsFile)?.runId).toBe("r-kept");
+    expect(pickDefaultRun(stateDir, pidsDir)?.runId).toBe("r-kept");
+    expect(pickWatchStartRun(stateDir, pidsDir)?.runId).toBe("r-kept");
+    expect(nextUnseenRun(stateDir, new Set(), null)?.runId).toBe("r-kept");
   });
 });
 

--- a/src/commands/follow.ts
+++ b/src/commands/follow.ts
@@ -12,11 +12,11 @@
 
 import { openSync, readSync, closeSync, fstatSync } from "fs";
 import {
-  legacyFindShortId as findShortId,
+  findShortId,
   listRuns,
   listRunsForThread,
   loadRun,
-  loadThreadMapping,
+  loadThreadIndex,
 } from "../threads";
 import { resolveReadableLogPath } from "./threads";
 import { LogEntryParser, renderEntry, renderFinalStatus, type RenderOptions } from "../render";
@@ -94,11 +94,10 @@ export function runIsLive(run: RunRecord, pidsDir: string): boolean {
  * thread with no mapping, no log, and no PID file — a stale `running` orphan
  * reads as alive (missing PID file = alive) and would hang the tail forever.
  */
-function candidateRuns(stateDir: string, threadsFile: string | undefined): RunRecord[] {
+function candidateRuns(stateDir: string): RunRecord[] {
   const runs = listRuns(stateDir); // newest first
-  if (!threadsFile) return runs;
-  const mapping = loadThreadMapping(threadsFile);
-  return runs.filter(r => Object.hasOwn(mapping, r.shortId));
+  const index = loadThreadIndex(stateDir);
+  return runs.filter(r => Object.hasOwn(index, r.shortId));
 }
 
 /**
@@ -107,8 +106,8 @@ function candidateRuns(stateDir: string, threadsFile: string | undefined): RunRe
  * record from a crash shouldn't shadow real work), else the newest run
  * overall (replay). Exported for tests.
  */
-export function pickDefaultRun(stateDir: string, pidsDir: string, threadsFile?: string): RunRecord | null {
-  const runs = candidateRuns(stateDir, threadsFile);
+export function pickDefaultRun(stateDir: string, pidsDir: string): RunRecord | null {
+  const runs = candidateRuns(stateDir);
   const live = runs.find(r => r.status === "running" && runIsLive(r, pidsDir));
   return live ?? runs[0] ?? null;
 }
@@ -120,8 +119,8 @@ export function pickDefaultRun(stateDir: string, pidsDir: string, threadsFile?: 
  * newer one finished. Falls back to the newest run overall for a replay.
  * Exported for tests.
  */
-export function pickWatchStartRun(stateDir: string, pidsDir: string, threadsFile?: string): RunRecord | null {
-  const runs = candidateRuns(stateDir, threadsFile);
+export function pickWatchStartRun(stateDir: string, pidsDir: string): RunRecord | null {
+  const runs = candidateRuns(stateDir);
   for (let i = runs.length - 1; i >= 0; i--) {
     if (runs[i].status === "running" && runIsLive(runs[i], pidsDir)) {
       return runs[i];
@@ -193,11 +192,10 @@ export function nextUnseenRun(
   stateDir: string,
   seen: ReadonlySet<string>,
   scopedShortId: string | null,
-  threadsFile?: string,
 ): RunRecord | null {
   const runs = scopedShortId
     ? listRunsForThread(stateDir, scopedShortId)
-    : candidateRuns(stateDir, threadsFile);
+    : candidateRuns(stateDir);
   for (let i = runs.length - 1; i >= 0; i--) {
     if (!seen.has(runs[i].runId)) return runs[i]; // newest-first list → walk backwards
   }
@@ -332,14 +330,14 @@ export async function handleFollow(args: string[]): Promise<void> {
     // Watch mode displays runs in start order, so it starts from the OLDEST
     // live run; a one-shot follow attaches to the newest (most relevant) one.
     run = options.watch
-      ? pickWatchStartRun(ws.stateDir, ws.pidsDir, ws.threadsFile)
-      : pickDefaultRun(ws.stateDir, ws.pidsDir, ws.threadsFile);
+      ? pickWatchStartRun(ws.stateDir, ws.pidsDir)
+      : pickDefaultRun(ws.stateDir, ws.pidsDir);
     if (!run && !options.watch) {
       die("No runs in this workspace yet.\nUsage: codex-collab follow [id] [--watch]");
     }
   } else {
-    const threadId = resolveThreadIdOrDie(ws.threadsFile, positional[0]);
-    scopedShortId = findShortId(ws.threadsFile, threadId) ?? positional[0];
+    const threadId = resolveThreadIdOrDie(ws.stateDir, positional[0]);
+    scopedShortId = findShortId(ws.stateDir, threadId) ?? positional[0];
     // Live-first, like the bare path: a newer terminal record must not
     // shadow an older run that is still active on this thread.
     run = pickThreadRun(ws.stateDir, ws.pidsDir, scopedShortId, options.watch);
@@ -368,7 +366,7 @@ export async function handleFollow(args: string[]): Promise<void> {
       console.log("");
       hadRun = true;
     }
-    run = nextUnseenRun(ws.stateDir, seen, scopedShortId, ws.threadsFile);
+    run = nextUnseenRun(ws.stateDir, seen, scopedShortId);
     if (!run) {
       console.log(renderDim(
         hadRun ? "⏳ waiting for the next run… (Ctrl-C to stop)" : "⏳ waiting for the first run… (Ctrl-C to stop)",
@@ -376,7 +374,7 @@ export async function handleFollow(args: string[]): Promise<void> {
       ));
       do {
         await sleep(POLL_INTERVAL_MS);
-        run = nextUnseenRun(ws.stateDir, seen, scopedShortId, ws.threadsFile);
+        run = nextUnseenRun(ws.stateDir, seen, scopedShortId);
       } while (!run);
     }
   }

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -1,17 +1,13 @@
 // src/commands/kill.ts — kill command handler
 
-import {
-  findShortId,
-  loadThreadIndex,
-  updateThreadStatus,
-} from "../threads";
+import { loadThreadIndex, updateThreadStatus } from "../threads";
 import { writeFileSync } from "fs";
 import { join } from "path";
 import {
   die,
   parseOptions,
   validateIdOrDie,
-  resolveThreadIdOrDie,
+  resolveThreadIdAllowRaw,
   progress,
   withClient,
   readPidFile,
@@ -26,8 +22,7 @@ export async function handleKill(args: string[]): Promise<void> {
   if (!id) die("Usage: codex-collab kill <id>");
   validateIdOrDie(id);
 
-  const threadId = resolveThreadIdOrDie(ws.stateDir, id);
-  const shortId = findShortId(ws.stateDir, threadId);
+  const { threadId, shortId } = resolveThreadIdAllowRaw(ws.stateDir, id);
 
   // Skip kill for threads that have already reached a terminal status
   if (shortId) {
@@ -97,8 +92,10 @@ export async function handleKill(args: string[]): Promise<void> {
   }
 
   if (killSignalWritten || serverInterrupted) {
-    updateThreadStatus(ws.stateDir, threadId, "interrupted");
-    if (shortId) removePidFile(ws.pidsDir, shortId);
+    if (shortId) {
+      updateThreadStatus(ws.stateDir, threadId, "interrupted");
+      removePidFile(ws.pidsDir, shortId);
+    }
     progress(`Stopped thread ${id}`);
   } else {
     progress(`Could not signal thread ${id} — try again.`);

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -1,8 +1,8 @@
 // src/commands/kill.ts — kill command handler
 
 import {
-  legacyFindShortId as findShortId,
-  loadThreadMapping,
+  findShortId,
+  loadThreadIndex,
   updateThreadStatus,
 } from "../threads";
 import { writeFileSync } from "fs";
@@ -26,13 +26,13 @@ export async function handleKill(args: string[]): Promise<void> {
   if (!id) die("Usage: codex-collab kill <id>");
   validateIdOrDie(id);
 
-  const threadId = resolveThreadIdOrDie(ws.threadsFile, id);
-  const shortId = findShortId(ws.threadsFile, threadId);
+  const threadId = resolveThreadIdOrDie(ws.stateDir, id);
+  const shortId = findShortId(ws.stateDir, threadId);
 
   // Skip kill for threads that have already reached a terminal status
   if (shortId) {
-    const mapping = loadThreadMapping(ws.threadsFile);
-    const localStatus = mapping[shortId]?.lastStatus;
+    const index = loadThreadIndex(ws.stateDir);
+    const localStatus = index[shortId]?.lastStatus;
     if (localStatus && localStatus !== "running") {
       progress(`Thread ${id} is already ${localStatus}`);
       return;
@@ -97,7 +97,7 @@ export async function handleKill(args: string[]): Promise<void> {
   }
 
   if (killSignalWritten || serverInterrupted) {
-    updateThreadStatus(ws.threadsFile, threadId, "interrupted");
+    updateThreadStatus(ws.stateDir, threadId, "interrupted");
     if (shortId) removePidFile(ws.pidsDir, shortId);
     progress(`Stopped thread ${id}`);
   } else {

--- a/src/commands/peek.ts
+++ b/src/commands/peek.ts
@@ -1,10 +1,7 @@
 // src/commands/peek.ts — peek command and pure formatting helpers.
 
 import type { Turn, ThreadItem, Thread, UserMessageItem, AgentMessageItem } from "../types";
-import {
-  legacyResolveThreadId as resolveThreadId,
-  legacyFindShortId as findShortId,
-} from "../threads";
+import { resolveThreadId } from "../threads";
 import {
   die,
   parseOptions,
@@ -162,13 +159,11 @@ export async function handlePeek(args: string[]): Promise<void> {
   let threadId: string;
   let shortId: string | null;
   try {
-    threadId = resolveThreadId(ws.threadsFile, id);
-    shortId = findShortId(ws.threadsFile, threadId);
+    const resolved = resolveThreadId(ws.stateDir, id);
+    threadId = resolved?.threadId ?? id;
+    shortId = resolved?.shortId ?? null;
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (!msg.startsWith("Thread not found")) die(msg);
-    threadId = id;
-    shortId = null;
+    die(e instanceof Error ? e.message : String(e));
   }
 
   const limit = options.explicit.has("limit") ? options.limit : DEFAULT_PEEK_LIMIT;

--- a/src/commands/peek.ts
+++ b/src/commands/peek.ts
@@ -1,11 +1,12 @@
 // src/commands/peek.ts — peek command and pure formatting helpers.
 
 import type { Turn, ThreadItem, Thread, UserMessageItem, AgentMessageItem } from "../types";
-import { resolveThreadId } from "../threads";
+
 import {
   die,
   parseOptions,
   validateIdOrDie,
+  resolveThreadIdAllowRaw,
   withClient,
   getWorkspacePaths,
 } from "./shared";
@@ -156,15 +157,7 @@ export async function handlePeek(args: string[]): Promise<void> {
   // Try local index first; if not found, treat the input as a raw thread ID
   // and let the server validate it. Surface ambiguous-prefix errors immediately
   // — only "Thread not found" should fall through to the server.
-  let threadId: string;
-  let shortId: string | null;
-  try {
-    const resolved = resolveThreadId(ws.stateDir, id);
-    threadId = resolved?.threadId ?? id;
-    shortId = resolved?.shortId ?? null;
-  } catch (e) {
-    die(e instanceof Error ? e.message : String(e));
-  }
+  const { threadId, shortId } = resolveThreadIdAllowRaw(ws.stateDir, id);
 
   const limit = options.explicit.has("limit") ? options.limit : DEFAULT_PEEK_LIMIT;
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -93,7 +93,7 @@ export async function handleReview(args: string[]): Promise<void> {
       }
     }
 
-    updateThreadStatus(ws.threadsFile, threadId, "running");
+    updateThreadStatus(ws.stateDir, threadId, "running");
     setActiveThreadId(threadId);
     setActiveShortId(shortId);
     setActiveWsPaths(ws);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -144,7 +144,7 @@ async function detachRun(
         progress(`  Output:   codex-collab output ${rec.shortId}`);
         process.exit(0);
       }
-      if (rec.status === "cancelled") {
+      if (rec.status === "interrupted") {
         dieWithRunnerOutput(`Detached run was interrupted before the turn started (thread ${rec.shortId}).`);
       }
       // A `failed` record is only definitive once the child has exited:

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -241,7 +241,7 @@ export async function handleRun(args: string[]): Promise<void> {
       progress("Turn started");
     }
 
-    updateThreadStatus(ws.threadsFile, threadId, "running");
+    updateThreadStatus(ws.stateDir, threadId, "running");
     setActiveThreadId(threadId);
     setActiveShortId(shortId);
     setActiveWsPaths(ws);

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -1671,10 +1671,10 @@ let callNo = 0;
 
 function ws(name: string) {
   const stateDir = join(${JSON.stringify(stateRoot)}, name);
-  const w = { stateDir, threadsFile: join(stateDir, "threads.json"), logsDir: join(stateDir, "logs"),
+  const w = { stateDir, logsDir: join(stateDir, "logs"),
     approvalsDir: join(stateDir, "approvals"), killSignalsDir: join(stateDir, "kill-signals"),
     pidsDir: join(stateDir, "pids"), runsDir: join(stateDir, "runs") };
-  for (const d of Object.values(w)) if (d !== w.threadsFile) mkdirSync(d, { recursive: true });
+  for (const d of Object.values(w)) mkdirSync(d, { recursive: true });
   return w;
 }
 

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -39,7 +39,6 @@ function freshWorkspace(name: string): WorkspacePaths {
   const stateDir = freshTmpDir(name);
   const ws = {
     stateDir,
-    threadsFile: join(stateDir, "threads.json"),
     logsDir: join(stateDir, "logs"),
     approvalsDir: join(stateDir, "approvals"),
     killSignalsDir: join(stateDir, "kill-signals"),

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -13,10 +13,10 @@ import {
 import { type AppServerClient, connectDirect } from "../client";
 import { ensureConnection, getCurrentSessionId, isBrokerBusyError } from "../broker";
 import {
-  legacyRegisterThread as registerThread,
-  legacyResolveThreadId as resolveThreadId,
-  legacyFindShortId as findShortId,
-  legacyUpdateThreadMeta as updateThreadMeta,
+  registerThread,
+  resolveThreadId,
+  findShortId,
+  updateThreadMeta,
   updateThreadStatus,
   generateRunId,
   createRun,
@@ -57,7 +57,6 @@ import type {
 
 export interface WorkspacePaths {
   stateDir: string;
-  threadsFile: string;
   logsDir: string;
   approvalsDir: string;
   killSignalsDir: string;
@@ -69,7 +68,6 @@ export function getWorkspacePaths(cwd: string): WorkspacePaths {
   const stateDir = resolveStateDir(cwd);
   const paths = {
     stateDir,
-    threadsFile: join(stateDir, "threads.json"),
     logsDir: join(stateDir, "logs"),
     approvalsDir: join(stateDir, "approvals"),
     killSignalsDir: join(stateDir, "kill-signals"),
@@ -209,9 +207,11 @@ export function validateIdOrDie(id: string): string {
 /** Resolve a user-supplied thread ID or exit with a friendly error.
  *  "Thread not found" and "Ambiguous prefix" are user mistakes and should
  *  print as `Error: …`, not escape to main()'s `Fatal: …` handler. */
-export function resolveThreadIdOrDie(threadsFile: string, id: string): string {
+export function resolveThreadIdOrDie(stateDir: string, id: string): string {
   try {
-    return resolveThreadId(threadsFile, id);
+    const resolved = resolveThreadId(stateDir, id);
+    if (!resolved) die(`Thread not found: "${id}"`);
+    return resolved.threadId;
   } catch (e) {
     die(e instanceof Error ? e.message : String(e));
   }
@@ -798,19 +798,15 @@ export async function startOrResumeThread(
 
   if (opts.resumeId) {
     // Try local resolution first; if not found, treat the ID as a full thread ID
-    // and pass it directly to the server (handles TUI-created threads not yet discovered)
-    try {
-      threadId = resolveThreadId(ws.threadsFile, opts.resumeId);
-    } catch (e) {
-      // Only "not found" falls through to the raw-ID path. Everything else
-      // must surface: ambiguity so the user can disambiguate, and index
-      // corruption because bailOnCorruptThreads has just renamed the index
-      // aside and its message explains how to recover — swallowing it here
-      // used to replace that with a baffling server-side "thread not found".
-      if (!(e instanceof Error && e.message.startsWith("Thread not found"))) {
-        throw e;
-      }
-      // Thread not found locally — treat as raw server thread ID
+    // and pass it directly to the server (handles TUI-created threads not yet
+    // discovered). Ambiguity and index corruption still throw and must surface:
+    // ambiguity so the user can disambiguate, corruption because
+    // bailOnCorruptThreads has just renamed the index aside and its message
+    // explains how to recover.
+    const resolved = resolveThreadId(ws.stateDir, opts.resumeId);
+    if (resolved) {
+      threadId = resolved.threadId;
+    } else {
       validateId(opts.resumeId);
       threadId = opts.resumeId;
     }
@@ -830,17 +826,14 @@ export async function startOrResumeThread(
       Object.assign(forkParams, extraStartParams ?? {});
       effective = await client.request<ThreadStartResponse>("thread/fork", forkParams);
       threadId = effective.thread.id;
-      registerThread(ws.threadsFile, threadId, {
+      shortId = registerThread(ws.stateDir, threadId, {
         model: effective.model,
         cwd: effective.cwd ?? opts.dir,
         preview,
       });
-      const resolvedShortId = findShortId(ws.threadsFile, threadId);
-      if (!resolvedShortId) die(`Internal error: forked review thread ${threadId.slice(0, 12)}... registered but not found in mapping`);
-      shortId = resolvedShortId;
       isNewThread = true;
     } else {
-      shortId = findShortId(ws.threadsFile, threadId) ?? opts.resumeId;
+      shortId = findShortId(ws.stateDir, threadId) ?? opts.resumeId;
       const resumeParams: Record<string, unknown> = {
         threadId,
         persistExtendedHistory: false,
@@ -854,16 +847,15 @@ export async function startOrResumeThread(
       if (extraStartParams) Object.assign(resumeParams, extraStartParams);
       effective = await client.request<ThreadStartResponse>("thread/resume", resumeParams);
       // Ensure the thread is in our local index (may not be if it was created externally)
-      if (!findShortId(ws.threadsFile, threadId)) {
-        registerThread(ws.threadsFile, threadId, {
+      if (!findShortId(ws.stateDir, threadId)) {
+        shortId = registerThread(ws.stateDir, threadId, {
           model: effective.model,
           cwd: opts.dir,
           preview,
         });
-        shortId = findShortId(ws.threadsFile, threadId) ?? shortId;
       } else {
         // Refresh stored metadata so `threads` stays accurate after resume
-        updateThreadMeta(ws.threadsFile, threadId, {
+        updateThreadMeta(ws.stateDir, threadId, {
           model: effective.model,
           ...(opts.explicit.has("dir") ? { cwd: opts.dir } : {}),
           ...(preview ? { preview } : {}),
@@ -887,14 +879,11 @@ export async function startOrResumeThread(
       startParams,
     );
     threadId = effective.thread.id;
-    registerThread(ws.threadsFile, threadId, {
+    shortId = registerThread(ws.stateDir, threadId, {
       model: effective.model,
       cwd: opts.dir,
       preview,
     });
-    const resolvedShortId = findShortId(ws.threadsFile, threadId);
-    if (!resolvedShortId) die(`Internal error: thread ${threadId.slice(0, 12)}... registered but not found in mapping`);
-    shortId = resolvedShortId;
     isNewThread = true;
   }
 
@@ -1094,7 +1083,7 @@ export function recordTerminalRunState(
   // on approval" case, and gets its own exit code.
   const hadPendingApproval = hasPendingApproval(ws.stateDir, runId);
   try {
-    updateThreadStatus(ws.threadsFile, threadId, result.status as "completed" | "failed" | "interrupted");
+    updateThreadStatus(ws.stateDir, threadId, result.status as "completed" | "failed" | "interrupted");
   } catch (e) {
     console.error(`[codex] Warning: could not update thread status for ${threadId}: ${e instanceof Error ? e.message : String(e)}`);
   }
@@ -1146,7 +1135,7 @@ export function recordRunFailure(
   error: unknown,
 ): void {
   try {
-    updateThreadStatus(ws.threadsFile, threadId, "failed");
+    updateThreadStatus(ws.stateDir, threadId, "failed");
   } catch (e) {
     console.error(`[codex] Warning: could not update thread status for ${threadId}: ${e instanceof Error ? e.message : String(e)}`);
   }

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1090,7 +1090,7 @@ export function recordTerminalRunState(
   let stateSaveFailed = false;
   try {
     updateRun(ws.stateDir, runId, {
-      status: result.status === "completed" ? "completed" : result.status === "interrupted" ? "cancelled" : "failed",
+      status: result.status,
       phase: "finalizing",
       completedAt: new Date().toISOString(),
       elapsed: formatDuration(result.durationMs),

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -217,6 +217,25 @@ export function resolveThreadIdOrDie(stateDir: string, id: string): string {
   }
 }
 
+/** Like resolveThreadIdOrDie, but an ID missing from the local index is
+ *  treated as a raw server thread ID (shortId: null) instead of an error —
+ *  peek, run --resume, kill, and delete all accept threads created by the
+ *  Codex TUI or another workspace that were never discovered locally.
+ *  Ambiguous prefixes and index corruption still die. Callers must
+ *  validateIdOrDie(id) first. */
+export function resolveThreadIdAllowRaw(
+  stateDir: string,
+  id: string,
+): { threadId: string; shortId: string | null } {
+  try {
+    const resolved = resolveThreadId(stateDir, id);
+    if (resolved) return resolved;
+  } catch (e) {
+    die(e instanceof Error ? e.message : String(e));
+  }
+  return { threadId: id, shortId: null };
+}
+
 export function progress(text: string): void {
   console.log(`[codex] ${text}`);
 }

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -29,6 +29,7 @@ import {
   parseOptions,
   validateIdOrDie,
   resolveThreadIdOrDie,
+  resolveThreadIdAllowRaw,
   progress,
   formatAge,
   isThreadProcessAlive,
@@ -381,8 +382,7 @@ export async function handleDelete(args: string[]): Promise<void> {
   if (!id) die("Usage: codex-collab delete <id>");
   validateIdOrDie(id);
 
-  const threadId = resolveThreadIdOrDie(ws.stateDir, id);
-  const shortId = findShortId(ws.stateDir, threadId);
+  const { threadId, shortId } = resolveThreadIdAllowRaw(ws.stateDir, id);
 
   // If the thread is currently running, stop it first before archiving
   const localStatus = shortId ? loadThreadIndex(ws.stateDir)[shortId]?.lastStatus : undefined;

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -1,12 +1,11 @@
 // src/commands/threads.ts — threads, output, progress, delete, clean commands
 
 import {
-  legacyRegisterThread as registerThread,
-  legacyFindShortId as findShortId,
-  legacyRemoveThread as removeThread,
-  loadThreadMapping,
-  saveThreadMapping,
-  withThreadLock,
+  registerThread,
+  findShortId,
+  removeThread,
+  loadThreadIndex,
+  mutateThreadIndex,
   removeLegacyGlobalThread,
   getLatestRun,
   removeRunsForThread,
@@ -81,7 +80,7 @@ async function discoverThreads(client: AppServerClient, ws: WorkspacePaths, cwd:
   });
   if (serverThreads.length === 0) return 0;
 
-  const mapping = loadThreadMapping(ws.threadsFile);
+  const mapping = loadThreadIndex(ws.stateDir);
   const knownThreadIds = new Set(Object.values(mapping).map(e => e.threadId));
   let discovered = 0;
 
@@ -93,7 +92,7 @@ async function discoverThreads(client: AppServerClient, ws: WorkspacePaths, cwd:
     // thread/list exposes only the provider ("openai"), not a model name —
     // storing it as `model` made discovered threads display a provider where
     // local threads show a model. Leave model unset instead.
-    registerThread(ws.threadsFile, thread.id, {
+    registerThread(ws.stateDir, thread.id, {
       cwd: thread.cwd ?? cwd,
       preview: thread.preview ?? thread.name ?? undefined,
       createdAt,
@@ -128,7 +127,7 @@ export async function handleThreads(args: string[]): Promise<void> {
     }
   }
 
-  const mapping = loadThreadMapping(ws.threadsFile);
+  const mapping = loadThreadIndex(ws.stateDir);
 
   // Build entries sorted by updatedAt (most recent first), falling back to createdAt
   let entries = Object.entries(mapping)
@@ -146,8 +145,7 @@ export async function handleThreads(args: string[]): Promise<void> {
     (e) => e.lastStatus === "running" && !isThreadProcessAlive(ws.pidsDir, e.shortId),
   );
   if (stale.length > 0) {
-    withThreadLock(ws.threadsFile, () => {
-      const fresh = loadThreadMapping(ws.threadsFile);
+    mutateThreadIndex(ws.stateDir, (fresh) => {
       const now = new Date().toISOString();
       for (const e of stale) {
         const entry = fresh[e.shortId];
@@ -156,7 +154,6 @@ export async function handleThreads(args: string[]): Promise<void> {
           entry.updatedAt = now;
         }
       }
-      saveThreadMapping(ws.threadsFile, fresh);
     });
     for (const e of stale) {
       e.lastStatus = "interrupted";
@@ -261,8 +258,8 @@ function resolveLogPath(
   const id = positional[0];
   if (!id) die(usage);
   validateIdOrDie(id);
-  const threadId = resolveThreadIdOrDie(ws.threadsFile, id);
-  const shortId = findShortId(ws.threadsFile, threadId);
+  const threadId = resolveThreadIdOrDie(ws.stateDir, id);
+  const shortId = findShortId(ws.stateDir, threadId);
   if (!shortId) die(`Thread not found: ${id}`);
   return { logPath: resolveReadableLogPath(ws.stateDir, ws.logsDir, shortId), shortId };
 }
@@ -384,11 +381,11 @@ export async function handleDelete(args: string[]): Promise<void> {
   if (!id) die("Usage: codex-collab delete <id>");
   validateIdOrDie(id);
 
-  const threadId = resolveThreadIdOrDie(ws.threadsFile, id);
-  const shortId = findShortId(ws.threadsFile, threadId);
+  const threadId = resolveThreadIdOrDie(ws.stateDir, id);
+  const shortId = findShortId(ws.stateDir, threadId);
 
   // If the thread is currently running, stop it first before archiving
-  const localStatus = shortId ? loadThreadMapping(ws.threadsFile)[shortId]?.lastStatus : undefined;
+  const localStatus = shortId ? loadThreadIndex(ws.stateDir)[shortId]?.lastStatus : undefined;
   if (localStatus === "running") {
     const signalPath = join(ws.killSignalsDir, threadId);
     try {
@@ -456,7 +453,7 @@ export async function handleDelete(args: string[]): Promise<void> {
     removePidFile(ws.pidsDir, shortId);
     const logPath = join(ws.logsDir, `${shortId}.log`);
     if (existsSync(logPath)) unlinkSync(logPath);
-    removeThread(ws.threadsFile, shortId);
+    removeThread(ws.stateDir, shortId);
     // Run records must go with the thread: a stale `running` record whose
     // PID file is gone reads as alive and would make bare `follow` hang.
     removeRunsForThread(ws.stateDir, shortId);
@@ -516,8 +513,7 @@ export async function handleClean(args: string[]): Promise<void> {
   // activity so recently-used threads aren't pruned just because they
   // were created more than 7 days ago.
   let mappingsRemoved = 0;
-  withThreadLock(ws.threadsFile, () => {
-    const mapping = loadThreadMapping(ws.threadsFile);
+  mutateThreadIndex(ws.stateDir, (mapping) => {
     const now = Date.now();
     for (const [shortId, entry] of Object.entries(mapping)) {
       try {
@@ -535,9 +531,7 @@ export async function handleClean(args: string[]): Promise<void> {
         console.error(`[codex] Warning: skipping mapping ${shortId}: ${e instanceof Error ? e.message : e}`);
       }
     }
-    if (mappingsRemoved > 0) {
-      saveThreadMapping(ws.threadsFile, mapping);
-    }
+    return mappingsRemoved > 0;
   });
 
   const parts: string[] = [];

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -25,7 +25,6 @@ describe("config object", () => {
   });
 
   test("deprecated paths still work", () => {
-    expect(config.threadsFile).toContain("threads.json");
     expect(config.logsDir).toContain("logs");
     expect(config.approvalsDir).toContain("approvals");
     expect(config.killSignalsDir).toContain("kill-signals");

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,6 @@ export const config = {
   get dataDir() { return join(getHome(), ".codex-collab"); },
 
   /** @deprecated Will be removed when threads module is refactored to use per-workspace state. */
-  get threadsFile() { return join(this.dataDir, "threads.json"); },
   /** @deprecated Will be removed when events module is refactored to use per-workspace state. */
   get logsDir() { return join(this.dataDir, "logs"); },
   /** @deprecated Will be removed when approvals module is refactored to use per-workspace state. */

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -103,7 +103,7 @@ describe("renderFinalStatus", () => {
   test("covers the run-record status vocabulary", () => {
     expect(renderFinalStatus("completed", { elapsed: "14s", filesChanged: 2 }, false))
       .toBe("✔ completed (14s, 2 files changed)");
-    expect(renderFinalStatus("cancelled", { elapsed: "5s" }, false)).toBe("■ interrupted (5s)");
+    expect(renderFinalStatus("interrupted", { elapsed: "5s" }, false)).toBe("■ interrupted (5s)");
     expect(renderFinalStatus("failed", { error: "boom" }, false)).toBe("✖ failed — boom");
     expect(renderFinalStatus("running", {}, false)).toBe("● running");
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -196,7 +196,7 @@ export function renderFinalStatus(
   switch (status) {
     case "completed":
       return style(`✔ completed${suffix}`, [ANSI.bold, ANSI.green], color);
-    case "cancelled":
+    case "interrupted":
       return style(`■ interrupted${suffix}`, [ANSI.bold, ANSI.yellow], color);
     case "failed":
       return style(`✖ failed${suffix}${detail.error ? ` — ${detail.error}` : ""}`, [ANSI.bold, ANSI.red], color);

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,0 +1,407 @@
+// src/rpc.ts — shared JSON-RPC endpoint core
+//
+// One implementation of the wire-level plumbing that client.ts (stdio to the
+// app-server child) and broker-client.ts (socket to the broker) both need:
+// message parsing, pending-request tracking, response/error/server-request/
+// notification dispatch, and the newline-buffered read path. The transports
+// stay in their own files; everything protocol-shaped lives here.
+//
+// Several review-sweep bugs (#10) were drift between the two hand-maintained
+// copies of this logic — that is the reason this module exists.
+
+import type {
+  JsonRpcMessage,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcError,
+  JsonRpcNotification,
+  RequestId,
+} from "./types";
+import { RpcError } from "./types";
+
+export const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
+/** Format a JSON-RPC-style notification (no id, no response). Returns newline-terminated JSON.
+ *  Note: Codex app server protocol omits the standard `jsonrpc: "2.0"` field. */
+export function formatNotification(method: string, params?: unknown): string {
+  const msg: Record<string, unknown> = { method };
+  if (params !== undefined) msg.params = params;
+  return JSON.stringify(msg) + "\n";
+}
+
+/** Format a JSON-RPC response to a server request. Returns newline-terminated JSON. */
+export function formatResponse(id: RequestId, result: unknown): string {
+  return JSON.stringify({ id, result }) + "\n";
+}
+
+/** Parse a JSON-RPC message from a line. Returns null if unparseable or not a valid protocol message. */
+export function parseMessage(line: string): JsonRpcMessage | null {
+  try {
+    const raw = JSON.parse(line);
+    if (typeof raw !== "object" || raw === null) return null;
+
+    const hasMethod = "method" in raw && typeof raw.method === "string";
+    const hasId = "id" in raw && (typeof raw.id === "string" || typeof raw.id === "number");
+    const hasResult = "result" in raw;
+    const hasError = "error" in raw;
+
+    if (!hasMethod && !hasId) {
+      console.error(`[codex] Warning: ignoring non-protocol message: ${line.slice(0, 200)}`);
+      return null;
+    }
+
+    if (hasId && !hasMethod) {
+      if (hasResult === hasError) {
+        console.error(`[codex] Warning: ignoring malformed response: ${line.slice(0, 200)}`);
+        return null;
+      }
+      if (hasError) {
+        const error = (raw as { error?: unknown }).error;
+        if (
+          typeof error !== "object" ||
+          error === null ||
+          typeof (error as { code?: unknown }).code !== "number" ||
+          typeof (error as { message?: unknown }).message !== "string"
+        ) {
+          console.error(`[codex] Warning: ignoring malformed error response: ${line.slice(0, 200)}`);
+          return null;
+        }
+      }
+      return raw as JsonRpcMessage;
+    }
+
+    if (hasMethod && hasId && (hasResult || hasError)) {
+      console.error(`[codex] Warning: ignoring malformed request/response hybrid: ${line.slice(0, 200)}`);
+      return null;
+    }
+
+    if (hasMethod && !hasId && (hasResult || hasError)) {
+      console.error(`[codex] Warning: ignoring malformed notification/response hybrid: ${line.slice(0, 200)}`);
+      return null;
+    }
+
+    return raw as JsonRpcMessage;
+  } catch {
+    console.error(`[codex] Warning: unparseable message from app server: ${line.slice(0, 200)}`);
+    return null;
+  }
+}
+
+/** Type guard: message is a response (has id + result). */
+export function isResponse(msg: JsonRpcMessage): msg is JsonRpcResponse {
+  return "id" in msg && "result" in msg && !("method" in msg);
+}
+
+/** Type guard: message is an error response (has id + error). */
+export function isError(msg: JsonRpcMessage): msg is JsonRpcError {
+  return "id" in msg && "error" in msg && !("method" in msg);
+}
+
+/** Type guard: message is a request (has id + method). */
+export function isRequest(msg: JsonRpcMessage): msg is JsonRpcRequest {
+  return "id" in msg && "method" in msg && !("result" in msg) && !("error" in msg);
+}
+
+/** Type guard: message is a notification (has method, no id). */
+export function isNotification(msg: JsonRpcMessage): msg is JsonRpcNotification {
+  return "method" in msg && !("id" in msg);
+}
+
+/** Pending request tracker. */
+export interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Handler for server-sent notifications. */
+export type NotificationHandler = (params: unknown) => void;
+
+/** Handler for any server-sent notification, including the method name. */
+export type AnyNotificationHandler = (method: string, params: unknown) => void;
+
+/** Handler for server-sent requests (e.g. approval requests). Returns the result to send back. */
+export type ServerRequestHandler = (params: unknown) => unknown | Promise<unknown>;
+
+export interface RpcEndpointOptions {
+  /** Log prefix, e.g. "codex" or "broker-client". */
+  label: string;
+  /** Request timeout in ms. */
+  requestTimeout: number;
+  /** Raw transport write. May throw; a throw rejects all pending requests. */
+  send: (data: string) => void;
+  /** Reason the connection can no longer serve requests (process exited,
+   *  socket destroyed), or null while healthy. Consulted before each request
+   *  and when deciding whether a write failure is worth logging. */
+  downReason: () => string | null;
+  /** Rejection reason when the receive buffer exceeds MAX_BUFFER_SIZE. */
+  overflowReason: string;
+  /** Transport teardown after a buffer overflow (pending already rejected). */
+  onOverflow: () => void;
+  /** Prefix for the rejection reason when a transport write throws. */
+  writeFailedPrefix: string;
+}
+
+export interface RpcEndpoint {
+  /** Feed raw incoming bytes; complete lines are parsed and dispatched. */
+  feed(chunk: string): void;
+  /** Send a request and wait for a response. Rejects on timeout, error, or connection loss. */
+  request<T = unknown>(method: string, params?: unknown): Promise<T>;
+  /** Send a notification (fire-and-forget). */
+  notify(method: string, params?: unknown): void;
+  /** Register a handler for server-sent notifications. Returns an unsubscribe function. */
+  on(method: string, handler: NotificationHandler): () => void;
+  /** Register a wildcard handler that fires for every server-sent notification. */
+  onAny(handler: AnyNotificationHandler): () => void;
+  /** Register a handler for server-sent requests. One handler per method;
+   *  new registrations replace previous ones (with a warning). */
+  onRequest(method: string, handler: ServerRequestHandler): () => void;
+  /** Send a response to a server-sent request. */
+  respond(id: RequestId, result: unknown): void;
+  /** Register a callback invoked on unexpected connection loss (fail()).
+   *  Not called after markClosed(). Returns an unsubscribe function. */
+  onClose(handler: () => void): () => void;
+  /** Mark the endpoint intentionally closed: reject pending requests with
+   *  "Client is closed"-style reasons and stop accepting writes. Idempotent. */
+  markClosed(): void;
+  /** Report an unexpected connection loss: reject pending requests with the
+   *  given reason and fire onClose handlers once. No-op after markClosed(). */
+  fail(reason: string): void;
+  /** Reject all pending requests without firing onClose handlers (e.g. a
+   *  read-loop error where the connection may be torn down separately). */
+  rejectAllPending(reason: string): void;
+  /** True after markClosed(). */
+  isClosed(): boolean;
+}
+
+/**
+ * Create a JSON-RPC endpoint over an arbitrary line-oriented transport.
+ * The transport supplies raw writes and liveness; the endpoint owns request
+ * ids, pending tracking, dispatch, and handler registries.
+ */
+export function createRpcEndpoint(opts: RpcEndpointOptions): RpcEndpoint {
+  const { label, requestTimeout } = opts;
+
+  const pending = new Map<RequestId, PendingRequest>();
+  const notificationHandlers = new Map<string, Set<NotificationHandler>>();
+  const anyNotificationHandlers = new Set<AnyNotificationHandler>();
+  const requestHandlers = new Map<string, ServerRequestHandler>();
+  const closeHandlers = new Set<() => void>();
+  let closed = false;
+  let failReason: string | null = null;
+  let nextId = 1;
+  let buffer = "";
+
+  function write(data: string): void {
+    if (closed) return;
+    try {
+      opts.send(data);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (opts.downReason() === null) {
+        console.error(`[${label}] Failed to write: ${msg}`);
+      }
+      rejectAllPending(opts.writeFailedPrefix + msg);
+    }
+  }
+
+  function rejectAllPending(reason: string): void {
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error(reason));
+    }
+    pending.clear();
+  }
+
+  function fail(reason: string): void {
+    if (closed || failReason !== null) return;
+    failReason = reason;
+    rejectAllPending(reason);
+    for (const handler of closeHandlers) {
+      try { handler(); } catch (e) {
+        console.error(`[${label}] Warning: close handler error: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+
+  function dispatch(msg: JsonRpcMessage): void {
+    if (isResponse(msg)) {
+      const entry = pending.get(msg.id);
+      if (entry) {
+        clearTimeout(entry.timer);
+        pending.delete(msg.id);
+        entry.resolve(msg.result);
+      }
+      return;
+    }
+
+    if (isError(msg)) {
+      const entry = pending.get(msg.id);
+      if (entry) {
+        clearTimeout(entry.timer);
+        pending.delete(msg.id);
+        const e = msg.error;
+        entry.reject(new RpcError(
+          `JSON-RPC error ${e.code}: ${e.message}${e.data ? ` (${JSON.stringify(e.data)})` : ""}`,
+          e.code,
+        ));
+      }
+      return;
+    }
+
+    if (isRequest(msg)) {
+      const handler = requestHandlers.get(msg.method);
+      if (handler) {
+        Promise.resolve()
+          .then(() => handler(msg.params))
+          .then(
+            (res) => write(formatResponse(msg.id, res)),
+            (err) => {
+              const errMsg = err instanceof Error ? err.message : String(err);
+              // Preserve a structured code/data the handler attached to the
+              // Error (e.g. a forwarded client rejection); fall back to the
+              // generic internal-error code otherwise.
+              const errAny = err as { code?: unknown; data?: unknown };
+              const code = typeof errAny?.code === "number" ? errAny.code : -32603;
+              const message = code === -32603 ? `Handler error: ${errMsg}` : errMsg;
+              console.error(`[${label}] Error in request handler for "${msg.method}": ${errMsg}`);
+              const errBody: Record<string, unknown> = { code, message };
+              if (errAny?.data !== undefined) errBody.data = errAny.data;
+              write(JSON.stringify({ id: msg.id, error: errBody }) + "\n");
+            },
+          );
+      } else {
+        write(JSON.stringify({ id: msg.id, error: { code: -32601, message: `Method not found: ${msg.method}` } }) + "\n");
+      }
+      return;
+    }
+
+    if (isNotification(msg)) {
+      // Wildcard handlers fire first, regardless of method, so the broker
+      // forwards every notification — including new ones the protocol adds.
+      for (const h of anyNotificationHandlers) {
+        try {
+          h(msg.method, msg.params);
+        } catch (e) {
+          console.error(`[${label}] Error in wildcard notification handler for "${msg.method}": ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+      const handlers = notificationHandlers.get(msg.method);
+      if (handlers) {
+        for (const h of handlers) {
+          try {
+            h(msg.params);
+          } catch (e) {
+            console.error(`[${label}] Error in notification handler for "${msg.method}": ${e instanceof Error ? e.message : String(e)}`);
+          }
+        }
+      }
+    }
+  }
+
+  let overflowed = false;
+
+  function feed(chunk: string): void {
+    if (overflowed) return;
+    buffer += chunk;
+    if (buffer.length > MAX_BUFFER_SIZE) {
+      overflowed = true;
+      buffer = "";
+      console.error(`[${label}] ${opts.overflowReason}`);
+      fail(opts.overflowReason);
+      opts.onOverflow();
+      return;
+    }
+    let newlineIdx: number;
+    while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, newlineIdx).trim();
+      buffer = buffer.slice(newlineIdx + 1);
+      if (!line) continue;
+      const msg = parseMessage(line);
+      if (msg) dispatch(msg);
+    }
+  }
+
+  function request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      if (closed) { reject(new Error("Client is closed")); return; }
+      const down = failReason ?? opts.downReason();
+      if (down !== null) { reject(new Error(down)); return; }
+
+      const id = nextId++;
+      const msg: Record<string, unknown> = { id, method };
+      if (params !== undefined) msg.params = params;
+      const line = JSON.stringify(msg) + "\n";
+
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Request ${method} (id=${id}) timed out after ${requestTimeout}ms`));
+      }, requestTimeout);
+
+      pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
+      write(line);
+    });
+  }
+
+  function notify(method: string, params?: unknown): void {
+    write(formatNotification(method, params));
+  }
+
+  function on(method: string, handler: NotificationHandler): () => void {
+    if (!notificationHandlers.has(method)) {
+      notificationHandlers.set(method, new Set());
+    }
+    notificationHandlers.get(method)!.add(handler);
+    return () => {
+      notificationHandlers.get(method)?.delete(handler);
+    };
+  }
+
+  function onAny(handler: AnyNotificationHandler): () => void {
+    anyNotificationHandlers.add(handler);
+    return () => { anyNotificationHandlers.delete(handler); };
+  }
+
+  function onRequest(method: string, handler: ServerRequestHandler): () => void {
+    if (requestHandlers.has(method)) {
+      console.error(`[${label}] Warning: replacing existing request handler for "${method}"`);
+    }
+    requestHandlers.set(method, handler);
+    return () => {
+      // Only delete if this is still our handler
+      if (requestHandlers.get(method) === handler) {
+        requestHandlers.delete(method);
+      }
+    };
+  }
+
+  function respond(id: RequestId, result: unknown): void {
+    write(formatResponse(id, result));
+  }
+
+  function onClose(handler: () => void): () => void {
+    closeHandlers.add(handler);
+    return () => { closeHandlers.delete(handler); };
+  }
+
+  function markClosed(): void {
+    if (closed) return;
+    closed = true;
+    rejectAllPending("Client closed");
+  }
+
+  return {
+    feed,
+    request,
+    notify,
+    on,
+    onAny,
+    onRequest,
+    respond,
+    onClose,
+    markClosed,
+    fail,
+    rejectAllPending,
+    isClosed: () => closed,
+  };
+}

--- a/src/threads.test.ts
+++ b/src/threads.test.ts
@@ -19,7 +19,7 @@ import {
   migrateGlobalState,
   removeLegacyGlobalThread,
 } from "./threads";
-import type { RunRecord, ThreadMapping } from "./types";
+import type { RunRecord, ThreadIndex } from "./types";
 import { STATE_SCHEMA_VERSION, MIGRATION_STATE_FILENAME } from "./config";
 import { rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
@@ -62,7 +62,6 @@ describe("thread index", () => {
     const index = {
       abc12345: {
         threadId: "thr_long_id",
-        name: null,
         model: "gpt-5",
         cwd: "/proj",
         createdAt: "2026-01-01T00:00:00Z",
@@ -96,7 +95,6 @@ describe("thread index", () => {
     expect(index[shortId].threadId).toBe("thr_new_id");
     expect(index[shortId].model).toBe("gpt-5");
     expect(index[shortId].cwd).toBe("/proj");
-    expect(index[shortId].name).toBeNull();
   });
 
   test("registerThread regenerates on collision", () => {
@@ -104,8 +102,6 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       deadbeef: {
         threadId: "thr_existing",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -122,8 +118,6 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_long_id",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -137,8 +131,6 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_long_id",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -152,16 +144,12 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_1",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       },
       abc12399: {
         threadId: "thr_2",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -174,8 +162,6 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_full_thread_id_here",
-        name: "my thread",
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -189,8 +175,6 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "019d680c-7b23-7f22-ab99-6584214a2bed",
-        name: "uuid thread",
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -210,8 +194,6 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_long_id",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -229,16 +211,15 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_1",
-        name: null,
         model: "old-model",
         cwd: "/old",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    updateThreadMeta(testDir, "abc12345", { name: "my thread", model: "new-model" });
+    updateThreadMeta(testDir, "thr_1", { preview: "my thread", model: "new-model" });
     const index = loadThreadIndex(testDir);
-    expect(index.abc12345.name).toBe("my thread");
+    expect(index.abc12345.preview).toBe("my thread");
     expect(index.abc12345.model).toBe("new-model");
     expect(index.abc12345.cwd).toBe("/old"); // unchanged
     expect(index.abc12345.updatedAt).not.toBe("2026-01-01T00:00:00Z");
@@ -248,16 +229,12 @@ describe("thread index", () => {
     saveThreadIndex(testDir, {
       abc12345: {
         threadId: "thr_1",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
       },
       def67890: {
         threadId: "thr_2",
-        name: null,
-        model: null,
         cwd: "/",
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -674,7 +651,7 @@ function computeWsStateDir(globalDataDir: string, cwd: string): string {
   return join(globalDataDir, "workspaces", `${slug}-${hash}`);
 }
 
-function writeGlobalThreads(globalDataDir: string, mapping: ThreadMapping): void {
+function writeGlobalThreads(globalDataDir: string, mapping: ThreadIndex): void {
   const file = join(globalDataDir, "threads.json");
   mkdirSync(globalDataDir, { recursive: true });
   writeFileSync(file, JSON.stringify(mapping, null, 2));
@@ -731,7 +708,6 @@ describe("migrateGlobalState", () => {
     expect(Object.keys(index)).toHaveLength(2);
     expect(index.aaa11111.threadId).toBe("thr_alpha");
     expect(index.aaa11111.model).toBe("gpt-5");
-    expect(index.aaa11111.name).toBeNull();
     expect(index.aaa11111.preview).toBe("Do the thing");
     expect(index.aaa11111.lastStatus).toBe("completed");
     expect(index.bbb22222.threadId).toBe("thr_beta");
@@ -764,8 +740,6 @@ describe("migrateGlobalState", () => {
     saveThreadIndex(wsStateDir, {
       abc12345: {
         threadId: "thr_existing",
-        name: null,
-        model: null,
         cwd: wsRoot,
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
@@ -953,7 +927,6 @@ describe("migrateGlobalState", () => {
     saveThreadIndex(wsStateDir, {
       existing1: {
         threadId: "thr_existing",
-        name: "Existing Thread",
         model: "gpt-5",
         cwd: wsRoot,
         createdAt: "2025-01-01T00:00:00Z",
@@ -967,7 +940,7 @@ describe("migrateGlobalState", () => {
     const index = loadThreadIndex(wsStateDir);
     expect(Object.keys(index)).toHaveLength(2);
     expect(index.existing1.threadId).toBe("thr_existing");
-    expect(index.existing1.name).toBe("Existing Thread");
+    expect(index.existing1.model).toBe("gpt-5"); // pre-existing workspace state preserved
     expect(index.aaa11111.threadId).toBe("thr_alpha");
     expect(index.aaa11111.lastStatus).toBe("completed");
 

--- a/src/threads.test.ts
+++ b/src/threads.test.ts
@@ -309,6 +309,22 @@ describe("run ledger", () => {
     expect(loaded!.threadId).toBe("thr_test"); // unchanged
   });
 
+  test("legacy 'cancelled' records normalize to 'interrupted' on every read path", () => {
+    const run = makeRun();
+    createRun(testDir, run);
+    // Simulate a record written before the status unification.
+    const filePath = join(testDir, "runs", `${run.runId}.json`);
+    writeFileSync(filePath, readFileSync(filePath, "utf-8").replace('"completed"', '"cancelled"'));
+
+    expect(loadRun(testDir, run.runId)!.status).toBe("interrupted");
+    expect(listRuns(testDir).find(r => r.runId === run.runId)!.status).toBe("interrupted");
+
+    // updateRun persists the normalized value even when the patch doesn't touch status.
+    updateRun(testDir, run.runId, { error: "x" });
+    expect(readFileSync(filePath, "utf-8")).not.toContain("cancelled");
+    expect(loadRun(testDir, run.runId)!.status).toBe("interrupted");
+  });
+
   test("updateRun throws on unknown run instead of silently no-op", () => {
     expect(() => updateRun(testDir, "run-does-not-exist", { status: "completed" }))
       .toThrow(/unknown run/i);
@@ -1044,7 +1060,7 @@ describe("migrateGlobalState", () => {
     const byShortId = Object.fromEntries(runs.map(r => [r.shortId, r]));
     expect(byShortId.aaa11111.status).toBe("completed");
     expect(byShortId.bbb22222.status).toBe("failed");      // stale running -> failed
-    expect(byShortId.ccc33333.status).toBe("cancelled");    // interrupted -> cancelled
+    expect(byShortId.ccc33333.status).toBe("interrupted");
     expect(byShortId.ddd44444.status).toBe("failed");
 
     const index = loadThreadIndex(wsStateDir);

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -13,7 +13,7 @@ import { randomBytes, createHash } from "crypto";
 import { basename, dirname, join, resolve } from "path";
 import { config, validateId, resolveWorkspaceDir, isPathInside, STATE_SCHEMA_VERSION, MIGRATION_STATE_FILENAME } from "./config";
 import { acquireLockSync, LockTimeoutError } from "./lock";
-import type { ThreadIndex, ThreadIndexEntry, RunRecord, RunStatus, ThreadMapping, ThreadMappingEntry } from "./types";
+import type { ThreadIndex, ThreadIndexEntry, RunRecord, RunStatus } from "./types";
 
 // ─── Advisory file lock ────────────────────────────────────────────────────
 
@@ -99,8 +99,9 @@ function bailOnCorruptThreads(filePath: string, reason: string): Error {
   return new Error(`Threads file corrupted (${reason}).\n${where}`);
 }
 
-export function saveThreadIndex(stateDir: string, index: ThreadIndex): void {
-  const filePath = threadsFilePath(stateDir);
+/** Atomic write of a threads file at an explicit path. Used by saveThreadIndex
+ *  and by legacy-global-file maintenance in the migration code below. */
+function writeThreadsFileAt(filePath: string, index: ThreadIndex): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   const tmpPath = filePath + ".tmp";
@@ -108,10 +109,28 @@ export function saveThreadIndex(stateDir: string, index: ThreadIndex): void {
   renameSync(tmpPath, filePath);
 }
 
+export function saveThreadIndex(stateDir: string, index: ThreadIndex): void {
+  writeThreadsFileAt(threadsFilePath(stateDir), index);
+}
+
+/**
+ * Load the index, apply `mutate`, and save — all under the thread lock.
+ * Return false from `mutate` to skip the save (no changes).
+ */
+export function mutateThreadIndex(
+  stateDir: string,
+  mutate: (index: ThreadIndex) => boolean | void,
+): void {
+  withThreadLock(threadsFilePath(stateDir), () => {
+    const index = loadThreadIndex(stateDir);
+    if (mutate(index) !== false) saveThreadIndex(stateDir, index);
+  });
+}
+
 export function registerThread(
   stateDir: string,
   threadId: string,
-  meta?: Partial<ThreadIndexEntry>,
+  meta?: Partial<Pick<ThreadIndexEntry, "model" | "cwd" | "preview" | "createdAt" | "updatedAt">>,
 ): string {
   validateId(threadId);
   const filePath = threadsFilePath(stateDir);
@@ -122,11 +141,11 @@ export function registerThread(
     const now = new Date().toISOString();
     index[shortId] = {
       threadId,
-      name: meta?.name ?? null,
-      model: meta?.model ?? null,
-      cwd: meta?.cwd ?? process.cwd(),
       createdAt: meta?.createdAt ?? now,
       updatedAt: meta?.updatedAt ?? now,
+      model: meta?.model,
+      cwd: meta?.cwd,
+      preview: meta?.preview,
     };
     saveThreadIndex(stateDir, index);
     return shortId;
@@ -180,26 +199,48 @@ export function findShortId(stateDir: string, threadId: string): string | null {
   return null;
 }
 
-type ThreadMetaPatch = Partial<Pick<ThreadIndexEntry, "name" | "model" | "cwd">>;
+type ThreadMetaPatch = Partial<Pick<ThreadIndexEntry, "model" | "cwd" | "preview">>;
 
+/** Update display metadata for a thread, keyed by full thread ID (callers
+ *  coming off a server response hold the thread ID, not the short ID). */
 export function updateThreadMeta(
   stateDir: string,
-  shortId: string,
+  threadId: string,
   patch: ThreadMetaPatch,
 ): void {
-  const filePath = threadsFilePath(stateDir);
-  withThreadLock(filePath, () => {
-    const index = loadThreadIndex(stateDir);
-    if (!index[shortId]) {
-      console.error(`[codex] Warning: cannot update metadata for unknown short ID ${shortId}`);
-      return;
+  mutateThreadIndex(stateDir, (index) => {
+    for (const entry of Object.values(index)) {
+      if (entry.threadId === threadId) {
+        if (patch.model !== undefined) entry.model = patch.model;
+        if (patch.cwd !== undefined) entry.cwd = patch.cwd;
+        if (patch.preview !== undefined) entry.preview = patch.preview;
+        entry.updatedAt = new Date().toISOString();
+        return;
+      }
     }
-    const entry = index[shortId];
-    if (patch.name !== undefined) entry.name = patch.name;
-    if (patch.model !== undefined) entry.model = patch.model;
-    if (patch.cwd !== undefined) entry.cwd = patch.cwd;
-    entry.updatedAt = new Date().toISOString();
-    saveThreadIndex(stateDir, index);
+    console.error(`[codex] Warning: cannot update metadata for unknown thread ${threadId.slice(0, 12)}...`);
+    return false;
+  });
+}
+
+/** Update the denormalized display status for a thread, keyed by full thread
+ *  ID. The run ledger is the authoritative per-invocation record; this keeps
+ *  `threads` listings current without a ledger scan. */
+export function updateThreadStatus(
+  stateDir: string,
+  threadId: string,
+  status: NonNullable<ThreadIndexEntry["lastStatus"]>,
+): void {
+  mutateThreadIndex(stateDir, (index) => {
+    for (const entry of Object.values(index)) {
+      if (entry.threadId === threadId) {
+        entry.lastStatus = status;
+        entry.updatedAt = new Date().toISOString();
+        return;
+      }
+    }
+    console.error(`[codex] Warning: cannot update status for unknown thread ${threadId.slice(0, 12)}...`);
+    return false;
   });
 }
 
@@ -622,7 +663,7 @@ function runMigration(cwd: string, dataDir: string, globalThreadsFile: string, s
   // migrated yet, and (b) cascade through every CLI invocation since
   // migration runs from getWorkspacePaths. On corruption we skip migration
   // and leave the file in place so the user can inspect/repair it.
-  let globalMapping: ThreadMapping;
+  let globalMapping: ThreadIndex;
   let content: string;
   try {
     content = readFileSync(globalThreadsFile, "utf-8");
@@ -662,7 +703,7 @@ function runMigration(cwd: string, dataDir: string, globalThreadsFile: string, s
   // values that may be symlinked forms of the same directory (e.g. macOS
   // /var vs /private/var).
   const wsRoot = resolveWorkspaceDir(cwd);
-  const matchingEntries: [string, ThreadMappingEntry][] = [];
+  const matchingEntries: [string, ThreadIndexEntry][] = [];
   for (const [shortId, entry] of Object.entries(globalMapping)) {
     if (entry.cwd && isPathInside(canonicalizePath(entry.cwd), wsRoot)) {
       matchingEntries.push([shortId, entry]);
@@ -693,8 +734,7 @@ function runMigration(cwd: string, dataDir: string, globalThreadsFile: string, s
     const previous = index[targetShortId];
     const nextEntry = {
       threadId: entry.threadId,
-      name: previous?.name ?? null,
-      model: previous?.model ?? entry.model ?? null,
+      model: previous?.model ?? entry.model,
       cwd: previous?.cwd ?? entry.cwd ?? cwd,
       createdAt: previous?.createdAt ?? entry.createdAt,
       updatedAt: previous?.updatedAt ?? entry.updatedAt ?? entry.createdAt,
@@ -709,7 +749,6 @@ function runMigration(cwd: string, dataDir: string, globalThreadsFile: string, s
     };
     const changed = !previous ||
       previous.threadId !== nextEntry.threadId ||
-      previous.name !== nextEntry.name ||
       previous.model !== nextEntry.model ||
       previous.cwd !== nextEntry.cwd ||
       previous.createdAt !== nextEntry.createdAt ||
@@ -797,7 +836,7 @@ export function removeLegacyGlobalThread(
 
   const wsRoot = resolveWorkspaceDir(cwd);
   return withThreadLock(globalThreadsFile, () => {
-    let globalMapping: ThreadMapping;
+    let globalMapping: ThreadIndex;
     try {
       const parsed = JSON.parse(readFileSync(globalThreadsFile, "utf-8"));
       if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -818,174 +857,8 @@ export function removeLegacyGlobalThread(
       }
     }
 
-    if (changed) saveThreadMapping(globalThreadsFile, globalMapping);
+    if (changed) writeThreadsFileAt(globalThreadsFile, globalMapping);
     return changed;
   });
 }
 
-// ─── Legacy API (backward-compatible) ──────────────────────────────────────
-// These functions preserve the old signatures used by cli.ts, turns.ts, etc.
-// They delegate to the new thread index functions using the parent directory
-// of the threadsFile as the stateDir.
-
-/** @deprecated Use loadThreadIndex instead. */
-export function loadThreadMapping(threadsFile: string): ThreadMapping {
-  // The old API expected threadsFile = {dir}/threads.json
-  // We read the file directly to maintain exact backward compat
-  if (!existsSync(threadsFile)) return {};
-  let content: string;
-  try {
-    content = readFileSync(threadsFile, "utf-8");
-  } catch (e) {
-    throw new Error(`Cannot read threads file ${threadsFile}: ${e instanceof Error ? e.message : e}`);
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch (e) {
-    throw bailOnCorruptThreads(threadsFile, `unparseable JSON (${e instanceof Error ? e.message : e})`);
-  }
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw bailOnCorruptThreads(threadsFile, "invalid structure (not a JSON object)");
-  }
-  return parsed as ThreadMapping;
-}
-
-/** @deprecated Use saveThreadIndex instead. */
-export function saveThreadMapping(threadsFile: string, mapping: ThreadMapping): void {
-  const dir = dirname(threadsFile);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-  const tmpPath = threadsFile + ".tmp";
-  writeFileSync(tmpPath, JSON.stringify(mapping, null, 2), { mode: 0o600 });
-  renameSync(tmpPath, threadsFile);
-}
-
-/**
- * @deprecated Use updateThreadMeta (new signature) instead.
- * Old signature: updateThreadMeta(threadsFile, threadId, meta) where threadId is the full ID.
- */
-export function legacyUpdateThreadMeta(
-  threadsFile: string,
-  threadId: string,
-  meta: Partial<Pick<ThreadMappingEntry, "model" | "cwd" | "preview">>,
-): void {
-  withThreadLock(threadsFile, () => {
-    const mapping = loadThreadMapping(threadsFile);
-    for (const entry of Object.values(mapping)) {
-      if (entry.threadId === threadId) {
-        if (meta.model !== undefined) entry.model = meta.model;
-        if (meta.cwd !== undefined) entry.cwd = meta.cwd;
-        if (meta.preview !== undefined) entry.preview = meta.preview;
-        entry.updatedAt = new Date().toISOString();
-        saveThreadMapping(threadsFile, mapping);
-        return;
-      }
-    }
-    console.error(`[codex] Warning: cannot update metadata for unknown thread ${threadId.slice(0, 12)}...`);
-  });
-}
-
-/** @deprecated Use run ledger status tracking instead. */
-export function updateThreadStatus(
-  threadsFile: string,
-  threadId: string,
-  status: "running" | "completed" | "failed" | "interrupted",
-): void {
-  withThreadLock(threadsFile, () => {
-    const mapping = loadThreadMapping(threadsFile);
-    let found = false;
-    for (const entry of Object.values(mapping)) {
-      if (entry.threadId === threadId) {
-        found = true;
-        entry.lastStatus = status;
-        entry.updatedAt = new Date().toISOString();
-        break;
-      }
-    }
-    if (!found) {
-      console.error(`[codex] Warning: cannot update status for unknown thread ${threadId.slice(0, 12)}...`);
-      return;
-    }
-    saveThreadMapping(threadsFile, mapping);
-  });
-}
-
-/**
- * @deprecated Legacy registerThread that returns the full mapping.
- * New code should use the new registerThread (returns shortId string).
- */
-export function legacyRegisterThread(
-  threadsFile: string,
-  threadId: string,
-  meta?: { model?: string; cwd?: string; preview?: string; createdAt?: string; updatedAt?: string },
-): ThreadMapping {
-  validateId(threadId);
-  return withThreadLock(threadsFile, () => {
-    const mapping = loadThreadMapping(threadsFile);
-    let shortId = generateShortId();
-    while (shortId in mapping) shortId = generateShortId();
-    const now = new Date().toISOString();
-    mapping[shortId] = {
-      threadId,
-      createdAt: meta?.createdAt ?? now,
-      updatedAt: meta?.updatedAt ?? now,
-      model: meta?.model,
-      cwd: meta?.cwd,
-      preview: meta?.preview,
-    };
-    saveThreadMapping(threadsFile, mapping);
-    return mapping;
-  });
-}
-
-/**
- * @deprecated Legacy resolveThreadId that returns threadId string or throws.
- * New code should use the new resolveThreadId (returns object or null).
- */
-export function legacyResolveThreadId(threadsFile: string, idOrPrefix: string): string {
-  const mapping = loadThreadMapping(threadsFile);
-
-  // Exact short ID match (hasOwn: `mapping[idOrPrefix]` alone would hit
-  // Object.prototype members for IDs like "constructor", returning
-  // undefined as the threadId instead of falling through to "not found")
-  if (Object.hasOwn(mapping, idOrPrefix)) return mapping[idOrPrefix].threadId;
-
-  // Short ID prefix match
-  const matches = Object.entries(mapping).filter(([k]) => k.startsWith(idOrPrefix));
-  if (matches.length === 1) return matches[0][1].threadId;
-  if (matches.length > 1) {
-    throw new Error(
-      `Ambiguous ID prefix "${idOrPrefix}" — matches: ${matches.map(([k]) => k).join(", ")}`,
-    );
-  }
-
-  // Full thread ID match (e.g., UUID from Codex TUI handoff)
-  const byThreadId = Object.values(mapping).find(e => e.threadId === idOrPrefix);
-  if (byThreadId) return byThreadId.threadId;
-
-  throw new Error(`Thread not found: "${idOrPrefix}"`);
-}
-
-/**
- * @deprecated Legacy findShortId that takes threadsFile.
- * New code should use the new findShortId (takes stateDir).
- */
-export function legacyFindShortId(threadsFile: string, threadId: string): string | null {
-  const mapping = loadThreadMapping(threadsFile);
-  for (const [shortId, entry] of Object.entries(mapping)) {
-    if (entry.threadId === threadId) return shortId;
-  }
-  return null;
-}
-
-/**
- * @deprecated Legacy removeThread that takes threadsFile.
- * New code should use the new removeThread (takes stateDir).
- */
-export function legacyRemoveThread(threadsFile: string, shortId: string): void {
-  withThreadLock(threadsFile, () => {
-    const mapping = loadThreadMapping(threadsFile);
-    delete mapping[shortId];
-    saveThreadMapping(threadsFile, mapping);
-  });
-}

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -276,6 +276,14 @@ export function createRun(stateDir: string, record: RunRecord): void {
   renameSync(tmpPath, filePath);
 }
 
+/** Records written before the status unification say "cancelled" where the
+ *  thread index (and every display surface) says "interrupted". Normalize on
+ *  read — a lazy migration; the next updateRun persists the new value. */
+function normalizeRunRecord(record: RunRecord): RunRecord {
+  if ((record.status as string) === "cancelled") record.status = "interrupted";
+  return record;
+}
+
 export function loadRun(stateDir: string, runId: string): RunRecord | null {
   const filePath = runFilePath(stateDir, runId);
   if (!existsSync(filePath)) return null;
@@ -299,7 +307,7 @@ export function loadRun(stateDir: string, runId: string): RunRecord | null {
       console.error(`[codex] Warning: run file ${runId} has invalid structure`);
       return null;
     }
-    return parsed;
+    return normalizeRunRecord(parsed);
   } catch (e) {
     console.error(`[codex] Warning: failed to parse run file ${runId}: ${e instanceof Error ? e.message : e}`);
     return null;
@@ -325,7 +333,7 @@ export function updateRun(stateDir: string, runId: string, patch: RunPatch): voi
   }
   let record: RunRecord;
   try {
-    record = JSON.parse(readFileSync(filePath, "utf-8"));
+    record = normalizeRunRecord(JSON.parse(readFileSync(filePath, "utf-8")));
   } catch (e) {
     throw new Error(`Failed to read run ${runId}: ${e instanceof Error ? e.message : e}`);
   }
@@ -346,7 +354,7 @@ export function listRuns(stateDir: string, opts?: { sessionId?: string }): RunRe
   const records: RunRecord[] = [];
   for (const file of files) {
     try {
-      const record: RunRecord = JSON.parse(readFileSync(join(dir, file), "utf-8"));
+      const record: RunRecord = normalizeRunRecord(JSON.parse(readFileSync(join(dir, file), "utf-8")));
       if (opts?.sessionId && record.sessionId !== opts.sessionId) continue;
       records.push(record);
     } catch (e) {
@@ -503,7 +511,7 @@ function mapLegacyStatus(lastStatus?: string): RunStatus {
   switch (lastStatus) {
     case "completed": return "completed";
     case "failed": return "failed";
-    case "interrupted": return "cancelled";
+    case "interrupted": return "interrupted";
     case "running": return "failed"; // stale — process is gone
     default: return "failed";
   }
@@ -780,7 +788,7 @@ function runMigration(cwd: string, dataDir: string, globalThreadsFile: string, s
 
     // Determine terminal status
     const status = mapLegacyStatus(entry.lastStatus);
-    const isTerminal = status === "completed" || status === "failed" || status === "cancelled";
+    const isTerminal = status === "completed" || status === "failed" || status === "interrupted";
 
     // Create synthetic RunRecord
     const record: RunRecord = {

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -158,7 +158,7 @@ export function registerThread(
  * Resolution order:
  * 1. Exact short ID match
  * 2. Prefix match on short IDs (error if ambiguous)
- * 3. If starts with "thr_", search index values for matching threadId
+ * 3. Full thread ID lookup (any format — thr_, UUID, etc.)
  * 4. Otherwise, return null
  */
 export function resolveThreadId(
@@ -666,7 +666,8 @@ function runMigration(cwd: string, dataDir: string, globalThreadsFile: string, s
   const index: ThreadIndex = loadThreadIndex(stateDir);
 
   // 3. Load the global thread mapping directly. We deliberately do NOT use
-  // loadThreadMapping here — it renames the file aside on corruption, which
+  // loadThreadIndex-style corruption handling here — it renames the file
+  // aside on corruption, which
   // would (a) destroy the legacy state for OTHER workspaces that haven't
   // migrated yet, and (b) cascade through every CLI invocation since
   // migration runs from getWorkspacePaths. On corruption we skip migration

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -13,8 +13,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import {
   updateThreadStatus,
-  loadThreadMapping,
-  saveThreadMapping,
+  loadThreadIndex,
+  saveThreadIndex,
 } from "./threads";
 
 const TEST_LOG_DIR = join(tmpdir(), "codex-collab-test-turns");
@@ -906,7 +906,7 @@ describe("error propagation", () => {
 // updateThreadStatus
 // ---------------------------------------------------------------------------
 
-const TEST_THREADS_FILE = join(tmpdir(), "codex-collab-test-threads", "threads.json");
+const TEST_STATE_DIR = join(tmpdir(), "codex-collab-test-threads");
 
 describe("updateThreadStatus", () => {
   beforeEach(() => {
@@ -916,7 +916,7 @@ describe("updateThreadStatus", () => {
   });
 
   test("updates status and timestamp", () => {
-    saveThreadMapping(TEST_THREADS_FILE, {
+    saveThreadIndex(TEST_STATE_DIR, {
       abc12345: {
         threadId: "thr-1",
         createdAt: "2026-01-01T00:00:00Z",
@@ -924,18 +924,18 @@ describe("updateThreadStatus", () => {
       },
     });
 
-    updateThreadStatus(TEST_THREADS_FILE, "thr-1", "completed");
-    const loaded = loadThreadMapping(TEST_THREADS_FILE);
+    updateThreadStatus(TEST_STATE_DIR, "thr-1", "completed");
+    const loaded = loadThreadIndex(TEST_STATE_DIR);
     expect(loaded.abc12345.lastStatus).toBe("completed");
     expect(loaded.abc12345.updatedAt).toBeDefined();
   });
 
   test("warns on unknown thread", () => {
-    saveThreadMapping(TEST_THREADS_FILE, {});
+    saveThreadIndex(TEST_STATE_DIR, {});
     const warnings: string[] = [];
     const origError = console.error;
     console.error = (msg: string) => warnings.push(msg);
-    updateThreadStatus(TEST_THREADS_FILE, "thr-unknown", "running");
+    updateThreadStatus(TEST_STATE_DIR, "thr-unknown", "running");
     console.error = origError;
     expect(warnings.some((w) => w.includes("unknown thread"))).toBe(true);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -465,7 +465,7 @@ export type RunPhase =
   | "starting" | "reviewing" | "editing" | "verifying"
   | "running" | "investigating" | "finalizing";
 
-export type RunStatus = "running" | "completed" | "failed" | "cancelled";
+export type RunStatus = "running" | "completed" | "failed" | "interrupted";
 
 /** A pending interactive approval attached to a run — the on-disk signal
  *  observers (follow, Monitor scripts) use to see a blocked run without

--- a/src/types.ts
+++ b/src/types.ts
@@ -442,14 +442,14 @@ export interface TurnResult {
 
 export interface ThreadIndexEntry {
   threadId: string;
-  name: string | null;
-  model: string | null;
-  cwd: string;
   createdAt: string;
-  updatedAt: string;
-  /** Legacy display field preserved while commands finish moving to run ledger. */
+  updatedAt?: string;
+  model?: string;
+  cwd?: string;
+  /** First-prompt excerpt shown in `threads` listings. */
   preview?: string;
-  /** Legacy display field preserved while commands finish moving to run ledger. */
+  /** Denormalized latest-turn status for display; the run ledger is the
+   *  authoritative per-invocation record. */
   lastStatus?: "running" | "completed" | "failed" | "interrupted";
 }
 
@@ -525,20 +525,4 @@ export type BrokerEndpointKind = "unix" | "pipe";
 export interface ParsedEndpoint {
   kind: BrokerEndpointKind;
   path: string;
-}
-
-// --- Short ID mapping (legacy, pending migration) ---
-
-export interface ThreadMappingEntry {
-  threadId: string;
-  createdAt: string;
-  model?: string;
-  cwd?: string;
-  preview?: string;
-  lastStatus?: "running" | "completed" | "failed" | "interrupted";
-  updatedAt?: string;
-}
-
-export interface ThreadMapping {
-  [shortId: string]: ThreadMappingEntry;
 }


### PR DESCRIPTION
Closes out the deferred refactors from #11 (section 3) in one consolidated PR. No user-facing CLI changes except two strict improvements: `kill`/`delete` now accept raw server thread IDs, and shutdown no longer orphans grandchild processes on Unix.

## Shared JSON-RPC endpoint core (`src/rpc.ts`)

`client.ts` (stdio to the app-server child) and `broker-client.ts` (socket to the broker) each hand-maintained a copy of the wire-level plumbing — pending-request tracking, response/error/server-request/notification dispatch, newline-buffered parsing, handler registries. Several #10 review findings were drift between the copies. `createRpcEndpoint()` now owns all of it, parameterized only by what genuinely differs per transport (raw send, liveness probe, overflow teardown, reason strings). Protocol helpers moved to `rpc.ts` with re-exports from `client.ts`, so `broker-server.ts` and existing imports are untouched.

## Single stateDir-keyed thread API

The "new" stateDir API in `threads.ts` was dead code (zero production callers) whose schema dropped fields production relies on (`preview`, `lastStatus`) and carried one nothing read (`name` — thread names are server-side via `thread/name/set`). Production ran entirely on the `@deprecated` legacy layer through `legacyX as X` import aliases. Now there is one API with the production schema and the legacy semantics:

- `registerThread` returns the shortId (callers drop the find-after-register dance)
- `resolveThreadId` returns `{ shortId, threadId } | null`; the raw-ID fallbacks branch on null instead of string-matching error text
- new `mutateThreadIndex()` wraps the load-mutate-save-under-lock pattern
- `WorkspacePaths.threadsFile` / `config.threadsFile` removed — nothing outside `threads.ts` touches the file anymore

## Run-ledger status unified on `interrupted`

The ledger said `cancelled` where the thread index, the protocol's turn status, and every display surface say `interrupted`. Migration is lazy: `normalizeRunRecord` rewrites `cancelled` on every read path, so old records display correctly immediately and persist the new form on their next write. No sweep, no schema bump.

## `kill`/`delete`/`peek` accept raw server thread IDs

`peek` and `run --resume` already fell back to treating an unindexed ID as a raw server thread ID; `kill` and `delete` died with "Thread not found" — a TUI-created thread could be peeked and resumed but not stopped or archived. One shared `resolveThreadIdAllowRaw()` now serves all three (peek's inline copy removed).

## Unix shutdown: no more orphaned grandchildren

`connectDirect`'s escalation (SIGTERM → SIGKILL) signalled only the direct child. The app-server is now spawned via `child_process` with `detached: true` on Unix (own process group — the technique `broker.ts` already uses), and every `close()` exit path ends with a verify-and-escalate group sweep: check membership, SIGTERM, poll ~500ms, SIGKILL stragglers. Zero-cost when the group is already empty. On Windows the command is wrapped with `cmd.exe /c` (npm installs `codex` as a `.cmd` shim, which `child_process.spawn` refuses without a shell since the CVE-2024-27980 hardening — `Bun.spawn` did this wrap implicitly); tree termination there remains `taskkill /T`.

## Review & verification

- Iterated Codex reviews of the branch until clean; three real findings (Windows `.cmd` spawn regression, graceful-exit orphan gap, SIGTERM-ignoring straggler) each validated live, fixed, and pinned by regression tests that provably fail without their fix
- 582 tests pass; live end-to-end runs verified through both the broker path and the direct path, plus live `kill`/`delete` against raw unindexed thread IDs

Remaining from #11 after this: Guardian denial-override command; the conditional micro-MCP spike (proposed to drop — `follow --watch` covers it); per-run log tagging for the accepted concurrent-same-thread display limitation.
