### PR TITLE
feat(approve): Guardian denial override via thread/approveGuardianDeniedAction

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -151,6 +151,15 @@ codex-collab run "refactor the auth module" --approval auto --content-only
 
 With `--approval auto`, Guardian approves or **denies** each request on its own — it does not escalate to the interactive flow, so auto runs never block. Its decisions appear in the progress stream (`Guardian approved (low risk): …`) with full payloads in the thread log; judgment calls and denials additionally surface as `Guardian warning: …` lines carrying the risk level, the user-authorization assessment, and the rationale. Note Guardian weighs whether the *user* asked for the action — explicitly user-requested commands get high authorization and are usually approved; it exists to catch the model acting beyond its mandate.
 
+When Guardian denies an action the run keeps going (the agent works around it), and the denial is saved locally with a progress hint (`Override available: codex-collab approve --guardian <review-id>`). If the user decides the action was actually fine:
+
+```bash
+codex-collab approve --guardian               # list pending denials
+codex-collab approve --guardian <review-id>   # override one (prefix ok)
+```
+
+The override records a user approval for that exact action inside the thread — nothing executes immediately; the agent retries it on the thread's next run (`codex-collab run --resume <short-id> "continue"`). It authorizes only that specific action, not similar ones.
+
 Under the interactive policies (`on-request`, `on-failure`, `untrusted`), an approval request shows:
 ```
 [codex] APPROVAL NEEDED

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,6 +116,8 @@ Commands:
   models                  List available models
   templates               List available prompt templates
   approve <id>            Approve a pending request
+  approve --guardian [id] Override a Guardian denial (no id: list pending
+                          denials); takes effect on the thread's next run
   decline <id>            Decline a pending request
   clean                   Delete old logs and stale mappings
   delete <id> [--purge]   Archive thread (recoverable) and delete local files;

--- a/src/commands/approve.ts
+++ b/src/commands/approve.ts
@@ -17,7 +17,8 @@ import {
   markGuardianDenialOverridden,
   resolveGuardianDenial,
 } from "../guardian";
-import { findShortId } from "../threads";
+import { findShortId, loadThreadIndex } from "../threads";
+import type { GuardianDenialRecord } from "../types";
 
 function findApprovalRequest(currentPath: string, approvalId: string): string | null {
   if (existsSync(currentPath)) return currentPath;
@@ -81,6 +82,34 @@ async function handleApproveOrDecline(
  *  approving that exact action into the thread (no turn starts); the agent
  *  acts on it the next time the thread runs. With no ID, list pending
  *  denials instead. */
+/** Resolve a denial ID against the current workspace first, then across all
+ *  workspaces — mirroring findApprovalRequest, because the override hint is
+ *  printed by the run and the user may act on it from a different cwd. */
+function findGuardianDenial(
+  stateDir: string,
+  guardianDir: string,
+  idOrPrefix: string,
+): { record: GuardianDenialRecord; stateDir: string; guardianDir: string } | null {
+  const local = resolveGuardianDenial(guardianDir, idOrPrefix);
+  if (local) return { record: local, stateDir, guardianDir };
+
+  const workspacesDir = join(config.dataDir, "workspaces");
+  if (!existsSync(workspacesDir)) return null;
+
+  const matches: Array<{ record: GuardianDenialRecord; stateDir: string; guardianDir: string }> = [];
+  for (const workspaceName of readdirSync(workspacesDir)) {
+    const wsStateDir = join(workspacesDir, workspaceName);
+    if (wsStateDir === stateDir) continue;
+    const wsGuardianDir = join(wsStateDir, "guardian");
+    const record = resolveGuardianDenial(wsGuardianDir, idOrPrefix);
+    if (record) matches.push({ record, stateDir: wsStateDir, guardianDir: wsGuardianDir });
+  }
+  if (matches.length > 1) {
+    die(`Guardian denial ${idOrPrefix} matches in multiple workspaces. Re-run from the workspace directory or pass -d <workspace>.`);
+  }
+  return matches[0] ?? null;
+}
+
 async function handleGuardianOverride(
   stateDir: string,
   guardianDir: string,
@@ -102,13 +131,14 @@ async function handleGuardianOverride(
     return;
   }
 
-  let record;
+  let found;
   try {
-    record = resolveGuardianDenial(guardianDir, idOrPrefix);
+    found = findGuardianDenial(stateDir, guardianDir, idOrPrefix);
   } catch (e) {
     die(e instanceof Error ? e.message : String(e));
   }
-  if (!record) die(`No Guardian denial found for: ${idOrPrefix}`);
+  if (!found) die(`No Guardian denial found for: ${idOrPrefix}`);
+  const { record } = found;
   if (record.overriddenAt) die(`Denial ${record.reviewId} was already overridden at ${record.overriddenAt}`);
 
   let event;
@@ -119,15 +149,19 @@ async function handleGuardianOverride(
   }
 
   const threadId = record.threadId;
+  // Connect in the thread's own workspace so a cross-workspace override
+  // reuses that workspace's broker (and its already-loaded thread) instead
+  // of spawning a server keyed to the current cwd.
+  const threadCwd = loadThreadIndex(found.stateDir)[findShortId(found.stateDir, threadId) ?? ""]?.cwd;
   await withClient(async (client) => {
     // The RPC needs the thread loaded in the app-server; a minimal resume
     // loads it without starting a turn or changing settings.
     await client.request("thread/resume", { threadId, persistExtendedHistory: false });
     await client.request("thread/approveGuardianDeniedAction", { threadId, event });
-  });
+  }, threadCwd);
 
-  markGuardianDenialOverridden(guardianDir, record.reviewId);
-  const thread = findShortId(stateDir, threadId) ?? threadId;
+  markGuardianDenialOverridden(found.guardianDir, record.reviewId);
+  const thread = findShortId(found.stateDir, threadId) ?? threadId;
   console.log(`Guardian denial overridden: ${describeGuardianAction(record)}`);
   console.log(
     `The approval was recorded in thread ${thread}; it takes effect on the next run (e.g. codex-collab run --resume ${thread} "continue").`,

--- a/src/commands/approve.ts
+++ b/src/commands/approve.ts
@@ -8,7 +8,16 @@ import {
   parseOptions,
   validateIdOrDie,
   getWorkspacePaths,
+  withClient,
 } from "./shared";
+import {
+  buildGuardianOverrideEvent,
+  describeGuardianAction,
+  listGuardianDenials,
+  markGuardianDenialOverridden,
+  resolveGuardianDenial,
+} from "../guardian";
+import { findShortId } from "../threads";
 
 function findApprovalRequest(currentPath: string, approvalId: string): string | null {
   if (existsSync(currentPath)) return currentPath;
@@ -45,6 +54,10 @@ async function handleApproveOrDecline(
   const ws = getWorkspacePaths(options.dir);
   const approvalId = positional[0];
   const verb = decision === "accept" ? "approve" : "decline";
+  if (options.guardian) {
+    if (decision !== "accept") die("--guardian is only valid with approve (Guardian denials are already declines)");
+    return handleGuardianOverride(ws.stateDir, ws.guardianDir, approvalId);
+  }
   if (!approvalId) die(`Usage: codex-collab ${verb} <approval-id>`);
   validateIdOrDie(approvalId);
 
@@ -60,5 +73,63 @@ async function handleApproveOrDecline(
   }
   console.log(
     `${decision === "accept" ? "Approved" : "Declined"}: ${approvalId}`,
+  );
+}
+
+/** Override a Guardian denial: send thread/approveGuardianDeniedAction with
+ *  the persisted denial event. The server injects a developer message
+ *  approving that exact action into the thread (no turn starts); the agent
+ *  acts on it the next time the thread runs. With no ID, list pending
+ *  denials instead. */
+async function handleGuardianOverride(
+  stateDir: string,
+  guardianDir: string,
+  idOrPrefix: string | undefined,
+): Promise<void> {
+  const pending = listGuardianDenials(guardianDir).filter((r) => !r.overriddenAt);
+
+  if (!idOrPrefix) {
+    if (pending.length === 0) {
+      console.log("No pending Guardian denials.");
+      return;
+    }
+    console.log("Pending Guardian denials:");
+    for (const r of pending) {
+      const thread = findShortId(stateDir, r.threadId) ?? r.threadId;
+      console.log(`  ${r.reviewId}  thread ${thread}  ${r.receivedAt}  ${describeGuardianAction(r)}`);
+    }
+    console.log("\nOverride one with: codex-collab approve --guardian <review-id>");
+    return;
+  }
+
+  let record;
+  try {
+    record = resolveGuardianDenial(guardianDir, idOrPrefix);
+  } catch (e) {
+    die(e instanceof Error ? e.message : String(e));
+  }
+  if (!record) die(`No Guardian denial found for: ${idOrPrefix}`);
+  if (record.overriddenAt) die(`Denial ${record.reviewId} was already overridden at ${record.overriddenAt}`);
+
+  let event;
+  try {
+    event = buildGuardianOverrideEvent(record);
+  } catch (e) {
+    die(e instanceof Error ? e.message : String(e));
+  }
+
+  const threadId = record.threadId;
+  await withClient(async (client) => {
+    // The RPC needs the thread loaded in the app-server; a minimal resume
+    // loads it without starting a turn or changing settings.
+    await client.request("thread/resume", { threadId, persistExtendedHistory: false });
+    await client.request("thread/approveGuardianDeniedAction", { threadId, event });
+  });
+
+  markGuardianDenialOverridden(guardianDir, record.reviewId);
+  const thread = findShortId(stateDir, threadId) ?? threadId;
+  console.log(`Guardian denial overridden: ${describeGuardianAction(record)}`);
+  console.log(
+    `The approval was recorded in thread ${thread}; it takes effect on the next run (e.g. codex-collab run --resume ${thread} "continue").`,
   );
 }

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -100,7 +100,7 @@ export async function handleReview(args: string[]): Promise<void> {
     setActiveRunId(runId);
     writePidFile(ws.pidsDir, shortId);
 
-    const dispatcher = createDispatcher(shortId, ws.logsDir, options);
+    const dispatcher = createDispatcher(shortId, ws.logsDir, options, ws.guardianDir);
 
     // Note: model/cwd/approval/sandbox already reached the server via the
     // thread start/fork params in startOrResumeThread; review/start itself

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -100,7 +100,11 @@ export async function handleReview(args: string[]): Promise<void> {
     setActiveRunId(runId);
     writePidFile(ws.pidsDir, shortId);
 
-    const dispatcher = createDispatcher(shortId, ws.logsDir, options, ws.guardianDir);
+    // No guardianDir: review threads are ephemeral (never persisted
+    // server-side), so a Guardian denial here could not be overridden later —
+    // thread/resume on the dead thread would fail. Denials still show in the
+    // progress stream and log.
+    const dispatcher = createDispatcher(shortId, ws.logsDir, options);
 
     // Note: model/cwd/approval/sandbox already reached the server via the
     // thread start/fork params in startOrResumeThread; review/start itself

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -248,7 +248,7 @@ export async function handleRun(args: string[]): Promise<void> {
     setActiveRunId(runId);
     writePidFile(ws.pidsDir, shortId);
 
-    const dispatcher = createDispatcher(shortId, ws.logsDir, options);
+    const dispatcher = createDispatcher(shortId, ws.logsDir, options, ws.guardianDir);
 
     try {
       const result = await runTurn(

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -44,8 +44,9 @@ function freshWorkspace(name: string): WorkspacePaths {
     killSignalsDir: join(stateDir, "kill-signals"),
     pidsDir: join(stateDir, "pids"),
     runsDir: join(stateDir, "runs"),
+    guardianDir: join(stateDir, "guardian"),
   };
-  for (const dir of [ws.logsDir, ws.approvalsDir, ws.killSignalsDir, ws.pidsDir, ws.runsDir]) {
+  for (const dir of [ws.logsDir, ws.approvalsDir, ws.killSignalsDir, ws.pidsDir, ws.runsDir, ws.guardianDir]) {
     mkdirSync(dir, { recursive: true });
   }
   return ws;

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -62,6 +62,7 @@ export interface WorkspacePaths {
   killSignalsDir: string;
   pidsDir: string;
   runsDir: string;
+  guardianDir: string;
 }
 
 export function getWorkspacePaths(cwd: string): WorkspacePaths {
@@ -73,9 +74,10 @@ export function getWorkspacePaths(cwd: string): WorkspacePaths {
     killSignalsDir: join(stateDir, "kill-signals"),
     pidsDir: join(stateDir, "pids"),
     runsDir: join(stateDir, "runs"),
+    guardianDir: join(stateDir, "guardian"),
   };
   // Lazily ensure workspace directories exist on first access.
-  for (const dir of [paths.logsDir, paths.approvalsDir, paths.killSignalsDir, paths.pidsDir, paths.runsDir]) {
+  for (const dir of [paths.logsDir, paths.approvalsDir, paths.killSignalsDir, paths.pidsDir, paths.runsDir, paths.guardianDir]) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
   // Ensure global data dir exists for config.json
@@ -105,6 +107,9 @@ export interface Options {
   purge: boolean;
   /** output: print only the latest turn's agent output (implies contentOnly). */
   last: boolean;
+  /** approve: override a Guardian denial instead of answering a pending
+   *  interactive approval request. */
+  guardian: boolean;
   /** threads: only threads the current session has run. */
   session: boolean;
   dir: string;
@@ -250,6 +255,7 @@ export function defaultOptions(): Options {
     detach: false,
     watch: false,
     purge: false,
+    guardian: false,
     dir: process.cwd(),
     last: false,
     session: false,
@@ -391,6 +397,8 @@ export function parseOptions(args: string[]): { positional: string[]; options: O
     } else if (arg === "--last") {
       options.last = true;
       options.contentOnly = true;
+    } else if (arg === "--guardian") {
+      options.guardian = true;
     } else if (arg === "--session") {
       options.session = true;
     } else if (arg === "--content-only") {
@@ -675,11 +683,17 @@ export async function withClient<T>(fn: (client: AppServerClient) => Promise<T>,
   }
 }
 
-export function createDispatcher(shortId: string, logsDir: string, opts: Options): EventDispatcher {
+export function createDispatcher(
+  shortId: string,
+  logsDir: string,
+  opts: Options,
+  guardianDir?: string,
+): EventDispatcher {
   return new EventDispatcher(
     shortId,
     logsDir,
     opts.contentOnly ? () => {} : progress,
+    guardianDir,
   );
 }
 

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -256,6 +256,42 @@ describe("Guardian auto-approval review events", () => {
     expect(lines[1]).toBe("Guardian approved (low risk): /bin/zsh -lc 'touch canary.txt'");
   });
 
+  test("denied review is persisted for override when guardianDir is set", () => {
+    const lines: string[] = [];
+    const guardianDir = join(TEST_LOG_DIR, "guardian");
+    const dispatcher = new EventDispatcher("guardian-deny", TEST_LOG_DIR, (line) => lines.push(line), guardianDir);
+
+    dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      threadId: "t1", turnId: "turn1", reviewId: "rev-denied-1", decisionSource: "agent",
+      review: { status: "denied", riskLevel: "high", userAuthorization: "low", rationale: "out of scope" },
+      action: { type: "command", source: "shell", command: "rm -rf /tmp/y", cwd: "/tmp" },
+    });
+
+    const persisted = JSON.parse(readFileSync(join(guardianDir, "rev-denied-1.json"), "utf8"));
+    expect(persisted.reviewId).toBe("rev-denied-1");
+    expect(persisted.threadId).toBe("t1");
+    expect(lines.some((l) => l.includes("approve --guardian rev-deni"))).toBe(true);
+  });
+
+  test("approvals and denials without guardianDir are not persisted", () => {
+    const guardianDir = join(TEST_LOG_DIR, "guardian");
+    const withDir = new EventDispatcher("guardian-ok", TEST_LOG_DIR, () => {}, guardianDir);
+    withDir.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      threadId: "t1", turnId: "turn1", reviewId: "rev-approved-1",
+      review: { status: "approved", riskLevel: "low", userAuthorization: "high", rationale: null },
+      action: { type: "command", source: "shell", command: "ls", cwd: "/tmp" },
+    });
+    expect(existsSync(join(guardianDir, "rev-approved-1.json"))).toBe(false);
+
+    const withoutDir = new EventDispatcher("guardian-nodir", TEST_LOG_DIR, () => {});
+    withoutDir.handleAutoApprovalReview("item/autoApprovalReview/completed", {
+      threadId: "t1", turnId: "turn1", reviewId: "rev-denied-2",
+      review: { status: "denied", riskLevel: "high", userAuthorization: "low", rationale: null },
+      action: { type: "command", source: "shell", command: "ls", cwd: "/tmp" },
+    });
+    expect(existsSync(join(guardianDir, "rev-denied-2.json"))).toBe(false);
+  });
+
   test("enum-shaped decision objects use their type discriminant", () => {
     const lines: string[] = [];
     const dispatcher = new EventDispatcher("guardian3", TEST_LOG_DIR, (line) => lines.push(line));

--- a/src/events.ts
+++ b/src/events.ts
@@ -8,6 +8,7 @@ import {
   type ErrorNotificationParams, type AutoApprovalReviewParams,
   type FileChange, type CommandExec,
 } from "./types";
+import { saveGuardianDenial } from "./guardian";
 
 type ProgressCallback = (line: string) => void;
 
@@ -23,15 +24,20 @@ export class EventDispatcher {
   private logBuffer: string[] = [];
   private logPath: string;
   private onProgress: ProgressCallback;
+  /** When set, denied Guardian reviews are persisted here so the user can
+   *  override them later with `approve --guardian`. */
+  private guardianDir: string | null;
 
   constructor(
     shortId: string,
     logsDir: string,
     onProgress?: ProgressCallback,
+    guardianDir?: string,
   ) {
     if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true, mode: 0o700 });
     this.logPath = join(logsDir, `${shortId}.log`);
     this.onProgress = onProgress ?? ((line) => process.stderr.write(line + "\n"));
+    this.guardianDir = guardianDir ?? null;
   }
 
   handleItemStarted(params: ItemStartedParams): void {
@@ -168,6 +174,18 @@ export class EventDispatcher {
       // decision trail (rationale, decisionSource) matters for auditing an
       // autonomous approval.
       this.log(`guardian review completed: ${safeStringify(params)}`);
+      if (decision === "denied" && this.guardianDir) {
+        try {
+          if (saveGuardianDenial(this.guardianDir, params)) {
+            this.progress(
+              `Override available: codex-collab approve --guardian ${String(params.reviewId).slice(0, 8)}`,
+            );
+          }
+        } catch (e) {
+          // Persistence is best-effort; the denial is still in the log above.
+          this.log(`failed to persist guardian denial: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
     } else {
       this.progress(`Guardian reviewing approval request${clipped ? `: ${clipped}` : ""}`);
       this.log(`guardian review started: ${safeStringify(params)}`);

--- a/src/guardian.test.ts
+++ b/src/guardian.test.ts
@@ -1,0 +1,179 @@
+// src/guardian.test.ts — Guardian denial persistence + override-event mapping
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  buildGuardianOverrideEvent,
+  describeGuardianAction,
+  listGuardianDenials,
+  mapGuardianAction,
+  markGuardianDenialOverridden,
+  resolveGuardianDenial,
+  saveGuardianDenial,
+} from "./guardian";
+import type { AutoApprovalReviewParams, GuardianDenialRecord } from "./types";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "guardian-test-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function deniedNotification(overrides: Partial<AutoApprovalReviewParams> = {}): AutoApprovalReviewParams {
+  return {
+    threadId: "thread-1",
+    turnId: "turn-1",
+    reviewId: "rev-abc123",
+    targetItemId: "call_1",
+    startedAtMs: 1000,
+    completedAtMs: 2000,
+    decisionSource: "agent",
+    review: { status: "denied", riskLevel: "medium", userAuthorization: "low", rationale: "not asked for" },
+    action: { type: "command", source: "unifiedExec", command: "touch /tmp/x", cwd: "/tmp" },
+    ...overrides,
+  };
+}
+
+function record(overrides: Partial<AutoApprovalReviewParams> = {}): GuardianDenialRecord {
+  return {
+    reviewId: "rev-abc123",
+    threadId: "thread-1",
+    receivedAt: "2026-07-04T00:00:00.000Z",
+    notification: deniedNotification(overrides),
+  };
+}
+
+describe("saveGuardianDenial / listGuardianDenials", () => {
+  test("persists and lists a denial", () => {
+    const path = saveGuardianDenial(dir, deniedNotification());
+    expect(path).not.toBeNull();
+    expect(existsSync(path!)).toBe(true);
+    const listed = listGuardianDenials(dir);
+    expect(listed).toHaveLength(1);
+    expect(listed[0].reviewId).toBe("rev-abc123");
+    expect(listed[0].threadId).toBe("thread-1");
+    expect(listed[0].overriddenAt).toBeUndefined();
+  });
+
+  test("rejects payloads without a usable reviewId or threadId", () => {
+    expect(saveGuardianDenial(dir, deniedNotification({ reviewId: undefined }))).toBeNull();
+    expect(saveGuardianDenial(dir, deniedNotification({ threadId: undefined }))).toBeNull();
+    // Path-traversal-shaped IDs must not become file paths.
+    expect(saveGuardianDenial(dir, deniedNotification({ reviewId: "../evil" }))).toBeNull();
+    expect(listGuardianDenials(dir)).toHaveLength(0);
+  });
+
+  test("skips corrupt files", () => {
+    saveGuardianDenial(dir, deniedNotification());
+    Bun.spawnSync(["sh", "-c", `echo garbage > "${join(dir, "broken.json")}"`]);
+    expect(listGuardianDenials(dir)).toHaveLength(1);
+  });
+});
+
+describe("resolveGuardianDenial", () => {
+  test("resolves by exact ID and by prefix", () => {
+    saveGuardianDenial(dir, deniedNotification());
+    expect(resolveGuardianDenial(dir, "rev-abc123")?.reviewId).toBe("rev-abc123");
+    expect(resolveGuardianDenial(dir, "rev-a")?.reviewId).toBe("rev-abc123");
+    expect(resolveGuardianDenial(dir, "nope")).toBeNull();
+  });
+
+  test("throws on ambiguous prefix, prefers exact match", () => {
+    saveGuardianDenial(dir, deniedNotification({ reviewId: "rev-1" }));
+    saveGuardianDenial(dir, deniedNotification({ reviewId: "rev-12" }));
+    expect(() => resolveGuardianDenial(dir, "rev")).toThrow(/Ambiguous/);
+    expect(resolveGuardianDenial(dir, "rev-1")?.reviewId).toBe("rev-1");
+  });
+});
+
+describe("markGuardianDenialOverridden", () => {
+  test("stamps the record and survives a reload", () => {
+    saveGuardianDenial(dir, deniedNotification());
+    markGuardianDenialOverridden(dir, "rev-abc123");
+    const reloaded = JSON.parse(readFileSync(join(dir, "rev-abc123.json"), "utf8"));
+    expect(typeof reloaded.overriddenAt).toBe("string");
+  });
+});
+
+describe("mapGuardianAction", () => {
+  // Casings verified against codex-rs 0.142 source: the core
+  // GuardianAssessmentAction is snake_case-tagged with snake_case enum
+  // values, the v2 notification camelCases both.
+  test("command / execve pass through with source value converted", () => {
+    expect(mapGuardianAction({ type: "command", source: "unifiedExec", command: "ls", cwd: "/" }))
+      .toEqual({ type: "command", source: "unified_exec", command: "ls", cwd: "/" });
+    expect(mapGuardianAction({ type: "execve", source: "shell", program: "ls", argv: ["-l"], cwd: "/" }))
+      .toEqual({ type: "execve", source: "shell", program: "ls", argv: ["-l"], cwd: "/" });
+  });
+
+  test("tag values convert camelCase → snake_case", () => {
+    expect(mapGuardianAction({ type: "applyPatch", cwd: "/", files: ["/a"] }).type).toBe("apply_patch");
+    expect(mapGuardianAction({ type: "networkAccess", target: "t", host: "h", protocol: "socks5Tcp", port: 80 }))
+      .toEqual({ type: "network_access", target: "t", host: "h", protocol: "socks5_tcp", port: 80 });
+    expect(mapGuardianAction({ type: "requestPermissions", reason: null, permissions: { network: null, file_system: null } }))
+      .toEqual({ type: "request_permissions", reason: null, permissions: { network: null, file_system: null } });
+  });
+
+  test("mcpToolCall keys convert to snake_case", () => {
+    expect(mapGuardianAction({
+      type: "mcpToolCall", server: "s", toolName: "t", connectorId: null, connectorName: null, toolTitle: "T",
+    })).toEqual({
+      type: "mcp_tool_call", server: "s", tool_name: "t", connector_id: null, connector_name: null, tool_title: "T",
+    });
+  });
+});
+
+describe("buildGuardianOverrideEvent", () => {
+  test("maps the full notification to the core snake_case event", () => {
+    expect(buildGuardianOverrideEvent(record())).toEqual({
+      id: "rev-abc123",
+      turn_id: "turn-1",
+      status: "denied",
+      target_item_id: "call_1",
+      started_at_ms: 1000,
+      completed_at_ms: 2000,
+      risk_level: "medium",
+      user_authorization: "low",
+      rationale: "not asked for",
+      decision_source: "agent",
+      action: { type: "command", source: "unified_exec", command: "touch /tmp/x", cwd: "/tmp" },
+    });
+  });
+
+  test("omits optional fields the notification lacks", () => {
+    const event = buildGuardianOverrideEvent(record({
+      targetItemId: null,
+      startedAtMs: undefined,
+      completedAtMs: undefined,
+      decisionSource: undefined,
+      review: { status: "denied", riskLevel: null, userAuthorization: null, rationale: null },
+    }));
+    expect(event).toEqual({
+      id: "rev-abc123",
+      turn_id: "turn-1",
+      status: "denied",
+      action: { type: "command", source: "unified_exec", command: "touch /tmp/x", cwd: "/tmp" },
+    });
+  });
+
+  test("rejects non-denials and missing actions", () => {
+    expect(() => buildGuardianOverrideEvent(record({
+      review: { status: "approved", riskLevel: "low", userAuthorization: "high", rationale: null },
+    }))).toThrow(/not a denial/);
+    expect(() => buildGuardianOverrideEvent(record({ action: undefined }))).toThrow(/no action/);
+  });
+});
+
+describe("describeGuardianAction", () => {
+  test("summarizes each action type", () => {
+    expect(describeGuardianAction(record())).toBe("command: touch /tmp/x");
+    expect(describeGuardianAction(record({ action: { type: "networkAccess", target: "t", host: "example.com", protocol: "https", port: 443 } })))
+      .toBe("network: example.com:443");
+    expect(describeGuardianAction(record({ action: { type: "mcpToolCall", server: "srv", toolName: "fetch" } })))
+      .toBe("mcp tool: srv/fetch");
+  });
+});

