### PR TITLE
feat(logs): per-run log files + versioned ledger sweep

### DIFF
--- a/src/commands/follow.test.ts
+++ b/src/commands/follow.test.ts
@@ -135,6 +135,38 @@ describe("replayBound (shared thread log)", () => {
   });
 });
 
+describe("replayBound: per-run log files", () => {
+  test("runs with their own log files never bound each other", () => {
+    const { stateDir } = freshDirs("replay-bound-per-run");
+    // Concurrent same-thread runs, each with a per-run log file — the very
+    // case shared-log offsets couldn't attribute. Neither bounds the other:
+    // each replay reads its own file to EOF.
+    const rA = { ...record("r-a", "eeee0001", "running", "2026-07-03T10:00:00.000Z"), logFile: "logs/eeee0001/run-a.log" };
+    const rB = { ...record("r-b", "eeee0001", "running", "2026-07-03T10:00:01.000Z"), logFile: "logs/eeee0001/run-b.log" };
+    createRun(stateDir, rA);
+    createRun(stateDir, rB);
+
+    const { replayBound } = require("./follow") as typeof import("./follow");
+    expect(replayBound(stateDir, rA)).toBeNull();
+    expect(replayBound(stateDir, rB)).toBeNull();
+  });
+
+  test("a per-run record does not bound a legacy shared-log record", () => {
+    const { stateDir } = freshDirs("replay-bound-mixed");
+    // Legacy record on the shared log, later run on its own file: the
+    // legacy replay owns its file's tail — the newer run's offset (0 in a
+    // different file) must not clamp it to zero bytes.
+    const legacy = { ...record("r-legacy", "eeee0002", "completed", "2026-07-03T10:00:00.000Z"), logOffset: 300 };
+    const perRun = { ...record("r-new", "eeee0002", "running", "2026-07-03T11:00:00.000Z"), logFile: "logs/eeee0002/run-new.log" };
+    createRun(stateDir, legacy);
+    createRun(stateDir, perRun);
+
+    const { replayBound } = require("./follow") as typeof import("./follow");
+    expect(replayBound(stateDir, legacy)).toBeNull();
+    expect(replayBound(stateDir, perRun)).toBeNull();
+  });
+});
+
 describe("replayBound: zero-byte runs (equal logOffset)", () => {
   test("a run that wrote nothing is bounded at its own offset by the next run", () => {
     const { stateDir } = freshDirs("replay-bound-empty");

--- a/src/commands/follow.test.ts
+++ b/src/commands/follow.test.ts
@@ -167,6 +167,29 @@ describe("replayBound: per-run log files", () => {
   });
 });
 
+describe("replayBound: absolute vs relative logFile (migration records)", () => {
+  test("an absolute-path record bounds a relative-path record for the same file", () => {
+    const { stateDir } = freshDirs("replay-bound-abs-rel");
+    // Migration-created synthetic records store the shared log as an
+    // ABSOLUTE path; later pre-per-run records store the same physical file
+    // as stateDir-relative "logs/{shortId}.log". They must group as one
+    // file, or the older run's replay is unbounded and swallows the newer
+    // run's entries.
+    const relative = { ...record("r-rel", "ffff9001", "completed", "2026-07-03T10:00:00.000Z"), logOffset: 0 };
+    const absolute = {
+      ...record("r-abs", "ffff9001", "completed", "2026-07-03T11:00:00.000Z"),
+      logFile: join(stateDir, "logs", "ffff9001.log"),
+      logOffset: 400,
+    };
+    createRun(stateDir, relative);
+    createRun(stateDir, absolute);
+
+    const { replayBound } = require("./follow") as typeof import("./follow");
+    expect(replayBound(stateDir, relative)).toBe(400);
+    expect(replayBound(stateDir, absolute)).toBeNull();
+  });
+});
+
 describe("replayBound: zero-byte runs (equal logOffset)", () => {
   test("a run that wrote nothing is bounded at its own offset by the next run", () => {
     const { stateDir } = freshDirs("replay-bound-empty");

--- a/src/commands/follow.ts
+++ b/src/commands/follow.ts
@@ -11,6 +11,7 @@
 // detached — and survives broker handoffs.
 
 import { openSync, readSync, closeSync, fstatSync } from "fs";
+import { resolve } from "path";
 import {
   findShortId,
   listRuns,
@@ -169,10 +170,17 @@ function laterThan(a: RunRecord, b: RunRecord): boolean {
  * Exported for tests.
  */
 export function replayBound(stateDir: string, run: RunRecord): number | null {
+  // Canonicalize before comparing: migration-created records store logFile
+  // as an absolute path while normal legacy records store the same physical
+  // file as a stateDir-relative "logs/{shortId}.log" — a raw string compare
+  // would fail to group them and leave the older run's replay unbounded.
+  const logFileOf = (r: RunRecord): string | null =>
+    r.logFile ? resolve(stateDir, r.logFile) : null;
+  const runLogFile = logFileOf(run);
   let bound: number | null = null;
   for (const r of listRunsForThread(stateDir, run.shortId)) {
     if (r.runId === run.runId) continue;
-    if ((r.logFile || null) !== (run.logFile || null)) continue;
+    if (logFileOf(r) !== runLogFile) continue;
     const later = r.logOffset > run.logOffset
       || (r.logOffset === run.logOffset && laterThan(r, run));
     if (later && (bound === null || r.logOffset < bound)) {

--- a/src/commands/follow.ts
+++ b/src/commands/follow.ts
@@ -18,7 +18,7 @@ import {
   loadRun,
   loadThreadIndex,
 } from "../threads";
-import { resolveReadableLogPath } from "./threads";
+import { resolveRunLogPath } from "./threads";
 import { LogEntryParser, renderEntry, renderFinalStatus, type RenderOptions } from "../render";
 import type { RunRecord } from "../types";
 import {
@@ -156,10 +156,11 @@ function laterThan(a: RunRecord, b: RunRecord): boolean {
 }
 
 /**
- * Where this run's section of the shared thread log ends: the smallest
- * logOffset of any LATER run on the same thread, or null (unbounded — this
- * run owns the log's tail). Runs on one thread append to one log file, so a
- * replay that read to EOF would swallow the next run's entries and the
+ * Where this run's section of its log file ends: the smallest logOffset of
+ * any LATER run writing to the SAME file, or null (unbounded — this run owns
+ * the file's tail). Per-run records own their file exclusively, so the bound
+ * is always null for them; legacy records share `logs/{shortId}.log`, where
+ * a replay that read to EOF would swallow the next run's entries and the
  * watch loop would then render them a second time.
  *
  * "Later" must include runs at the SAME offset: a run that dies before
@@ -171,6 +172,7 @@ export function replayBound(stateDir: string, run: RunRecord): number | null {
   let bound: number | null = null;
   for (const r of listRunsForThread(stateDir, run.shortId)) {
     if (r.runId === run.runId) continue;
+    if ((r.logFile || null) !== (run.logFile || null)) continue;
     const later = r.logOffset > run.logOffset
       || (r.logOffset === run.logOffset && laterThan(r, run));
     if (later && (bound === null || r.logOffset < bound)) {
@@ -230,9 +232,9 @@ interface FollowOutcome {
  *  (replay + live tail). Prints the header and the final status line. */
 async function followRun(ws: WorkspacePaths, run: RunRecord, render: RenderOptions): Promise<FollowOutcome> {
   const shortId = run.shortId;
-  // Same resolution as `output`: prefer the workspace log, fall back to the
-  // run record's logFile for migrated runs whose log lives elsewhere.
-  const logPath = resolveReadableLogPath(ws.stateDir, ws.logsDir, shortId);
+  // The run's own log file (per-run records) or the shared thread log
+  // (legacy records / migration fallback), confined to the logs dirs.
+  const logPath = resolveRunLogPath(ws.stateDir, ws.logsDir, run);
   // Computed fresh before every read (loop top and finish) — see below.
   let bound: number | null = null;
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,7 +1,8 @@
 // src/commands/review.ts — review command handler
 
+import { join } from "path";
 import { runReview } from "../turns";
-import { updateThreadStatus } from "../threads";
+import { updateThreadStatus, runLogRelPath } from "../threads";
 import { getDefaultBranch } from "../git";
 import type { ReviewTarget } from "../types";
 import { wrapBrokerBusy } from "../broker";
@@ -104,7 +105,7 @@ export async function handleReview(args: string[]): Promise<void> {
     // server-side), so a Guardian denial here could not be overridden later —
     // thread/resume on the dead thread would fail. Denials still show in the
     // progress stream and log.
-    const dispatcher = createDispatcher(shortId, ws.logsDir, options);
+    const dispatcher = createDispatcher(join(ws.stateDir, runLogRelPath(shortId, runId)), options);
 
     // Note: model/cwd/approval/sandbox already reached the server via the
     // thread start/fork params in startOrResumeThread; review/start itself

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,7 +3,7 @@
 import { spawn as childSpawn, spawnSync } from "node:child_process";
 import { openSync, closeSync, readFileSync } from "fs";
 import { join } from "path";
-import { updateThreadStatus, generateRunId, loadRun, updateRun } from "../threads";
+import { updateThreadStatus, generateRunId, loadRun, updateRun, runLogRelPath } from "../threads";
 import { runTurn } from "../turns";
 import { config, loadTemplateWithMeta, interpolateTemplate, type SandboxMode } from "../config";
 import { wrapBrokerBusy, isBrokerBusyError } from "../broker";
@@ -248,7 +248,7 @@ export async function handleRun(args: string[]): Promise<void> {
     setActiveRunId(runId);
     writePidFile(ws.pidsDir, shortId);
 
-    const dispatcher = createDispatcher(shortId, ws.logsDir, options, ws.guardianDir);
+    const dispatcher = createDispatcher(join(ws.stateDir, runLogRelPath(shortId, runId)), options, ws.guardianDir);
 
     try {
       const result = await runTurn(

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -20,7 +20,7 @@ import {
   type WorkspacePaths,
   type Options,
 } from "./shared";
-import { createRun, loadRun } from "../threads";
+import { createRun, loadRun, registerThread } from "../threads";
 import { config } from "../config";
 import type { AppServerClient } from "../client";
 import type { Model, ThreadStartResponse } from "../types";
@@ -1261,8 +1261,50 @@ describe("startOrResumeThread", () => {
         approvalPolicy: "on-request",
         approvalsReviewer: "user",
         sandbox: "read-only",
+        // review_model pin: Codex would otherwise prefer its own config.toml
+        // review_model over the model we requested for this review.
+        config: { review_model: "gpt-5" },
       },
     });
+  });
+
+  test("review --resume without --model pins review_model to the thread's last known model", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const sourceThreadId = "01900000000070008000000000000003";
+    const forkedThreadId = "01900000000070008000000000000004";
+    const client = recordingClient(calls, {
+      "thread/fork": () => threadStartResponse(forkedThreadId, "/tmp/proj"),
+    });
+    const ws = freshWorkspace("review-resume-fork-index-model");
+    const shortId = registerThread(ws.stateDir, sourceThreadId, { model: "gpt-5.3-codex" });
+
+    const opts = defaultOptions();
+    opts.resumeId = shortId;
+    opts.dir = "/tmp/proj";
+
+    await startOrResumeThread(client, opts, ws, { sandbox: "read-only" }, "Review PR", true);
+
+    const fork = calls.find(c => c.method === "thread/fork");
+    expect(fork?.params).toMatchObject({ config: { review_model: "gpt-5.3-codex" } });
+  });
+
+  test("review --resume of an unknown external thread sends no review_model pin", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const externalThreadId = "01900000000070008000000000000005";
+    const forkedThreadId = "01900000000070008000000000000006";
+    const client = recordingClient(calls, {
+      "thread/fork": () => threadStartResponse(forkedThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.resumeId = externalThreadId;
+    opts.dir = "/tmp/proj";
+
+    await startOrResumeThread(
+      client, opts, freshWorkspace("review-resume-external"), { sandbox: "read-only" }, "Review PR", true,
+    );
+
+    const fork = calls.find(c => c.method === "thread/fork");
+    expect((fork?.params as Record<string, unknown>).config).toBeUndefined();
   });
 
   /** Mock client that records calls and answers from a method→response map.
@@ -1310,6 +1352,33 @@ describe("startOrResumeThread", () => {
     });
     const memory = calls.find(c => c.method === "thread/memoryMode/set");
     expect(memory?.params).toEqual({ threadId: newThreadId, mode: "disabled" });
+  });
+
+  test("fresh review thread pins review_model to the resolved model; plain runs don't", async () => {
+    const reviewCalls: Array<{ method: string; params: unknown }> = [];
+    const reviewClient = recordingClient(reviewCalls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+    opts.model = "gpt-5.3-codex";
+
+    await startOrResumeThread(
+      reviewClient, opts, freshWorkspace("review-start-model-pin"), { sandbox: "read-only" }, "Review PR", true,
+    );
+    const reviewStart = reviewCalls.find(c => c.method === "thread/start");
+    expect(reviewStart?.params).toMatchObject({
+      model: "gpt-5.3-codex",
+      config: { review_model: "gpt-5.3-codex" },
+    });
+
+    const runCalls: Array<{ method: string; params: unknown }> = [];
+    const runClient = recordingClient(runCalls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    await startOrResumeThread(runClient, opts, freshWorkspace("run-start-no-pin"), undefined, "task", false);
+    const runStart = runCalls.find(c => c.method === "thread/start");
+    expect((runStart?.params as Record<string, unknown>).config).toBeUndefined();
   });
 
   test("new thread with --memory: no memoryMode call", async () => {

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -41,7 +41,6 @@ import {
   readFileSync,
   writeFileSync,
   unlinkSync,
-  statSync,
 } from "fs";
 import { resolve, join, dirname } from "path";
 import type {

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -20,6 +20,7 @@ import {
   updateThreadStatus,
   generateRunId,
   runLogRelPath,
+  ensureLedgerVersion,
   createRun,
   updateRun,
   loadRun,
@@ -85,6 +86,9 @@ export function getWorkspacePaths(cwd: string): WorkspacePaths {
   mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
   // Migrate legacy global state to per-workspace layout (idempotent)
   migrateGlobalState(cwd);
+  // One-time run-ledger sweep (legacy "cancelled" → "interrupted"); cheap
+  // version-marker check on every subsequent access.
+  ensureLedgerVersion(stateDir);
   return paths;
 }
 

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -16,6 +16,7 @@ import {
   registerThread,
   resolveThreadId,
   findShortId,
+  loadThreadIndex,
   updateThreadMeta,
   updateThreadStatus,
   generateRunId,
@@ -854,6 +855,18 @@ export async function startOrResumeThread(
       if (opts.explicit.has("model")) forkParams.model = opts.model;
       if (opts.explicit.has("dir")) forkParams.cwd = opts.dir;
       if (opts.explicit.has("approval")) Object.assign(forkParams, resolveApproval(opts.approval));
+      // Codex resolves the review sub-agent's model from its own
+      // `review_model` config key before falling back to the thread's model,
+      // so a review_model in ~/.codex/config.toml would silently override the
+      // model requested here. Pin review_model to the model this review runs
+      // as: the explicit flag, else the thread's last known model. External
+      // threads with no local record get no pin.
+      const reviewModel = opts.explicit.has("model")
+        ? opts.model
+        : resolved
+          ? loadThreadIndex(ws.stateDir)[resolved.shortId]?.model
+          : undefined;
+      if (reviewModel) forkParams.config = { review_model: reviewModel };
       // Reviews must run in read-only mode. `thread/resume.sandbox` is not
       // reliable for already-loaded broker threads, and `review/start` has no
       // per-turn sandbox override, so fork the resumed context into a fresh
@@ -909,6 +922,10 @@ export async function startOrResumeThread(
       ...extraStartParams,
     };
     if (opts.model) startParams.model = opts.model;
+    // Same review_model pin as the fork path above: without it, a
+    // review_model in ~/.codex/config.toml would win over the model shown in
+    // our own "started for review" progress line.
+    if (isReview && opts.model) startParams.config = { review_model: opts.model };
     effective = await client.request<ThreadStartResponse>(
       "thread/start",
       startParams,

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -19,6 +19,7 @@ import {
   updateThreadMeta,
   updateThreadStatus,
   generateRunId,
+  runLogRelPath,
   createRun,
   updateRun,
   loadRun,
@@ -684,14 +685,12 @@ export async function withClient<T>(fn: (client: AppServerClient) => Promise<T>,
 }
 
 export function createDispatcher(
-  shortId: string,
-  logsDir: string,
+  logPath: string,
   opts: Options,
   guardianDir?: string,
 ): EventDispatcher {
   return new EventDispatcher(
-    shortId,
-    logsDir,
+    logPath,
     opts.contentOnly ? () => {} : progress,
     guardianDir,
   );
@@ -953,8 +952,6 @@ export async function startOrResumeThread(
   const prompt = preview ?? null;
   const runId = consumeInjectedRunId() ?? generateRunId();
   const sessionId = getCurrentSessionId(ws.stateDir);
-  const logPath = join(ws.logsDir, `${shortId}.log`);
-  const logOffset = existsSync(logPath) ? statSync(logPath).size : 0;
 
   createRun(ws.stateDir, {
     runId,
@@ -965,8 +962,11 @@ export async function startOrResumeThread(
     status: "running",
     pid: process.pid,
     sessionId,
-    logFile: `logs/${shortId}.log`,
-    logOffset,
+    // Per-run log file: this run owns it exclusively, so followers get
+    // perfect attribution even when runs on one thread overlap. logOffset
+    // stays for legacy records that share logs/{shortId}.log.
+    logFile: runLogRelPath(shortId, runId),
+    logOffset: 0,
     prompt,
     model: effective.model,
     startedAt: new Date().toISOString(),

--- a/src/commands/threads.test.ts
+++ b/src/commands/threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { applyDiscoverLimit, resolveReadableLogPath, resolveRunLogPath, collectThreadLogPaths, readThreadLog } from "./threads";
+import { applyDiscoverLimit, resolveRunLogPath, collectThreadLogPaths, readThreadLog } from "./threads";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -25,89 +25,6 @@ describe("applyDiscoverLimit", () => {
   test("returns Infinity when discover=false and --all", () => {
     const opts = { discover: false, limit: Infinity, explicit: new Set(["limit"]) };
     expect(applyDiscoverLimit(opts)).toBe(Infinity);
-  });
-});
-
-// resolveReadableLogPath addresses the migration-edge-case Codex flagged:
-// if migration's copyFileSync from {dataDir}/logs to {stateDir}/logs ever fails,
-// the run record stores the legacy global path as `logFile` and no workspace-
-// local log file exists. With the migration marker stamped, migration never
-// retries the copy. `output`/`progress` previously read only the workspace-
-// local path → empty/missing. The fallback resolves to the run record's
-// logFile when the workspace file is absent so the user can still read the log.
-describe("resolveReadableLogPath", () => {
-  let stateDir: string;
-  let logsDir: string;
-  let legacyLogsDir: string;
-  let legacyLog: string;
-
-  beforeEach(() => {
-    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    stateDir = join(tmpdir(), `codex-resolvable-log-${suffix}`);
-    logsDir = join(stateDir, "logs");
-    legacyLogsDir = join(tmpdir(), `codex-resolvable-legacy-${suffix}`);
-    legacyLog = join(legacyLogsDir, "abcd1234.log");
-    mkdirSync(logsDir, { recursive: true });
-    mkdirSync(legacyLogsDir, { recursive: true });
-  });
-
-  afterEach(() => {
-    if (existsSync(stateDir)) rmSync(stateDir, { recursive: true });
-    if (existsSync(legacyLogsDir)) rmSync(legacyLogsDir, { recursive: true });
-  });
-
-  function record(shortId: string, logFile: string): RunRecord {
-    return {
-      runId: `r-${shortId}`, threadId: `t-${shortId}`, shortId,
-      kind: "task", phase: null, status: "completed", sessionId: null,
-      logFile, logOffset: 0, prompt: null, model: null,
-      startedAt: "2026-01-01T00:00:00Z", completedAt: "2026-01-01T00:00:01Z",
-      elapsed: null, output: null, filesChanged: null, commandsRun: null, error: null,
-    };
-  }
-
-  test("prefers the workspace-local log when it exists", () => {
-    const ws = join(logsDir, "abcd1234.log");
-    writeFileSync(ws, "ws content");
-    writeFileSync(legacyLog, "legacy content");
-    createRun(stateDir, record("abcd1234", legacyLog));
-    expect(resolveReadableLogPath(stateDir, logsDir, "abcd1234", legacyLogsDir)).toBe(ws);
-  });
-
-  test("falls back to the run record's logFile when the workspace log is absent", () => {
-    // The migration-copy-failure scenario: no {logsDir}/<shortId>.log on disk;
-    // the run record points at the legacy global location, which still exists.
-    writeFileSync(legacyLog, "legacy content");
-    createRun(stateDir, record("abcd1234", legacyLog));
-    expect(resolveReadableLogPath(stateDir, logsDir, "abcd1234", legacyLogsDir)).toBe(legacyLog);
-  });
-
-  test("returns the workspace path (for downstream not-found handling) when neither file exists", () => {
-    createRun(stateDir, record("abcd1234", legacyLog)); // logFile points nowhere
-    const expected = join(logsDir, "abcd1234.log");
-    expect(resolveReadableLogPath(stateDir, logsDir, "abcd1234", legacyLogsDir)).toBe(expected);
-  });
-
-  test("returns the workspace path when no run record exists", () => {
-    const expected = join(logsDir, "abcd1234.log");
-    expect(resolveReadableLogPath(stateDir, logsDir, "abcd1234", legacyLogsDir)).toBe(expected);
-  });
-
-  test("refuses fallback paths outside both workspace and legacy logs roots", () => {
-    // Confinement: a run record carrying an arbitrary absolute path (corrupted
-    // state, adversarial input, file moved aside) must not let `output` or
-    // `progress` happily print contents from anywhere on the filesystem.
-    const evilDir = join(tmpdir(), `codex-resolvable-evil-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-    mkdirSync(evilDir, { recursive: true });
-    const evilLog = join(evilDir, "outside.log");
-    writeFileSync(evilLog, "should not be readable");
-    try {
-      createRun(stateDir, record("abcd1234", evilLog));
-      const expected = join(logsDir, "abcd1234.log");
-      expect(resolveReadableLogPath(stateDir, logsDir, "abcd1234", legacyLogsDir)).toBe(expected);
-    } finally {
-      rmSync(evilDir, { recursive: true });
-    }
   });
 });
 

--- a/src/commands/threads.test.ts
+++ b/src/commands/threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { applyDiscoverLimit, resolveReadableLogPath } from "./threads";
+import { applyDiscoverLimit, resolveReadableLogPath, resolveRunLogPath, collectThreadLogPaths, readThreadLog } from "./threads";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -108,6 +108,78 @@ describe("resolveReadableLogPath", () => {
     } finally {
       rmSync(evilDir, { recursive: true });
     }
+  });
+});
+
+describe("per-run log reading (resolveRunLogPath / collectThreadLogPaths / readThreadLog)", () => {
+  let stateDir: string;
+  let logsDir: string;
+
+  beforeEach(() => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    stateDir = join(tmpdir(), `codex-per-run-log-${suffix}`);
+    logsDir = join(stateDir, "logs");
+    mkdirSync(logsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(stateDir)) rmSync(stateDir, { recursive: true });
+  });
+
+  function record(shortId: string, runId: string, logFile: string): RunRecord {
+    return {
+      runId, threadId: `t-${shortId}`, shortId,
+      kind: "task", phase: null, status: "completed", sessionId: null,
+      logFile, logOffset: 0, prompt: null, model: null,
+      startedAt: "2026-01-01T00:00:00Z", completedAt: "2026-01-01T00:00:01Z",
+      elapsed: null, output: null, filesChanged: null, commandsRun: null, error: null,
+    };
+  }
+
+  test("resolveRunLogPath resolves the record's own confined logFile", () => {
+    const rec = record("aaaa1111", "run-1", "logs/aaaa1111/run-1.log");
+    expect(resolveRunLogPath(stateDir, logsDir, rec)).toBe(join(logsDir, "aaaa1111", "run-1.log"));
+  });
+
+  test("resolveRunLogPath refuses an escaping logFile and falls back to the thread log", () => {
+    const rec = record("aaaa2222", "run-1", "../../../etc/passwd");
+    expect(resolveRunLogPath(stateDir, logsDir, rec)).toBe(join(logsDir, "aaaa2222.log"));
+  });
+
+  test("collectThreadLogPaths orders legacy shared log before per-run files, per-run sorted by name", () => {
+    const shortId = "bbbb1111";
+    writeFileSync(join(logsDir, `${shortId}.log`), "legacy\n");
+    mkdirSync(join(logsDir, shortId), { recursive: true });
+    // base36-timestamp runIds sort chronologically by name
+    writeFileSync(join(logsDir, shortId, "run-b-second.log"), "second\n");
+    writeFileSync(join(logsDir, shortId, "run-a-first.log"), "first\n");
+
+    expect(collectThreadLogPaths(stateDir, logsDir, shortId)).toEqual([
+      join(logsDir, `${shortId}.log`),
+      join(logsDir, shortId, "run-a-first.log"),
+      join(logsDir, shortId, "run-b-second.log"),
+    ]);
+    expect(readThreadLog(stateDir, logsDir, shortId)).toBe("legacy\nfirst\nsecond\n");
+  });
+
+  test("readThreadLog returns null for a thread with no logs", () => {
+    expect(readThreadLog(stateDir, logsDir, "cccc1111")).toBeNull();
+  });
+
+  test("collectThreadLogPaths falls back to the migration-edge global log via the run record", () => {
+    // No workspace logs at all; the latest run record points at a legacy
+    // global-path log (the resolveReadableLogPath edge case).
+    const globalDir = join(stateDir, "global-logs");
+    mkdirSync(globalDir, { recursive: true });
+    const globalLog = join(globalDir, "dddd1111.log");
+    writeFileSync(globalLog, "global content\n");
+    createRun(stateDir, record("dddd1111", "run-1", globalLog));
+
+    const paths = collectThreadLogPaths(stateDir, logsDir, "dddd1111");
+    // resolveReadableLogPath confines to logsDir + config.logsDir; a path
+    // under stateDir/global-logs is OUTSIDE both, so the fallback must
+    // refuse it — an empty list, not an escape.
+    expect(paths).toEqual([]);
   });
 });
 

--- a/src/commands/threads.test.ts
+++ b/src/commands/threads.test.ts
@@ -166,6 +166,27 @@ describe("per-run log reading (resolveRunLogPath / collectThreadLogPaths / readT
     expect(readThreadLog(stateDir, logsDir, "cccc1111")).toBeNull();
   });
 
+  test("migration-edge global log survives alongside newer per-run files", () => {
+    // The copy-failed migration case: the only pre-resume history lives in
+    // the legacy GLOBAL logs dir (via the synthetic run record's logFile).
+    // Resuming the thread creates per-run logs — the global history must
+    // still be included, not dropped once per-run files exist.
+    const shortId = "eeee1111";
+    const globalLogsDir = join(stateDir, "fake-global-logs");
+    mkdirSync(globalLogsDir, { recursive: true });
+    const globalLog = join(globalLogsDir, `${shortId}.log`);
+    writeFileSync(globalLog, "pre-resume history\n");
+    createRun(stateDir, record(shortId, "run-0-migrated", globalLog));
+    mkdirSync(join(logsDir, shortId), { recursive: true });
+    writeFileSync(join(logsDir, shortId, "run-1-resumed.log"), "post-resume\n");
+    createRun(stateDir, record(shortId, "run-1-resumed", `logs/${shortId}/run-1-resumed.log`));
+
+    expect(collectThreadLogPaths(stateDir, logsDir, shortId, globalLogsDir)).toEqual([
+      globalLog,
+      join(logsDir, shortId, "run-1-resumed.log"),
+    ]);
+  });
+
   test("collectThreadLogPaths falls back to the migration-edge global log via the run record", () => {
     // No workspace logs at all; the latest run record points at a legacy
     // global-path log (the resolveReadableLogPath edge case).
@@ -176,9 +197,9 @@ describe("per-run log reading (resolveRunLogPath / collectThreadLogPaths / readT
     createRun(stateDir, record("dddd1111", "run-1", globalLog));
 
     const paths = collectThreadLogPaths(stateDir, logsDir, "dddd1111");
-    // resolveReadableLogPath confines to logsDir + config.logsDir; a path
-    // under stateDir/global-logs is OUTSIDE both, so the fallback must
-    // refuse it — an empty list, not an escape.
+    // The record scan confines to logsDir + the global logs dir; a path
+    // under stateDir/global-logs is OUTSIDE both (config.logsDir default),
+    // so it must be refused — an empty list, not an escape.
     expect(paths).toEqual([]);
   });
 });

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -214,49 +214,10 @@ export async function handleThreads(args: string[]): Promise<void> {
 // output
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve a thread's log path for reading, preferring the workspace-local
- * file but falling back to the run record's `logFile` if the workspace file
- * is absent.
- *
- * This handles the migration edge case: if `migrateGlobalState`'s
- * `copyFileSync` from the legacy `{dataDir}/logs` to `{stateDir}/logs` ever
- * fails (rare — transient I/O or restrictive source perms), the run record's
- * `logFile` falls back to the legacy global path while no workspace-local
- * file is created. With the migration marker stamped, migration won't retry
- * the copy — so without this fallback, `output` and `progress` would return
- * an empty/missing-file diagnostic even though the log content still exists
- * at the legacy path. (Run records created by normal turns store `logFile`
- * as a workspace-relative `logs/<shortId>.log` — see commands/shared.ts's
- * createRun call; legacy/migration synthetic records may instead carry an
- * absolute global path. `resolve(stateDir, …)` handles both cases.)
- *
- * The fallback is confined to the workspace `logsDir` or the legacy
- * `globalLogsDir` (defaults to `~/.codex-collab/logs`) so a corrupted or
- * adversarial run record cannot point us at arbitrary filesystem paths
- * (mirrors the confinement in pruneRuns' resolveLogFile).
- */
-export function resolveReadableLogPath(
-  stateDir: string,
-  logsDir: string,
-  shortId: string,
-  globalLogsDir: string = config.logsDir,
-): string {
-  const wsLog = join(logsDir, `${shortId}.log`);
-  if (existsSync(wsLog)) return wsLog;
-  const latest = getLatestRun(stateDir, shortId);
-  if (latest && latest.logFile) {
-    const fallback = resolve(stateDir, latest.logFile);
-    const confined = isPathInside(fallback, resolve(logsDir))
-      || isPathInside(fallback, resolve(globalLogsDir));
-    if (confined && existsSync(fallback)) return fallback;
-  }
-  return wsLog; // let the caller's existing not-found handling fire
-}
-
 /** Resolve one run's own log file: the record's `logFile` (confined to the
- *  workspace or legacy-global logs dirs, like resolveReadableLogPath), with
- *  the shared thread log as the legacy fallback. Per-run records always
+ *  workspace or legacy-global logs dirs so a corrupted or adversarial run
+ *  record cannot point us at arbitrary filesystem paths), with the shared
+ *  thread log as the legacy fallback. Per-run records always
  *  point inside `logs/{shortId}/`; legacy records point at the shared file
  *  or (migration edge) an absolute global path. */
 export function resolveRunLogPath(

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -19,6 +19,9 @@ import {
   existsSync,
   readFileSync,
   readdirSync,
+  rmdirSync,
+  rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
@@ -250,19 +253,73 @@ export function resolveReadableLogPath(
   return wsLog; // let the caller's existing not-found handling fire
 }
 
-/** Resolve a positional ID arg to a log file path (and shortId), or die. */
-function resolveLogPath(
+/** Resolve one run's own log file: the record's `logFile` (confined to the
+ *  workspace or legacy-global logs dirs, like resolveReadableLogPath), with
+ *  the shared thread log as the legacy fallback. Per-run records always
+ *  point inside `logs/{shortId}/`; legacy records point at the shared file
+ *  or (migration edge) an absolute global path. */
+export function resolveRunLogPath(
+  stateDir: string,
+  logsDir: string,
+  run: RunRecord,
+  globalLogsDir: string = config.logsDir,
+): string {
+  if (run.logFile) {
+    const candidate = resolve(stateDir, run.logFile);
+    const confined = isPathInside(candidate, resolve(logsDir))
+      || isPathInside(candidate, resolve(globalLogsDir));
+    if (confined) return candidate;
+  }
+  return join(logsDir, `${run.shortId}.log`);
+}
+
+/** All log files for a thread in chronological order: the legacy shared
+ *  `logs/{shortId}.log` (pre-per-run history) first, then the per-run files
+ *  under `logs/{shortId}/` — their base36-timestamp runId names make the
+ *  sorted directory listing chronological. Empty when the thread has no
+ *  logs; the resolveReadableLogPath fallback covers the migration edge
+ *  where the only copy lives in the legacy global logs dir. */
+export function collectThreadLogPaths(
+  stateDir: string,
+  logsDir: string,
+  shortId: string,
+): string[] {
+  const paths: string[] = [];
+  const legacy = join(logsDir, `${shortId}.log`);
+  if (existsSync(legacy)) paths.push(legacy);
+  const runDir = join(logsDir, shortId);
+  if (existsSync(runDir)) {
+    for (const name of readdirSync(runDir).sort()) {
+      if (name.endsWith(".log")) paths.push(join(runDir, name));
+    }
+  }
+  if (paths.length === 0) {
+    const fallback = resolveReadableLogPath(stateDir, logsDir, shortId);
+    if (existsSync(fallback)) paths.push(fallback);
+  }
+  return paths;
+}
+
+/** Concatenated log content for a thread, or null when it has none. */
+export function readThreadLog(stateDir: string, logsDir: string, shortId: string): string | null {
+  const paths = collectThreadLogPaths(stateDir, logsDir, shortId);
+  if (paths.length === 0) return null;
+  return paths.map((p) => readFileSync(p, "utf-8")).join("");
+}
+
+/** Resolve a positional ID arg to its shortId, or die. */
+function resolveLogTarget(
   positional: string[],
   usage: string,
   ws: ReturnType<typeof getWorkspacePaths>,
-): { logPath: string; shortId: string } {
+): { shortId: string } {
   const id = positional[0];
   if (!id) die(usage);
   validateIdOrDie(id);
   const threadId = resolveThreadIdOrDie(ws.stateDir, id);
   const shortId = findShortId(ws.stateDir, threadId);
   if (!shortId) die(`Thread not found: ${id}`);
-  return { logPath: resolveReadableLogPath(ws.stateDir, ws.logsDir, shortId), shortId };
+  return { shortId };
 }
 
 /** Extract agent output blocks from a thread log, one string per turn.
@@ -328,10 +385,10 @@ export function pickLastOutput(rec: RunRecord | null, logContent: string): LastO
 export async function handleOutput(args: string[]): Promise<void> {
   const { positional, options } = parseOptions(args);
   const ws = getWorkspacePaths(options.dir);
-  const { logPath, shortId } = resolveLogPath(positional, "Usage: codex-collab output <id>", ws);
+  const { shortId } = resolveLogTarget(positional, "Usage: codex-collab output <id>", ws);
   // The log may not exist yet for a just-started run — for --last the run
   // record is authoritative, so only the log-reading modes require the file.
-  const content = existsSync(logPath) ? readFileSync(logPath, "utf-8") : null;
+  const content = readThreadLog(ws.stateDir, ws.logsDir, shortId);
   if (options.last) {
     const res = pickLastOutput(getLatestRun(ws.stateDir, shortId), content ?? "");
     if (res.kind === "none") {
@@ -360,14 +417,15 @@ export async function handleOutput(args: string[]): Promise<void> {
 export async function handleProgress(args: string[]): Promise<void> {
   const { positional, options } = parseOptions(args);
   const ws = getWorkspacePaths(options.dir);
-  const { logPath } = resolveLogPath(positional, "Usage: codex-collab progress <id>", ws);
-  if (!existsSync(logPath)) {
+  const { shortId } = resolveLogTarget(positional, "Usage: codex-collab progress <id>", ws);
+  const content = readThreadLog(ws.stateDir, ws.logsDir, shortId);
+  if (content === null) {
     console.log("No activity yet.");
     return;
   }
 
   // Show last 20 lines
-  const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+  const lines = content.trim().split("\n");
   console.log(lines.slice(-20).join("\n"));
 }
 
@@ -453,6 +511,8 @@ export async function handleDelete(args: string[]): Promise<void> {
     removePidFile(ws.pidsDir, shortId);
     const logPath = join(ws.logsDir, `${shortId}.log`);
     if (existsSync(logPath)) unlinkSync(logPath);
+    // Per-run log files live under logs/{shortId}/ and die with the thread.
+    rmSync(join(ws.logsDir, shortId), { recursive: true, force: true });
     removeThread(ws.stateDir, shortId);
     // Run records must go with the thread: a stale `running` record whose
     // PID file is gone reads as alive and would make bare `follow` hang.
@@ -477,14 +537,25 @@ export async function handleDelete(args: string[]): Promise<void> {
 // clean
 // ---------------------------------------------------------------------------
 
-/** Delete files older than maxAgeMs in the given directory. Returns count deleted. */
-function deleteOldFiles(dir: string, maxAgeMs: number): number {
+/** Delete files older than maxAgeMs in the given directory. With `recurse`,
+ *  descend one level into subdirectories (per-run log dirs under logs/) and
+ *  remove any left empty. Returns count deleted. */
+function deleteOldFiles(dir: string, maxAgeMs: number, recurse = false): number {
   if (!existsSync(dir)) return 0;
   const now = Date.now();
   let deleted = 0;
   for (const file of readdirSync(dir)) {
     const path = join(dir, file);
     try {
+      if (statSync(path).isDirectory()) {
+        if (recurse) {
+          deleted += deleteOldFiles(path, maxAgeMs);
+          try {
+            rmdirSync(path); // only succeeds when empty
+          } catch { /* still has fresh logs */ }
+        }
+        continue;
+      }
       if (now - Bun.file(path).lastModified > maxAgeMs) {
         unlinkSync(path);
         deleted++;
@@ -504,7 +575,7 @@ export async function handleClean(args: string[]): Promise<void> {
   const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
   const oneDayMs = 24 * 60 * 60 * 1000;
 
-  const logsDeleted = deleteOldFiles(ws.logsDir, sevenDaysMs);
+  const logsDeleted = deleteOldFiles(ws.logsDir, sevenDaysMs, true);
   const approvalsDeleted = deleteOldFiles(ws.approvalsDir, oneDayMs);
   const killSignalsDeleted = deleteOldFiles(ws.killSignalsDir, oneDayMs);
   const pidsDeleted = deleteOldFiles(ws.pidsDir, oneDayMs);
@@ -519,8 +590,8 @@ export async function handleClean(args: string[]): Promise<void> {
       try {
         let lastActivity = new Date(entry.createdAt).getTime();
         if (Number.isNaN(lastActivity)) lastActivity = 0;
-        const logPath = join(ws.logsDir, `${shortId}.log`);
-        if (existsSync(logPath)) {
+        // Legacy shared log AND per-run log files both count as activity.
+        for (const logPath of collectThreadLogPaths(ws.stateDir, ws.logsDir, shortId)) {
           lastActivity = Math.max(lastActivity, Bun.file(logPath).lastModified);
         }
         if (now - lastActivity > sevenDaysMs) {

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -10,6 +10,7 @@ import {
   getLatestRun,
   removeRunsForThread,
   listRuns,
+  listRunsForThread,
 } from "../threads";
 import { getCurrentSessionId } from "../broker";
 import { resolveWorkspaceDir } from "../config";
@@ -273,29 +274,37 @@ export function resolveRunLogPath(
   return join(logsDir, `${run.shortId}.log`);
 }
 
-/** All log files for a thread in chronological order: the legacy shared
- *  `logs/{shortId}.log` (pre-per-run history) first, then the per-run files
- *  under `logs/{shortId}/` — their base36-timestamp runId names make the
- *  sorted directory listing chronological. Empty when the thread has no
- *  logs; the resolveReadableLogPath fallback covers the migration edge
- *  where the only copy lives in the legacy global logs dir. */
+/** All log files for a thread in chronological order: legacy shared logs
+ *  (pre-per-run history) first, then the per-run files under
+ *  `logs/{shortId}/` — their base36-timestamp runId names make the sorted
+ *  directory listing chronological. Legacy history is the workspace
+ *  `logs/{shortId}.log` plus any confined log a run record points at
+ *  outside the per-run dir — the migration edge where the only copy lives
+ *  in the legacy global logs dir. That record-based scan must run even when
+ *  per-run files exist: resuming a migrated thread creates per-run logs
+ *  without ever copying the global one into the workspace. */
 export function collectThreadLogPaths(
   stateDir: string,
   logsDir: string,
   shortId: string,
+  globalLogsDir: string = config.logsDir,
 ): string[] {
   const paths: string[] = [];
   const legacy = join(logsDir, `${shortId}.log`);
   if (existsSync(legacy)) paths.push(legacy);
   const runDir = join(logsDir, shortId);
+  for (const run of [...listRunsForThread(stateDir, shortId)].reverse()) { // oldest first
+    if (!run.logFile) continue;
+    const candidate = resolve(stateDir, run.logFile);
+    const confined = isPathInside(candidate, resolve(logsDir))
+      || isPathInside(candidate, resolve(globalLogsDir));
+    if (!confined || isPathInside(candidate, runDir)) continue; // per-run files come from the dir listing below
+    if (!paths.includes(candidate) && existsSync(candidate)) paths.push(candidate);
+  }
   if (existsSync(runDir)) {
     for (const name of readdirSync(runDir).sort()) {
       if (name.endsWith(".log")) paths.push(join(runDir, name));
     }
-  }
-  if (paths.length === 0) {
-    const fallback = resolveReadableLogPath(stateDir, logsDir, shortId);
-    if (existsSync(fallback)) paths.push(fallback);
   }
   return paths;
 }

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 describe("EventDispatcher", () => {
   test("accumulates agent message deltas", () => {
-    const dispatcher = new EventDispatcher("test1", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test1.log"));
     dispatcher.handleDelta("item/agentMessage/delta", {
       threadId: "t1", turnId: "turn1", itemId: "item1", delta: "Hello ",
     });
@@ -25,7 +25,7 @@ describe("EventDispatcher", () => {
 
   test("formats progress line for command execution", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("test2", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test2.log"), (line) => lines.push(line));
 
     dispatcher.handleItemStarted({
       item: { type: "commandExecution", id: "i1", command: "npm test", cwd: "/proj", status: "inProgress", processId: null, commandActions: [] },
@@ -39,7 +39,7 @@ describe("EventDispatcher", () => {
 
   test("formats progress line for file change", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("test3", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test3.log"), (line) => lines.push(line));
 
     dispatcher.handleItemCompleted({
       item: {
@@ -57,7 +57,7 @@ describe("EventDispatcher", () => {
   });
 
   test("writes events to log file", () => {
-    const dispatcher = new EventDispatcher("test4", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test4.log"));
     dispatcher.handleItemCompleted({
       item: {
         type: "commandExecution", id: "i1", command: "echo hello", cwd: "/tmp",
@@ -75,7 +75,7 @@ describe("EventDispatcher", () => {
   });
 
   test("captures review output from exitedReviewMode item/completed", () => {
-    const dispatcher = new EventDispatcher("test-review", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review.log"));
 
     dispatcher.handleItemCompleted({
       item: { type: "exitedReviewMode", id: "review-1", review: "Code looks great" },
@@ -93,7 +93,7 @@ describe("EventDispatcher", () => {
     // final_answer over the full review — the entire review body was dropped
     // from TurnResult.output (and thus from the run-ledger output field and
     // the CLI's stdout under --content-only). The full review must win.
-    const dispatcher = new EventDispatcher("test-review-finalanswer", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review-finalanswer.log"));
     const fullReview = Array.from({ length: 40 }, (_, i) =>
       `Finding ${i + 1}: detailed substantive review content.`).join("\n");
 
@@ -115,7 +115,7 @@ describe("EventDispatcher", () => {
 
   test("handles mid-turn error notifications", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("test-error", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-error.log"), (line) => lines.push(line));
 
     dispatcher.handleError({
       error: { message: "Rate limit exceeded" },
@@ -131,7 +131,7 @@ describe("EventDispatcher", () => {
 
   test("does not count declined command in commandsRun", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("test-declined-cmd", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-declined-cmd.log"), (line) => lines.push(line));
 
     dispatcher.handleItemCompleted({
       item: {
@@ -148,7 +148,7 @@ describe("EventDispatcher", () => {
 
   test("does not count failed file change in filesChanged", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("test-failed-fc", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-failed-fc.log"), (line) => lines.push(line));
 
     dispatcher.handleItemCompleted({
       item: {
@@ -166,7 +166,7 @@ describe("EventDispatcher", () => {
   });
 
   test("progress events auto-flush to log file", () => {
-    const dispatcher = new EventDispatcher("test-autoflush", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-autoflush.log"));
     const logPath = join(TEST_LOG_DIR, "test-autoflush.log");
 
     // Trigger a progress event (command started) — should auto-flush without explicit flush() call
@@ -183,7 +183,7 @@ describe("EventDispatcher", () => {
   });
 
   test("collects file changes and commands", () => {
-    const dispatcher = new EventDispatcher("test5", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test5.log"));
 
     dispatcher.handleItemCompleted({
       item: {
@@ -212,7 +212,7 @@ describe("EventDispatcher", () => {
 describe("Guardian auto-approval review events", () => {
   test("started event renders a progress line with the command", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("guardian1", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian1.log"), (line) => lines.push(line));
 
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/started", {
       threadId: "t1", turnId: "turn1", itemId: "i1", command: "touch /tmp/file",
@@ -225,7 +225,7 @@ describe("Guardian auto-approval review events", () => {
 
   test("completed event renders the decision", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("guardian2", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian2.log"), (line) => lines.push(line));
 
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
       threadId: "t1", turnId: "turn1", itemId: "i1", decision: "approved", command: "touch /tmp/file",
@@ -238,7 +238,7 @@ describe("Guardian auto-approval review events", () => {
 
   test("observed 0.142 shape: action.command + review.status/riskLevel", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("guardian-live", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian-live.log"), (line) => lines.push(line));
 
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/started", {
       threadId: "t1", turnId: "turn1", reviewId: "r1", targetItemId: "call_1",
@@ -259,7 +259,7 @@ describe("Guardian auto-approval review events", () => {
   test("denied review is persisted for override when guardianDir is set", () => {
     const lines: string[] = [];
     const guardianDir = join(TEST_LOG_DIR, "guardian");
-    const dispatcher = new EventDispatcher("guardian-deny", TEST_LOG_DIR, (line) => lines.push(line), guardianDir);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian-deny.log"), (line) => lines.push(line), guardianDir);
 
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
       threadId: "t1", turnId: "turn1", reviewId: "rev-denied-1", decisionSource: "agent",
@@ -275,7 +275,7 @@ describe("Guardian auto-approval review events", () => {
 
   test("approvals and denials without guardianDir are not persisted", () => {
     const guardianDir = join(TEST_LOG_DIR, "guardian");
-    const withDir = new EventDispatcher("guardian-ok", TEST_LOG_DIR, () => {}, guardianDir);
+    const withDir = new EventDispatcher(join(TEST_LOG_DIR, "guardian-ok.log"), () => {}, guardianDir);
     withDir.handleAutoApprovalReview("item/autoApprovalReview/completed", {
       threadId: "t1", turnId: "turn1", reviewId: "rev-approved-1",
       review: { status: "approved", riskLevel: "low", userAuthorization: "high", rationale: null },
@@ -283,7 +283,7 @@ describe("Guardian auto-approval review events", () => {
     });
     expect(existsSync(join(guardianDir, "rev-approved-1.json"))).toBe(false);
 
-    const withoutDir = new EventDispatcher("guardian-nodir", TEST_LOG_DIR, () => {});
+    const withoutDir = new EventDispatcher(join(TEST_LOG_DIR, "guardian-nodir.log"), () => {});
     withoutDir.handleAutoApprovalReview("item/autoApprovalReview/completed", {
       threadId: "t1", turnId: "turn1", reviewId: "rev-denied-2",
       review: { status: "denied", riskLevel: "high", userAuthorization: "low", rationale: null },
@@ -294,7 +294,7 @@ describe("Guardian auto-approval review events", () => {
 
   test("enum-shaped decision objects use their type discriminant", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("guardian3", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian3.log"), (line) => lines.push(line));
 
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
       decision: { type: "rejected" },
@@ -306,7 +306,7 @@ describe("Guardian auto-approval review events", () => {
 
   test("degrades to a generic line on an unrecognized payload (UNSTABLE protocol)", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("guardian4", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian4.log"), (line) => lines.push(line));
 
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/started", {});
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {});
@@ -317,7 +317,7 @@ describe("Guardian auto-approval review events", () => {
   });
 
   test("full payload is written to the log for auditability", () => {
-    const dispatcher = new EventDispatcher("guardian5", TEST_LOG_DIR);
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian5.log"));
     dispatcher.handleAutoApprovalReview("item/autoApprovalReview/completed", {
       decision: "approved", command: "rm -rf node_modules",
     });
@@ -332,7 +332,7 @@ describe("Guardian auto-approval review events", () => {
 describe("guardianWarning", () => {
   test("renders the warning message as a Guardian progress line", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("gw1", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "gw1.log"), (line) => lines.push(line));
 
     dispatcher.handleGuardianWarning({
       message: "Automatic approval review approved (risk: medium, authorization: high): persistent modification to /etc/hosts.",
@@ -344,7 +344,7 @@ describe("guardianWarning", () => {
 
   test("degrades gracefully when the UNSTABLE payload has no message", () => {
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("gw2", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "gw2.log"), (line) => lines.push(line));
     dispatcher.handleGuardianWarning({});
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain("Guardian issued a warning");

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,7 +1,7 @@
 // src/events.ts — Event dispatcher for app server notifications
 
 import { appendFileSync, mkdirSync, existsSync } from "fs";
-import { join } from "path";
+import { dirname } from "path";
 import {
   isKnownItem,
   type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
@@ -29,13 +29,13 @@ export class EventDispatcher {
   private guardianDir: string | null;
 
   constructor(
-    shortId: string,
-    logsDir: string,
+    logPath: string,
     onProgress?: ProgressCallback,
     guardianDir?: string,
   ) {
-    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true, mode: 0o700 });
-    this.logPath = join(logsDir, `${shortId}.log`);
+    const dir = dirname(logPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+    this.logPath = logPath;
     this.onProgress = onProgress ?? ((line) => process.stderr.write(line + "\n"));
     this.guardianDir = guardianDir ?? null;
   }

--- a/src/threads.test.ts
+++ b/src/threads.test.ts
@@ -16,6 +16,7 @@ import {
   listRunsForThread,
   getLatestRun,
   pruneRuns,
+  ensureLedgerVersion,
   migrateGlobalState,
   removeLegacyGlobalThread,
 } from "./threads";
@@ -309,20 +310,31 @@ describe("run ledger", () => {
     expect(loaded!.threadId).toBe("thr_test"); // unchanged
   });
 
-  test("legacy 'cancelled' records normalize to 'interrupted' on every read path", () => {
+  test("ensureLedgerVersion sweeps legacy 'cancelled' records to 'interrupted' once", () => {
     const run = makeRun();
+    const untouched = makeRun();
     createRun(testDir, run);
-    // Simulate a record written before the status unification.
+    createRun(testDir, untouched);
+    // Simulate a record written before the status unification, plus a
+    // pre-sweep (missing) version marker.
     const filePath = join(testDir, "runs", `${run.runId}.json`);
     writeFileSync(filePath, readFileSync(filePath, "utf-8").replace('"completed"', '"cancelled"'));
+    const versionPath = join(testDir, "runs", ".ledger-version");
+    rmSync(versionPath, { force: true });
 
-    expect(loadRun(testDir, run.runId)!.status).toBe("interrupted");
-    expect(listRuns(testDir).find(r => r.runId === run.runId)!.status).toBe("interrupted");
+    ensureLedgerVersion(testDir);
 
-    // updateRun persists the normalized value even when the patch doesn't touch status.
-    updateRun(testDir, run.runId, { error: "x" });
+    // The sweep rewrote the file on disk — read paths need no normalizer.
     expect(readFileSync(filePath, "utf-8")).not.toContain("cancelled");
     expect(loadRun(testDir, run.runId)!.status).toBe("interrupted");
+    expect(loadRun(testDir, untouched.runId)!.status).toBe("completed");
+    expect(readFileSync(versionPath, "utf-8")).toBe("2");
+
+    // Stamped marker short-circuits: a new legacy record is NOT swept (no
+    // current writer produces "cancelled", so this only guards the fast path).
+    writeFileSync(filePath, readFileSync(filePath, "utf-8").replace('"interrupted"', '"cancelled"'));
+    ensureLedgerVersion(testDir);
+    expect(readFileSync(filePath, "utf-8")).toContain("cancelled");
   });
 
   test("updateRun throws on unknown run instead of silently no-op", () => {

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -267,6 +267,14 @@ export function generateRunId(): string {
   return `run-${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
 }
 
+/** Stable stateDir-relative path of a run's own log file. Each run writes
+ *  its own log (per-run attribution for concurrent same-thread runs);
+ *  legacy records point at the shared `logs/{shortId}.log` instead. The
+ *  base36-timestamp runId prefix keeps a directory listing chronological. */
+export function runLogRelPath(shortId: string, runId: string): string {
+  return `logs/${shortId}/${runId}.log`;
+}
+
 export function createRun(stateDir: string, record: RunRecord): void {
   const dir = runsDir(stateDir);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -413,9 +421,17 @@ export function pruneRuns(stateDir: string, maxRuns?: number): void {
   const resolveLogFile = (logFile: string | null): string | null => {
     if (!logFile) return null;
     const abs = resolve(stateDir, logFile);
-    if (isPathInside(abs, logsRoot)) return abs;
-    console.error(`[codex] Warning: refusing to prune log outside workspace state: ${logFile}`);
-    return null;
+    if (!isPathInside(abs, logsRoot)) {
+      console.error(`[codex] Warning: refusing to prune log outside workspace state: ${logFile}`);
+      return null;
+    }
+    // Per-run logs (in a logs/{shortId}/ subdir) are NOT pruned with their
+    // record: they are the thread's readable history for `output`, retained
+    // like the legacy shared log until `clean`'s age policy or `delete`
+    // removes them. Only legacy shared logs directly under logs/ are prune
+    // candidates (for threads that already left the index).
+    if (dirname(abs) !== logsRoot) return null;
+    return abs;
   };
 
   type Entry = { file: string; activityAt: string; logFile: string | null; logPath: string | null; running: boolean };

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -284,12 +284,54 @@ export function createRun(stateDir: string, record: RunRecord): void {
   renameSync(tmpPath, filePath);
 }
 
-/** Records written before the status unification say "cancelled" where the
- *  thread index (and every display surface) says "interrupted". Normalize on
- *  read — a lazy migration; the next updateRun persists the new value. */
-function normalizeRunRecord(record: RunRecord): RunRecord {
-  if ((record.status as string) === "cancelled") record.status = "interrupted";
-  return record;
+/** Current run-ledger schema version. v2: statuses unified on
+ *  "interrupted" (records written before the unification said "cancelled"),
+ *  swept once by ensureLedgerVersion so read paths need no normalization. */
+const LEDGER_VERSION = "2";
+const LEDGER_VERSION_FILE = ".ledger-version";
+
+/**
+ * One-time ledger migration, called on every workspace access (cheap fast
+ * path: a one-byte file compare). If the version marker is stale or missing,
+ * rewrite any legacy "cancelled" statuses to "interrupted" under the ledger
+ * lock, then stamp the marker. Idempotent: a crash mid-sweep leaves the
+ * marker unstamped and the next invocation re-sweeps. If the lock is
+ * contended (another process is sweeping right now), skip — the worst case
+ * is one cosmetic "cancelled" render during the first post-upgrade command.
+ */
+export function ensureLedgerVersion(stateDir: string): void {
+  const dir = runsDir(stateDir);
+  const versionPath = join(dir, LEDGER_VERSION_FILE);
+  try {
+    if (readFileSync(versionPath, "utf-8") === LEDGER_VERSION) return;
+  } catch { /* missing or unreadable → sweep */ }
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(versionPath, LEDGER_VERSION, { mode: 0o600 });
+    return;
+  }
+  try {
+    withThreadLock(versionPath, () => {
+      for (const file of readdirSync(dir)) {
+        if (!file.endsWith(".json")) continue;
+        const filePath = join(dir, file);
+        try {
+          const record = JSON.parse(readFileSync(filePath, "utf-8"));
+          if (record?.status === "cancelled") {
+            record.status = "interrupted";
+            const tmpPath = filePath + ".tmp";
+            writeFileSync(tmpPath, JSON.stringify(record, null, 2), { mode: 0o600 });
+            renameSync(tmpPath, filePath);
+          }
+        } catch (e) {
+          console.error(`[codex] Warning: could not sweep run file ${file}: ${e instanceof Error ? e.message : e}`);
+        }
+      }
+      writeFileSync(versionPath, LEDGER_VERSION, { mode: 0o600 });
+    });
+  } catch (e) {
+    console.error(`[codex] Warning: ledger sweep skipped: ${e instanceof Error ? e.message : e}`);
+  }
 }
 
 export function loadRun(stateDir: string, runId: string): RunRecord | null {
@@ -315,7 +357,7 @@ export function loadRun(stateDir: string, runId: string): RunRecord | null {
       console.error(`[codex] Warning: run file ${runId} has invalid structure`);
       return null;
     }
-    return normalizeRunRecord(parsed);
+    return parsed;
   } catch (e) {
     console.error(`[codex] Warning: failed to parse run file ${runId}: ${e instanceof Error ? e.message : e}`);
     return null;
@@ -341,7 +383,7 @@ export function updateRun(stateDir: string, runId: string, patch: RunPatch): voi
   }
   let record: RunRecord;
   try {
-    record = normalizeRunRecord(JSON.parse(readFileSync(filePath, "utf-8")));
+    record = JSON.parse(readFileSync(filePath, "utf-8"));
   } catch (e) {
     throw new Error(`Failed to read run ${runId}: ${e instanceof Error ? e.message : e}`);
   }
@@ -362,7 +404,7 @@ export function listRuns(stateDir: string, opts?: { sessionId?: string }): RunRe
   const records: RunRecord[] = [];
   for (const file of files) {
     try {
-      const record: RunRecord = normalizeRunRecord(JSON.parse(readFileSync(join(dir, file), "utf-8")));
+      const record: RunRecord = JSON.parse(readFileSync(join(dir, file), "utf-8"));
       if (opts?.sessionId && record.sessionId !== opts.sessionId) continue;
       records.push(record);
     } catch (e) {

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -151,7 +151,7 @@ describe("runTurn", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-turn", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turn.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -178,7 +178,7 @@ describe("runTurn", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-turn-delta", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turn-delta.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -198,7 +198,7 @@ describe("runTurn", () => {
       completionParams: completedTurn("turn-1", "failed", { message: "Context window exceeded" }),
     });
 
-    const dispatcher = new EventDispatcher("test-turn-err", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turn-err.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -224,7 +224,7 @@ describe("runTurn", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-instant", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-instant.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -239,7 +239,7 @@ describe("runTurn", () => {
   test("times out when turn/completed never fires", async () => {
     const { client } = buildMockClient(() => inProgressTurn("turn-1"));
 
-    const dispatcher = new EventDispatcher("test-turn-timeout", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turn-timeout.log"), () => {});
 
     const start = Date.now();
     try {
@@ -286,7 +286,7 @@ describe("runTurn", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-turn-collect", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turn-collect.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "run tests" }], {
       dispatcher,
@@ -316,7 +316,7 @@ describe("runTurn", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-turn-params", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turn-params.log"), () => {});
 
     await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -353,7 +353,7 @@ describe("runTurn", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-turnid-filter", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-turnid-filter.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -387,7 +387,7 @@ describe("runReview", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-review", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review.log"), () => {});
 
     const result = await runReview(
       client,
@@ -428,7 +428,7 @@ describe("runReview", () => {
     });
     void emit;
 
-    const dispatcher = new EventDispatcher("test-review-kill", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review-kill.log"), () => {});
 
     // Drop a kill signal file after a brief delay so the awaiter picks it up.
     setTimeout(() => {
@@ -475,7 +475,7 @@ describe("runReview", () => {
     });
     void emit; // keep mock alive
 
-    const dispatcher = new EventDispatcher("test-review-interrupt", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review-interrupt.log"), () => {});
 
     await expect(
       runReview(
@@ -524,7 +524,7 @@ describe("runReview", () => {
     });
     void emit;
 
-    const dispatcher = new EventDispatcher("test-review-subthread-inference", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review-subthread-inference.log"), () => {});
 
     const t0 = Date.now();
     const result = await runReview(
@@ -556,7 +556,7 @@ describe("runReview", () => {
       completionParams: completedTurn("review-turn-2", "failed", { message: "No changes to review" }),
     });
 
-    const dispatcher = new EventDispatcher("test-review-err", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review-err.log"), () => {});
 
     const result = await runReview(
       client,
@@ -600,7 +600,7 @@ describe("review output via exitedReviewMode", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-review-override", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-review-override.log"), () => {});
 
     const result = await runReview(
       client,
@@ -641,7 +641,7 @@ describe("kill signal", () => {
       writeFileSync(join(TEST_KILL_DIR, "thr-1"), "", { mode: 0o600 });
     }, 100);
 
-    const dispatcher = new EventDispatcher("test-kill-request", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-kill-request.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -668,7 +668,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-kill", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-kill.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -699,7 +699,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-stale-kill", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-stale-kill.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -724,7 +724,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-fresh-kill", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-fresh-kill.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -750,7 +750,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-pid-mismatch", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-pid-mismatch.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -772,7 +772,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-pid-match", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-pid-match.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -794,7 +794,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-wildcard", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-wildcard.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -820,7 +820,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-stale-wildcard", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-stale-wildcard.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -841,7 +841,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-no-kill", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-no-kill.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -862,7 +862,7 @@ describe("kill signal", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-cleanup", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-cleanup.log"), () => {});
 
     await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -889,7 +889,7 @@ describe("error propagation", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-propagate", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-propagate.log"), () => {});
 
     await expect(
       runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
@@ -981,7 +981,7 @@ describe("approval wiring", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-approval-wiring", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-approval-wiring.log"), () => {});
 
     await runTurn(client, "thr-1", [{ type: "text", text: "do stuff" }], {
       dispatcher,
@@ -1059,7 +1059,7 @@ describe("notification buffering and turn filtering", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-buffer-replay", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-buffer-replay.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1090,7 +1090,7 @@ describe("notification buffering and turn filtering", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-buffer-other-thread", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-buffer-other-thread.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1137,7 +1137,7 @@ describe("notification buffering and turn filtering", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-foreign-filter", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-foreign-filter.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1165,7 +1165,7 @@ describe("connection loss", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-conn-loss", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-conn-loss.log"), () => {});
 
     const started = Date.now();
     await expect(
@@ -1203,7 +1203,7 @@ describe("completion inference", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-infer-completion", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-infer-completion.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1237,7 +1237,7 @@ describe("completion inference", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-normal-beats-inference", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-normal-beats-inference.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1287,7 +1287,7 @@ describe("completion inference", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-inference-reset", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-inference-reset.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1340,7 +1340,7 @@ describe("structured capture from item/completed", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-structured-capture", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-structured-capture.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "build" }], {
       dispatcher,
@@ -1389,7 +1389,7 @@ describe("structured capture from item/completed", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("test-dedup-capture", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-dedup-capture.log"), () => {});
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "run tests" }], {
       dispatcher,
@@ -1427,7 +1427,7 @@ describe("Guardian event routing", () => {
     });
 
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("guardian-routing", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "guardian-routing.log"), (line) => lines.push(line));
 
     const result = await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
@@ -1455,7 +1455,7 @@ describe("per-turn approvalsReviewer forwarding", () => {
       throw new Error(`Unexpected method: ${method}`);
     });
 
-    const dispatcher = new EventDispatcher("reviewer-fwd", TEST_LOG_DIR, () => {});
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "reviewer-fwd.log"), () => {});
     await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,
       approvalHandler: autoApproveHandler,
@@ -1488,7 +1488,7 @@ describe("guardianWarning routing", () => {
     });
 
     const lines: string[] = [];
-    const dispatcher = new EventDispatcher("gw-routing", TEST_LOG_DIR, (line) => lines.push(line));
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "gw-routing.log"), (line) => lines.push(line));
 
     await runTurn(client, "thr-1", [{ type: "text", text: "hello" }], {
       dispatcher,


### PR DESCRIPTION
Closes the last two client-side items in #11: the accepted concurrent-same-thread display limitation (per-run log tagging, via per-run files) and the deferred `cancelled` status retirement.

## Per-run log files

Each run now writes its own `logs/{shortId}/{runId}.log` instead of appending to a shared `logs/{shortId}.log`. Previously, when runs on one thread overlapped (broker-busy → direct-connection parallelism), `follow A`'s tail stopped at run B's `logOffset` and A's remaining output rendered inside B's stream — status stayed correct, attribution didn't.

- `follow` tails the run record's own file. `replayBound` now groups by log file: per-run records never bound each other; legacy shared-log records keep the old offset semantics untouched.
- `output`/`progress` concatenate the thread's logs chronologically: legacy shared log(s) first — including the migration edge where the only copy lives at the legacy global path — then per-run files, whose base36-timestamp runId names make the sorted directory listing chronological.
- `delete` removes the per-run dir with the thread; `clean` recurses one level into `logs/` subdirs and removes emptied dirs; `pruneRuns` leaves per-run logs alone — they are the thread's readable history, retained like the legacy shared log until `clean`/`delete`.
- No migration needed: old records keep working through the same read paths.

## Versioned ledger sweep (retires the lazy status normalizer)

PR #15 unified run statuses on `interrupted` with a read-side normalizer rewriting legacy `cancelled` values on every ledger read. That's now a one-time sweep: `ensureLedgerVersion` (called on every workspace access, one-byte marker compare thereafter) rewrites remaining legacy records under the ledger lock and stamps `runs/.ledger-version`; `normalizeRunRecord` and its three call sites are deleted. A crash mid-sweep re-sweeps next invocation; a contended lock skips (worst case: one cosmetic `cancelled` render during the first post-upgrade command).

## Validation

- Live end-to-end: two overlapping runs on one thread each captured only their own commands/output; concatenated `output <id>` shows all runs in order; `delete --purge` removes the per-run dir; a planted `cancelled` record was rewritten on the next command.
- 606 tests pass / 0 fail; typecheck clean; two local Codex review rounds (one P2 — migration-edge log history dropped once per-run files existed — fixed with a regression test, then clean).