--- a/src/guardian.test.ts
+++ b/src/guardian.test.ts
@@ -160,6 +160,13 @@ describe("buildGuardianOverrideEvent", () => {
     });
   });
 
+  test("accepts the enum-shaped status the dispatcher tolerates", () => {
+    const event = buildGuardianOverrideEvent(record({
+      review: { status: { type: "denied" }, riskLevel: null, userAuthorization: null, rationale: null },
+    }));
+    expect(event.status).toBe("denied");
+  });
+
   test("rejects non-denials and missing actions", () => {
     expect(() => buildGuardianOverrideEvent(record({
       review: { status: "approved", riskLevel: "low", userAuthorization: "high", rationale: null },

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -1,0 +1,181 @@
+// src/guardian.ts — Guardian denial persistence and override-event mapping
+//
+// Guardian (`--approval auto`) denies actions autonomously. The app-server
+// exposes `thread/approveGuardianDeniedAction` to override a denial: it takes
+// the serialized core `GuardianAssessmentEvent` back and injects a developer
+// message ("The user has manually approved a specific action...") into the
+// thread without starting a turn — the agent retries on its next turn, and
+// Guardian keeps that message in its review transcript so the retry passes.
+//
+// The server does not look the event up in any history; it only checks
+// `status == "denied"` and formats the message from `event.action`. So the
+// client's job is to (1) persist each denial as it arrives and (2) map the
+// camelCase v2 notification shape back to the snake_case core event shape.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { AutoApprovalReviewParams, GuardianDenialRecord } from "./types";
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+/** Persist a denied review's notification payload for later override.
+ *  Returns the record path, or null if the payload has no usable reviewId
+ *  (the protocol is [UNSTABLE]; degrade to log-only rather than crash). */
+export function saveGuardianDenial(
+  guardianDir: string,
+  params: AutoApprovalReviewParams,
+): string | null {
+  const reviewId = typeof params.reviewId === "string" ? params.reviewId : null;
+  const threadId = typeof params.threadId === "string" ? params.threadId : null;
+  if (!reviewId || !threadId || !/^[A-Za-z0-9._-]+$/.test(reviewId)) return null;
+  const record: GuardianDenialRecord = {
+    reviewId,
+    threadId,
+    receivedAt: new Date().toISOString(),
+    notification: params,
+  };
+  mkdirSync(guardianDir, { recursive: true, mode: 0o700 });
+  const path = join(guardianDir, `${reviewId}.json`);
+  writeFileSync(path, JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
+  return path;
+}
+
+/** All persisted denials in a workspace, newest first. Unreadable files are
+ *  skipped (same tolerance as the run ledger). */
+export function listGuardianDenials(guardianDir: string): GuardianDenialRecord[] {
+  if (!existsSync(guardianDir)) return [];
+  const records: GuardianDenialRecord[] = [];
+  for (const name of readdirSync(guardianDir)) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(join(guardianDir, name), "utf8"));
+      if (typeof parsed?.reviewId === "string" && typeof parsed?.threadId === "string") {
+        records.push(parsed as GuardianDenialRecord);
+      }
+    } catch {
+      // Corrupt or partial file — skip.
+    }
+  }
+  records.sort((a, b) => (a.receivedAt < b.receivedAt ? 1 : -1));
+  return records;
+}
+
+/** Resolve a (possibly prefixed) review ID against persisted denials.
+ *  Throws on ambiguity, returns null when nothing matches. */
+export function resolveGuardianDenial(
+  guardianDir: string,
+  idOrPrefix: string,
+): GuardianDenialRecord | null {
+  const matches = listGuardianDenials(guardianDir).filter(
+    (r) => r.reviewId === idOrPrefix || r.reviewId.startsWith(idOrPrefix),
+  );
+  const exact = matches.find((r) => r.reviewId === idOrPrefix);
+  if (exact) return exact;
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous review ID prefix "${idOrPrefix}" matches: ${matches.map((r) => r.reviewId).join(", ")}`,
+    );
+  }
+  return matches[0] ?? null;
+}
+
+/** Stamp a denial record as overridden so it drops out of the pending list. */
+export function markGuardianDenialOverridden(guardianDir: string, reviewId: string): void {
+  const path = join(guardianDir, `${reviewId}.json`);
+  const record = JSON.parse(readFileSync(path, "utf8")) as GuardianDenialRecord;
+  record.overriddenAt = new Date().toISOString();
+  writeFileSync(path, JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
+}
+
+// ---------------------------------------------------------------------------
+// Wire mapping: v2 notification (camelCase) → core GuardianAssessmentEvent
+// (snake_case). Verified against codex-rs 0.142: the core struct has no
+// serde rename_all, its enums are snake_case/lowercase, and the v2 schema
+// camelCases both keys and enum values (e.g. "applyPatch", "unifiedExec",
+// "socks5Tcp"). `permissions` (RequestPermissionProfile) is the core type
+// embedded directly in the v2 schema — already snake_case, pass verbatim
+// (it is deny_unknown_fields on the server, so do NOT transform it).
+// ---------------------------------------------------------------------------
+
+const ACTION_KEY_MAP: Record<string, string> = {
+  toolName: "tool_name",
+  connectorId: "connector_id",
+  connectorName: "connector_name",
+  toolTitle: "tool_title",
+};
+
+function camelToSnake(value: string): string {
+  // serde snake_case splits on uppercase only: "socks5Tcp" → "socks5_tcp".
+  return value.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+}
+
+/** Enum-valued action fields whose camelCase wire values must be converted
+ *  (e.g. source "unifiedExec" → "unified_exec", protocol "socks5Tcp" →
+ *  "socks5_tcp"). Data fields (command, cwd, argv, ...) pass through. */
+const ACTION_ENUM_VALUE_KEYS = new Set(["type", "source", "protocol"]);
+
+/** Map the notification's action payload to the core snake_case shape. */
+export function mapGuardianAction(action: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(action)) {
+    const mappedKey = ACTION_KEY_MAP[key] ?? key;
+    out[mappedKey] =
+      ACTION_ENUM_VALUE_KEYS.has(key) && typeof value === "string" ? camelToSnake(value) : value;
+  }
+  return out;
+}
+
+/** Build the `event` param for thread/approveGuardianDeniedAction from a
+ *  persisted denial. Throws when the stored notification is missing the
+ *  pieces the server requires (id, denied status, action). */
+export function buildGuardianOverrideEvent(record: GuardianDenialRecord): Record<string, unknown> {
+  const n = record.notification;
+  const review = (n.review ?? {}) as Record<string, unknown>;
+  const status = typeof review.status === "string" ? review.status : null;
+  if (status !== "denied") {
+    throw new Error(`Review ${record.reviewId} is not a denial (status: ${status ?? "unknown"})`);
+  }
+  const action = n.action;
+  if (action === null || typeof action !== "object" || typeof (action as { type?: unknown }).type !== "string") {
+    throw new Error(`Review ${record.reviewId} has no action payload to approve`);
+  }
+
+  const event: Record<string, unknown> = {
+    id: record.reviewId,
+    turn_id: typeof n.turnId === "string" ? n.turnId : "",
+    status: "denied",
+    action: mapGuardianAction(action as Record<string, unknown>),
+  };
+  if (typeof n.targetItemId === "string") event.target_item_id = n.targetItemId;
+  if (typeof n.startedAtMs === "number") event.started_at_ms = n.startedAtMs;
+  if (typeof n.completedAtMs === "number") event.completed_at_ms = n.completedAtMs;
+  if (typeof review.riskLevel === "string") event.risk_level = review.riskLevel;
+  if (typeof review.userAuthorization === "string") event.user_authorization = review.userAuthorization;
+  if (typeof review.rationale === "string") event.rationale = review.rationale;
+  if (typeof n.decisionSource === "string") event.decision_source = camelToSnake(n.decisionSource);
+  return event;
+}
+
+/** One-line summary of a denied action for listings and progress lines. */
+export function describeGuardianAction(record: GuardianDenialRecord): string {
+  const action = (record.notification.action ?? {}) as Record<string, unknown>;
+  const type = typeof action.type === "string" ? action.type : "action";
+  switch (type) {
+    case "command":
+      return `command: ${action.command}`;
+    case "execve":
+      return `execve: ${[action.program, ...((action.argv as string[]) ?? [])].join(" ")}`;
+    case "applyPatch":
+      return `patch: ${((action.files as string[]) ?? []).join(", ")}`;
+    case "networkAccess":
+      return `network: ${action.host}:${action.port}`;
+    case "mcpToolCall":
+      return `mcp tool: ${action.server}/${action.toolName}`;
+    case "requestPermissions":
+      return `permissions request${action.reason ? `: ${action.reason}` : ""}`;
+    default:
+      return type;
+  }
+}

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -133,7 +133,17 @@ export function mapGuardianAction(action: Record<string, unknown>): Record<strin
 export function buildGuardianOverrideEvent(record: GuardianDenialRecord): Record<string, unknown> {
   const n = record.notification;
   const review = (n.review ?? {}) as Record<string, unknown>;
-  const status = typeof review.status === "string" ? review.status : null;
+  // The dispatcher tolerates enum-shaped values like { type: "denied" }
+  // (UNSTABLE protocol); accept the same shapes here so any denial it
+  // persisted can actually be overridden.
+  const rawStatus = review.status;
+  const status =
+    typeof rawStatus === "string"
+      ? rawStatus
+      : rawStatus !== null && typeof rawStatus === "object" &&
+          typeof (rawStatus as { type?: unknown }).type === "string"
+        ? (rawStatus as { type: string }).type
+        : null;
   if (status !== "denied") {
     throw new Error(`Review ${record.reviewId} is not a denial (status: ${status ?? "unknown"})`);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -396,7 +396,32 @@ export interface AutoApprovalReviewParams {
   threadId?: string;
   turnId?: string;
   itemId?: string;
+  /** Stable identifier for the review lifecycle — the handle
+   *  thread/approveGuardianDeniedAction overrides are keyed by. */
+  reviewId?: string;
+  targetItemId?: string | null;
+  startedAtMs?: number;
+  completedAtMs?: number;
+  decisionSource?: string;
+  /** Verdict: { status, riskLevel, userAuthorization, rationale }. */
+  review?: unknown;
+  /** Reviewed action, tagged by `type` (command, execve, applyPatch,
+   *  networkAccess, mcpToolCall, requestPermissions). */
+  action?: unknown;
   [key: string]: unknown;
+}
+
+/** A Guardian denial captured from item/autoApprovalReview/completed and
+ *  persisted under the workspace's guardian/ dir so the user can override
+ *  it later with `approve --guardian <review-id>`. */
+export interface GuardianDenialRecord {
+  reviewId: string;
+  threadId: string;
+  receivedAt: string;
+  /** Set once the override RPC has been sent; hides it from the pending list. */
+  overriddenAt?: string;
+  /** Raw notification payload (camelCase v2 wire shape). */
+  notification: AutoApprovalReviewParams;
 }
 
 // --- Model list ---


### PR DESCRIPTION
Closes the Guardian denial-override item in #11 (section 4).

With `--approval auto`, Guardian denies actions autonomously and the run works around them. Until now a denial was final — the only recourse was rephrasing the prompt. This exposes the app-server's `thread/approveGuardianDeniedAction` RPC so the user can overrule a specific denial.

## What's new

- **Denial persistence**: denied Guardian reviews (from `item/autoApprovalReview/completed`) are saved under the workspace's `guardian/` dir, and the progress stream shows a hint: `Override available: codex-collab approve --guardian <review-id>`.
- **`approve --guardian`** lists pending denials; **`approve --guardian <review-id>`** (prefix ok) resumes the thread and sends the override, then marks the record consumed. `decline --guardian` is rejected — a Guardian denial already is a decline.
- Review threads don't persist denials: they're ephemeral, so an override could never be applied to them after the review exits.

## Semantics (from the codex-rs source)

The RPC takes the serialized core `GuardianAssessmentEvent` back and does **not** re-execute anything: the server checks only `status == "denied"`, then injects a developer message approving that exact action into the thread without starting a turn. The agent retries on the thread's next run, and Guardian keeps the injected message in its review transcript so the retry passes. It authorizes only that specific action, not similar ones.

The mapping subtlety: the notification we receive is camelCase v2 wire shape, but the event the server expects is snake_case core shape — keys, action tags (`applyPatch` → `apply_patch`), and enum values (`unifiedExec` → `unified_exec`, `socks5Tcp` → `socks5_tcp`) all convert, except `permissions`, which is the core type embedded verbatim in the v2 schema and `deny_unknown_fields` on the server. `src/guardian.ts` owns this mapping and the persistence.

## Validation

- Live end-to-end against a real app-server: override RPC accepted, injected approval confirmed visible to the agent on the thread's next turn; already-overridden / empty-list / prefix-ambiguity guards exercised.
- Full suite 595 pass / 3 skip / 0 fail; typecheck clean.
- Enum-shaped `{ type: "denied" }` statuses (tolerated by the dispatcher; the protocol is `[UNSTABLE]`) are accepted by the override builder too, with a regression test.