### PR TITLE
feat(ask): the ask channel — Codex asks mid-turn, anyone answers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ codex-collab health
 | `src/turns.ts` | Turn lifecycle (runTurn, runReview), event wiring |
 | `src/events.ts` | Event dispatcher (progress lines, log writer, output accumulator) |
 | `src/approvals.ts` | Approval handler abstraction (auto-approve, interactive IPC) |
+| `src/questions.ts` | Ask-channel mailbox (Codex asks mid-turn via `ask`, fail-open on timeout; markers, temp-space mailbox) |
 | `src/types.ts` | Protocol types (JSON-RPC, threads, turns, items, approvals) |
 | `src/config.ts` | Configuration constants, workspace resolution |
 | `src/broker.ts` | Shared app-server lifecycle (connection pooling) |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ codex-collab follow --watch
 | `peek <id>` | Show recent conversation slice from server |
 | `ask "question"` | (for Codex, mid-turn) Post a question to the collaborator and wait for the answer; `--timeout <sec>` sets the deadline (default 600). Fails open: on expiry it prints proceed-on-your-judgment guidance and exits 0 |
 | `answer <id> "text"` | Answer a pending question (`answer <id> -` reads the answer from stdin) |
-| `questions` | List pending questions in this workspace |
+| `questions [id]` | List pending questions in this workspace; with an ID, show that question's full text |
 | `next` | Block until something needs attention (question or approval), print one JSON event line, exit |
 | `config [key] [value]` | Show or set persistent defaults |
 | `models` | List available models |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ codex-collab is a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-
 - **Review automation** — One command to run code reviews for PRs, uncommitted changes, or specific commits in a read-only sandbox.
 - **Thread reuse** — Resume existing threads to send follow-up prompts, build on previous responses, or steer the work in a new direction.
 - **Approval control** — Configurable approval policies for tool calls: auto-approve, interactive, deny, or Codex's Guardian auto-reviewer (`--approval auto`).
+- **Two-way ask channel** — Codex can ask a question mid-turn (`ask`) and keep working once the answer arrives (`answer`); `next` blocks until something needs attention. Fail-open: an unanswered question never stalls a run.
 - **Live observability** — `run --detach` hands a long task to a detached runner; `follow --watch` is a purpose-built live view that tracks every run in a terminal pane.
 - **Memory isolation** — Threads created by codex-collab are excluded from Codex's memory feature by default, so agent-driven sessions don't shape Codex's learned picture of how *you* work. Opt back in with `--memory` (see Options for details).
 
@@ -114,6 +115,10 @@ codex-collab follow --watch
 | `output <id> [--last]` | Full log for thread (`--last`: only the latest turn's output) |
 | `progress <id>` | Recent activity (tail of log) |
 | `peek <id>` | Show recent conversation slice from server |
+| `ask "question"` | (for Codex, mid-turn) Post a question to the collaborator and wait for the answer; `--timeout <sec>` sets the deadline (default 600). Fails open: on expiry it prints proceed-on-your-judgment guidance and exits 0 |
+| `answer <id> "text"` | Answer a pending question (`answer <id> -` reads the answer from stdin) |
+| `questions` | List pending questions in this workspace |
+| `next` | Block until something needs attention (question or approval), print one JSON event line, exit |
 | `config [key] [value]` | Show or set persistent defaults |
 | `models` | List available models |
 | `templates` | List available prompt templates |
@@ -157,12 +162,14 @@ codex-collab follow --watch
 | `--content-only` | Suppress progress lines; with `output`, return only extracted content |
 | `--last` | (output) Only the latest turn's output instead of the whole thread history (implies `--content-only`) |
 | `--session` | (threads) Only threads the current session has run |
-| `--timeout <sec>` | Turn timeout (default: 1200, max 2147483) |
+| `--timeout <sec>` | Turn timeout (default: 1200, max 2147483). For `ask`: answer deadline (default: 600); for `next`: wait deadline (default: wait indefinitely) |
 | `--base <branch>` | Base branch for PR review (default: auto-detected default branch) |
 | `--` | End of options; remaining arguments are treated as prompt text |
 | `-` | (run) Read the prompt from stdin |
 
 `run` and `review` exit with a status code that classifies the outcome: `0` completed, `1` failed, `3` timed out, `4` interrupted, `5` died blocked on an approval (the request is void — resume with a longer `--timeout` or `--approval auto`), `6` broker busy (transient — retry).
+
+`next` exits `0` when an event was delivered (JSON on stdout), `3` when `--timeout` elapsed with no event, and `10` when the workspace is idle — nothing running, nothing pending.
 
 </details>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -169,6 +169,7 @@ A pending question surfaces in the progress stream (and `follow`):
 
 ```bash
 codex-collab questions            # list pending questions (id, age, time left)
+codex-collab questions <id>       # full text of one question (list view clips long ones)
 codex-collab answer <id> "text"   # answer one (prefix matching works)
 ```
 
@@ -225,7 +226,7 @@ codex-collab delete <id> --purge        # Permanently delete server-side instead
 codex-collab clean                      # Delete old logs, stale mappings, old question files
 codex-collab approve <id> | decline <id> # Answer a pending approval
 codex-collab answer <id> "text"         # Answer a pending ask-channel question (see The Ask Channel)
-codex-collab questions                  # List pending questions in this workspace
+codex-collab questions [id]             # List pending questions (with an ID: show its full text)
 codex-collab next [--timeout <sec>]     # Block until a question/approval needs you; print one JSON event
                                         # (exit 0 = event, 10 = workspace idle, 3 = timeout)
 codex-collab ask "q" [--timeout <sec>]  # (invoked BY CODEX mid-turn, not by you) post a question, wait, fail open

--- a/SKILL.md
+++ b/SKILL.md
@@ -33,7 +33,8 @@ cat prompt.md | codex-collab run - --content-only
 - For `run` and `review`: also use `run_in_background=true` — these take minutes. After launching, tell the user it's running and end your turn. **While running**: do NOT poll, block, wait, or spawn an agent to monitor — you will be notified automatically when the task finishes. If other tasks complete while Codex is running, handle them normally without checking on Codex. **When notified**: surface the result per Context Efficiency & Result Visibility below.
 - `run --detach` returns in seconds — run it in the **foreground**.
 - `follow` on a live run blocks until that run completes, and `follow --watch` never exits: both are primarily the **user's** view for their own terminal pane — don't run `--watch` yourself. The one agent-facing use: `follow <id>` in background Bash is the completion signal for a detached run (see Detached Runs below). `follow` on an already-finished run is a quick foreground replay.
-- All other commands (`kill`, `threads`, `progress`, `output`, `peek`, `approve`, `decline`, `clean`, `delete`, `config`, `models`, `templates`, `health`, `version`): run in the **foreground** — they complete in seconds.
+- `next` blocks until something needs a response — run it in the **background**; its exit is your notification (see the `next` section below).
+- All other commands (`kill`, `threads`, `progress`, `output`, `peek`, `approve`, `decline`, `answer`, `questions`, `clean`, `delete`, `config`, `models`, `templates`, `health`, `version`): run in the **foreground** — they complete in seconds.
 
 If the user asks about progress mid-task, use `TaskOutput(block=false)` to read the background output stream, or `codex-collab progress <id>` for just the log tail. `<id>` is the codex-collab thread short ID (8-char hex), not the Claude Code task ID — it appears in the first progress line (`[codex] Thread a1b2c3d4 started`); `codex-collab threads` lists them. Progress lines stream in real time:
 
@@ -122,19 +123,53 @@ codex-collab run "large refactor task" --detach --approval auto
 
 **Completion signal for detached runs (agent-facing):** the detach parent exits when the turn *starts*, not when it finishes — so backgrounding `run --detach` gives you no completion notification. When you need one, run `codex-collab follow <id>` in background Bash: it exits exactly when the run reaches a terminal state (exit 0 = completed), and that exit is your notification.
 
-### Watching for approvals without polling (Monitor pattern)
+### Watching for questions and approvals without polling (`next`)
 
-**Only arm this when the approval mode can actually block**: `on-request`, `on-failure`, or `untrusted`. Under the default `never` there are no approval requests, and under `auto` Guardian decides everything autonomously (approve or deny — it never blocks on a human), so a watcher there is waste.
+`codex-collab next` blocks until the first event that needs a response in the workspace — an ask-channel question (see The Ask Channel below) or a pending interactive approval — prints **one JSON event line**, and exits. Exit codes: `0` event delivered · `10` workspace idle (nothing running, nothing pending — the self-cleaning path, so a watcher never dangles after the run ends) · `3` only with an explicit `--timeout <sec>`.
 
-When you run codex-collab in background Bash, you're notified when the *process exits* — but an approval request blocks mid-run without exiting. Watch on-disk state instead; both signals below appear regardless of which process owns the run:
+**Arm it whenever a run can produce something answerable**: any run using the ask channel (`--template collab`), or an approval mode that can block (`on-request`, `on-failure`, `untrusted`). Under `--approval never` with no ask template, nothing can fire — a watcher there is waste (it will exit `10` when the run ends). Under `auto`, Guardian handles approvals autonomously, but questions still fire.
 
-- an approval request file appears at `~/.codex-collab/workspaces/*/approvals/<id>.json` while a request is pending (and disappears when answered); its JSON carries the command, reason, and `workspaceDir`
-- the run record (`workspaces/*/runs/<runId>.json`) carries `"pendingApproval": {id, kind, summary, requestedAt}` while blocked, `null` otherwise
-
-Arm a single-shot watcher alongside the background run and keep working — approval appears → notification → `codex-collab approve <id>` → the run continues (no kill/resume cycle, no polling in your context). With the Monitor tool, this is the command; without it, run the same loop as a second background Bash command and its *exit* becomes your notification:
+The pattern: launch the run and `next` as two background Bash commands in the same breath, then keep working — `next` exiting *is* your notification. **`next` watches one workspace** — arm it with the same `-d` you gave the run (bare `next` watches the cwd workspace only, and will exit `10` without ever seeing another workspace's events):
 
 ```bash
-until [ -n "$(ls ~/.codex-collab/workspaces/*/approvals/*.json 2>/dev/null)" ]; do sleep 2; done; cat ~/.codex-collab/workspaces/*/approvals/*.json
+codex-collab next -d /path/to/project   # in background Bash; its exit = something needs you
+# → {"type":"question","id":"q7f3a2c1","summary":"…","expiresAt":"…","answerWith":"codex-collab answer q7f3a2c1 \"<text>\""}
+```
+
+**Respond and re-arm in the same message**: when `next` exits, issue the `answer` (or `approve`) and a fresh `next` as parallel tool calls — each event then costs exactly one wake-up plus one turn. Re-arm only *after* answering; `next` has no memory of delivered events, so re-arming while a question is still pending fires immediately with the same event. A parked `next` consumes zero context, and long runs can ask several times — keep the loop going until the run completes (its own exit notifies you) or `next` exits `10`.
+
+On-disk state backs all of this regardless of which process owns the run: the run record (`workspaces/*/runs/<runId>.json`) carries `pendingQuestion` and `pendingApproval` while blocked, and `questions[]` as the resolved audit trail.
+
+## The Ask Channel (Codex Asks, You Answer)
+
+On long or autonomous runs, Codex can pause mid-turn to ask you a question — without betting the run on your reply. Launch the run with the built-in `collab` template to teach it the channel:
+
+```bash
+codex-collab run "large refactor task…" --template collab --timeout 3600
+```
+
+Mid-turn, Codex runs `codex-collab ask "…"`, which waits up to 10 minutes and then resolves one of two ways, both printed into Codex's own context: your answer (steering), or a graceful no-answer notice (fail-open; the run continues, and the unanswered question lands in the run record). Questions are *judgment*, not permission — unlike approvals they never block the run terminally. The template declares the channel and its costs but deliberately prescribes no rules: whether and when to ask is Codex's own call.
+
+**Restate the channel when you resume a long collab thread.** The channel instructions ride the first prompt, and long threads compact oldest-first — so include one line in your own words in the resume prompt (e.g. "the collaboration channel is still open — `codex-collab ask` reaches me"). Codex only needs the gist; the mechanics are rediscoverable from `codex-collab --help`.
+
+A pending question surfaces in the progress stream (and `follow`):
+
+```
+[codex] QUESTION FROM CODEX (expires in 10m)
+[codex]   Migrating auth to JWT next. Drop the FK constraints or dual-write?
+[codex]   Answer: codex-collab answer q7f3a2c1 "<text>" -d '/path/to/project'
+```
+
+**Triage, in order of preference:**
+1. **Answer from your own context** — you launched the run; you usually hold exactly what the question needs. Questions are interrupt-priority: Codex is burning its deadline budget while you deliberate.
+2. **Escalate to the user** when it's a preference or product call above your mandate — relay the question, relay their answer back.
+3. **Decline explicitly** — `codex-collab answer <id> "Your call — proceed and note the decision"` — rather than letting it expire silently, so the audit trail can distinguish a deliberate "proceed" from nobody having been around to answer.
+
+**Answer craft: transfer judgment, not tokens.** State the choice, the reason, and the condition under which Codex should deviate or ask again — a bare "yes" steers one decision; a reasoned answer steers the next ten. Long answers: `codex-collab answer <id> -` reads stdin.
+
+```bash
+codex-collab questions            # list pending questions (id, age, time left)
+codex-collab answer <id> "text"   # answer one (prefix matching works)
 ```
 
 ## Approvals
@@ -187,8 +222,13 @@ codex-collab peek <id> [--limit N --full] # Recent conversation slice from serve
 codex-collab kill <id>                  # Stop a running thread
 codex-collab delete <id>                # Archive thread (recoverable via `codex unarchive`), delete local files
 codex-collab delete <id> --purge        # Permanently delete server-side instead — NOT recoverable; needs explicit user intent
-codex-collab clean                      # Delete old logs and stale mappings
+codex-collab clean                      # Delete old logs, stale mappings, old question files
 codex-collab approve <id> | decline <id> # Answer a pending approval
+codex-collab answer <id> "text"         # Answer a pending ask-channel question (see The Ask Channel)
+codex-collab questions                  # List pending questions in this workspace
+codex-collab next [--timeout <sec>]     # Block until a question/approval needs you; print one JSON event
+                                        # (exit 0 = event, 10 = workspace idle, 3 = timeout)
+codex-collab ask "q" [--timeout <sec>]  # (invoked BY CODEX mid-turn, not by you) post a question, wait, fail open
 codex-collab config [key] [value] [--unset] # Show/set/unset persistent defaults (model, reasoning, sandbox, approval, timeout, memory)
 codex-collab models | templates | health | version
 ```
@@ -204,7 +244,7 @@ Note: `jobs` still works as a deprecated alias for `threads`.
 | `-s, --sandbox <mode>` | Sandbox: read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
 | `-d, --dir <path>` | Working directory (default: cwd) |
 | `--resume <id>` | Resume existing thread (run and review) |
-| `--timeout <sec>` | Turn timeout in seconds (default: 1200). Do not lower this — Codex tasks routinely take 5-15 minutes. Increase for large reviews or complex tasks. |
+| `--timeout <sec>` | (run, review) Turn timeout in seconds (default: 1200). Do not lower this — Codex tasks routinely take 5-15 minutes; increase for large reviews or complex tasks. (ask) Answer deadline, default 600. (next) Wait bound, default none — it waits until an event or workspace idle. |
 | `--approval <policy>` | never, on-request, on-failure, untrusted, auto (default: never) — see Approvals |
 | `--memory` | Let Codex's memory feature learn from threads this run creates (default: created threads are excluded so agent-driven sessions don't shape Codex's picture of the user) |
 | `--detach` | (run) Return once the turn is running — see Detached Runs |
@@ -244,7 +284,7 @@ To hand off a thread to the Codex TUI, look up the full thread ID with `codex-co
 
 - **`run --resume` requires a prompt.** `review --resume` works without one (it uses the review workflow), but `run --resume <id>` will error if no prompt is given.
 - **Omit `-d` if already in the project directory** — it defaults to cwd. Only pass `-d` when the target project differs from your current directory.
-- **Multiple concurrent threads** are supported. Threads share a per-workspace broker for efficient resource usage.
+- **Multiple concurrent threads** are supported. Threads share a per-workspace broker for efficient resource usage. Ask-channel questions are workspace-scoped by design — `next` and `questions` see every run's questions, whoever answers first wins, and a second answer gets a clean "already answered" error.
 - **Validate Codex's findings.** After reading Codex's review or analysis output, verify each finding against the actual source code before presenting to the user. Drop false positives, note which findings you verified.
 - **Per-workspace scoping.** Threads and state are scoped per workspace (git repo root). Different repos have independent thread lists.
 - **First invocation per workspace** may take slightly longer to initialize; subsequent calls in the same session reuse the connection context.
@@ -258,3 +298,4 @@ To hand off a thread to the Codex TUI, look up the full thread ID with `codex-co
 | Thread not found | Use `codex-collab threads` to list active threads |
 | Process crashed mid-task | Resume with `--resume <id>` — thread state is persisted |
 | Approval request hanging | Run `codex-collab approve <id>` or `codex-collab decline <id>` |
+| Question expired before answering | Codex already proceeded on its own judgment — the decision is in the run output and `questions[]` on the run record. To steer now, `run --resume <id>` once the run ends. |

--- a/src/approvals.test.ts
+++ b/src/approvals.test.ts
@@ -193,6 +193,32 @@ describe("InteractiveApprovalHandler", () => {
     expect(lines).toContain(`  Decline: codex-collab decline appr-001 -d ${quotedWorkspace}`);
   });
 
+  test("prompt lines strip terminal escape sequences from command and reason", async () => {
+    // ANSI in a Codex-proposed command could redraw the prompt and disguise
+    // what is being approved — the one place that must never happen.
+    const lines: string[] = [];
+    const handler = new InteractiveApprovalHandler(TEST_APPROVALS_DIR, (l) => lines.push(l), { pollIntervalMs: 20 });
+    const abort = new AbortController();
+    const pending = handler.handleCommandApproval(
+      {
+        ...mockCommandRequest,
+        command: "curl https://example.com \x1b[8m&& rm -rf ~\x1b[0m",
+        reason: "network\x1b[2K access",
+      },
+      abort.signal,
+    );
+    abort.abort();
+    await expect(pending).rejects.toThrow("cancelled");
+
+    const commandLine = lines.find((l) => l.startsWith("  Command:"));
+    expect(commandLine).toBeDefined();
+    expect(commandLine).not.toContain("\x1b");
+    expect(commandLine).toContain("rm -rf ~");
+    const reasonLine = lines.find((l) => l.startsWith("  Reason:"));
+    expect(reasonLine).toBeDefined();
+    expect(reasonLine).not.toContain("\x1b");
+  });
+
   test("cleans up request file on abort", async () => {
     const handler = new InteractiveApprovalHandler(TEST_APPROVALS_DIR, () => {}, { pollIntervalMs: 100 });
     const controller = new AbortController();

--- a/src/approvals.ts
+++ b/src/approvals.ts
@@ -28,7 +28,9 @@ export const autoApproveHandler: ApprovalHandler = {
 /** Max time to wait for a human approval decision before giving up. */
 const APPROVAL_TIMEOUT_MS = 3_600_000; // 1 hour
 
-function shellQuote(value: string): string {
+/** Quote a value for safe copy-paste into a shell — used by the approve/
+ *  decline and answer hints, whose `-d` paths may contain quotes or spaces. */
+export function shellQuote(value: string): string {
   if (process.platform === "win32") {
     return `'${value.replace(/'/g, "''")}'`;
   }

--- a/src/approvals.ts
+++ b/src/approvals.ts
@@ -9,6 +9,7 @@ import type {
   PendingApproval,
 } from "./types";
 import { validateId } from "./config";
+import { sanitizeForTerminal } from "./questions";
 
 export interface ApprovalHandler {
   handleCommandApproval(req: CommandApprovalRequest, signal?: AbortSignal): Promise<ApprovalDecision>;
@@ -80,8 +81,12 @@ export class InteractiveApprovalHandler implements ApprovalHandler {
     const cwd = this.workspaceDir ?? req.cwd;
     const dirFlag = cwd ? ` -d ${shellQuote(cwd)}` : "";
     this.onProgress(`APPROVAL NEEDED`);
-    this.onProgress(`  Command: ${req.command ?? "(no command)"}`);
-    if (req.reason) this.onProgress(`  Reason: ${req.reason}`);
+    // The command and reason are Codex-proposed text headed for the user's
+    // terminal at the moment of a permission decision — strip escape
+    // sequences so embedded ANSI can't redraw the prompt and disguise what
+    // is being approved.
+    this.onProgress(`  Command: ${sanitizeForTerminal(req.command ?? "(no command)")}`);
+    if (req.reason) this.onProgress(`  Reason: ${sanitizeForTerminal(req.reason)}`);
     this.onProgress(`  Approve: codex-collab approve ${id}${dirFlag}`);
     this.onProgress(`  Decline: codex-collab decline ${id}${dirFlag}`);
 
@@ -109,7 +114,7 @@ export class InteractiveApprovalHandler implements ApprovalHandler {
     const cwd = this.workspaceDir ?? req.grantRoot;
     const dirFlag = cwd ? ` -d ${shellQuote(cwd)}` : "";
     this.onProgress(`APPROVAL NEEDED (file change)`);
-    if (req.reason) this.onProgress(`  Reason: ${req.reason}`);
+    if (req.reason) this.onProgress(`  Reason: ${sanitizeForTerminal(req.reason)}`);
     this.onProgress(`  Approve: codex-collab approve ${id}${dirFlag}`);
     this.onProgress(`  Decline: codex-collab decline ${id}${dirFlag}`);
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -240,7 +240,8 @@ describe("CLI questions <id>", () => {
         cwd: import.meta.dir + "/..",
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 5000,
-        env: { ...process.env, HOME: TEST_HOME, TMPDIR: tmp },
+        // TMPDIR steers os.tmpdir() on POSIX; TEMP/TMP do the same on Windows.
+        env: { ...process.env, HOME: TEST_HOME, TMPDIR: tmp, TEMP: tmp, TMP: tmp },
       });
       const stdout = (result.stdout ?? "") as string;
       expect(result.status).toBe(0);
@@ -263,7 +264,8 @@ describe("CLI questions <id>", () => {
         cwd: import.meta.dir + "/..",
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 5000,
-        env: { ...process.env, HOME: TEST_HOME, TMPDIR: tmp },
+        // TMPDIR steers os.tmpdir() on POSIX; TEMP/TMP do the same on Windows.
+        env: { ...process.env, HOME: TEST_HOME, TMPDIR: tmp, TEMP: tmp, TMP: tmp },
       });
       expect(result.status).toBe(1);
       expect((result.stderr ?? "") as string).toContain("No pending question");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, setDefaultTimeout, afterAll } from "bun:test";
 import { spawnSync } from "child_process";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import pkg from "../package.json";
@@ -214,5 +214,61 @@ describe("CLI global options before command", () => {
     const { stderr, exitCode } = run("--reasoning", "invalid", "run", "prompt");
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Invalid reasoning level");
+  });
+});
+
+describe("CLI questions <id>", () => {
+  it("prints the full multiline question without truncation", () => {
+    // Isolated TMPDIR so the mailbox scan can't touch (or pollute) the real
+    // workspace mailbox; findQuestion's cross-mailbox fallback locates the
+    // record whatever the workspace key resolves to.
+    const tmp = mkdtempSync(join(tmpdir(), "codex-collab-mb-"));
+    try {
+      const uid = typeof process.getuid === "function" ? String(process.getuid()) : "u";
+      const mailboxDir = join(tmp, `codex-collab-${uid}`, "ws-testkey", "questions");
+      mkdirSync(mailboxDir, { recursive: true });
+      const longQuestion = Array.from({ length: 10 }, (_, i) => `question line ${i + 1}`).join("\n");
+      writeFileSync(join(mailboxDir, "q1234abc.json"), JSON.stringify({
+        id: "q1234abc", question: longQuestion,
+        askedAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 600_000).toISOString(),
+        workspaceDir: tmp, pid: process.pid,
+      }), { mode: 0o600 });
+
+      const result = spawnSync("bun", ["run", CLI, "questions", "q1234abc"], {
+        encoding: "utf-8",
+        cwd: import.meta.dir + "/..",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 5000,
+        env: { ...process.env, HOME: TEST_HOME, TMPDIR: tmp },
+      });
+      const stdout = (result.stdout ?? "") as string;
+      expect(result.status).toBe(0);
+      // The live prompt clips at 6 lines and the list view at 100 chars —
+      // this path is the escape hatch, so every line must be present.
+      expect(stdout).toContain("Question q1234abc");
+      expect(stdout).toContain("question line 1");
+      expect(stdout).toContain("question line 10");
+      expect(stdout).toContain('Answer with: codex-collab answer q1234abc');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("unknown id exits nonzero with a pointer to the list", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "codex-collab-mb-"));
+    try {
+      const result = spawnSync("bun", ["run", CLI, "questions", "qdead999"], {
+        encoding: "utf-8",
+        cwd: import.meta.dir + "/..",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 5000,
+        env: { ...process.env, HOME: TEST_HOME, TMPDIR: tmp },
+      });
+      expect(result.status).toBe(1);
+      expect((result.stderr ?? "") as string).toContain("No pending question");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,7 +123,8 @@ Commands:
                           expiry it prints proceed-on-your-judgment guidance
                           and exits 0
   answer <id> "text"      Answer a pending question (answer <id> - for stdin)
-  questions               List pending questions in this workspace
+  questions [id]          List pending questions in this workspace; with an
+                          ID, show that question's full text
   next                    Block until something needs attention (question or
                           approval), print one JSON event line, exit
   approve <id>            Approve a pending request

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,8 +48,10 @@ async function handleShutdownSignal(exitCode: number): Promise<void> {
           error: "Interrupted by signal",
           // Ctrl-C while blocked on an approval exits before the approval
           // poll's cleanup tick — terminal records must never claim a
-          // pending approval (same guarantee as recordTerminalRunState).
+          // pending approval or ask-channel question (same guarantee as
+          // recordTerminalRunState).
           pendingApproval: null,
+          pendingQuestion: null,
         });
       } catch (e) {
         console.error(`[codex] Warning: could not update run record during shutdown: ${e instanceof Error ? e.message : String(e)}`);
@@ -122,6 +124,8 @@ Commands:
                           and exits 0
   answer <id> "text"      Answer a pending question (answer <id> - for stdin)
   questions               List pending questions in this workspace
+  next                    Block until something needs attention (question or
+                          approval), print one JSON event line, exit
   approve <id>            Approve a pending request
   approve --guardian [id] Override a Guardian denial (no id: list pending
                           denials); takes effect on the thread's next run
@@ -168,6 +172,10 @@ Exit codes (run, review):
                            5  died blocked on an approval (request now void —
                               resume with a longer --timeout or --approval auto)
                            6  broker busy and fallback unavailable (transient; retry)
+
+Exit codes (next):
+  0  event delivered (JSON on stdout)   3  --timeout elapsed with no event
+  10 workspace idle — nothing running, nothing pending
 
 Examples:
   codex-collab run "what does this project do?" -s read-only --content-only
@@ -293,7 +301,7 @@ async function main() {
   const knownCommands = new Set([
     "run", "review", "threads", "jobs", "kill", "follow", "output", "progress",
     "config", "models", "templates", "approve", "decline", "clean", "delete", "health",
-    "peek", "version", "ask", "answer", "questions",
+    "peek", "version", "ask", "answer", "questions", "next",
   ]);
   if (!knownCommands.has(command)) {
     console.error(`Error: Unknown command: ${command}`);
@@ -339,6 +347,8 @@ async function main() {
       return (await import("./commands/answer")).handleAnswer(rest);
     case "questions":
       return (await import("./commands/answer")).handleQuestions(rest);
+    case "next":
+      return (await import("./commands/next")).handleNext(rest);
     case "approve":
       return (await import("./commands/approve")).handleApprove(rest);
     case "decline":

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,6 +115,13 @@ Commands:
   config [key] [value]    Show or set persistent defaults
   models                  List available models
   templates               List available prompt templates
+  ask "question"          (for Codex, mid-turn) Post a question to the
+                          collaborator and wait for the answer; --timeout <sec>
+                          sets the deadline (default 600). Fails open: on
+                          expiry it prints proceed-on-your-judgment guidance
+                          and exits 0
+  answer <id> "text"      Answer a pending question (answer <id> - for stdin)
+  questions               List pending questions in this workspace
   approve <id>            Approve a pending request
   approve --guardian [id] Override a Guardian denial (no id: list pending
                           denials); takes effect on the thread's next run
@@ -286,7 +293,7 @@ async function main() {
   const knownCommands = new Set([
     "run", "review", "threads", "jobs", "kill", "follow", "output", "progress",
     "config", "models", "templates", "approve", "decline", "clean", "delete", "health",
-    "peek", "version",
+    "peek", "version", "ask", "answer", "questions",
   ]);
   if (!knownCommands.has(command)) {
     console.error(`Error: Unknown command: ${command}`);
@@ -326,6 +333,12 @@ async function main() {
       return (await import("./commands/config")).handleModels(rest);
     case "templates":
       return (await import("./commands/config")).handleTemplates(rest);
+    case "ask":
+      return (await import("./commands/ask")).handleAsk(rest);
+    case "answer":
+      return (await import("./commands/answer")).handleAnswer(rest);
+    case "questions":
+      return (await import("./commands/answer")).handleQuestions(rest);
     case "approve":
       return (await import("./commands/approve")).handleApprove(rest);
     case "decline":

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -1,0 +1,151 @@
+// src/commands/answer.ts — answer + questions command handlers
+//
+// The responder side of the ask channel. `answer` writes the answer file the
+// waiting `ask` polls for; `questions` lists what's pending. Anyone can
+// answer — the Claude session that launched the run, or a human at a
+// terminal — the mechanism doesn't care.
+
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { mailboxRoot, resolveMailboxDir } from "../config";
+import {
+  answerPath,
+  isAskerAlive,
+  listPendingQuestions,
+  listQuestions,
+  questionSummary,
+  writeAnswerExclusive,
+} from "../questions";
+import { die, formatAge, parseOptions, validateIdOrDie } from "./shared";
+import type { QuestionRecord } from "../types";
+
+interface FoundQuestion {
+  mailboxDir: string;
+  record: QuestionRecord;
+}
+
+/** Resolve an ID or unambiguous prefix against the current workspace's
+ *  mailbox first, then across all mailboxes — mirroring approvals'
+ *  findApprovalRequest, because the answer hint is printed by the run and
+ *  the responder may act on it from a different cwd. */
+function findQuestion(cwd: string, idOrPrefix: string): FoundQuestion | null {
+  const matchesIn = (mailboxDir: string): FoundQuestion[] =>
+    listQuestions(mailboxDir)
+      .filter((r) => r.id === idOrPrefix || r.id.startsWith(idOrPrefix))
+      .map((record) => ({ mailboxDir, record }));
+
+  const localDir = resolveMailboxDir(cwd);
+  const local = matchesIn(localDir);
+  if (local.length === 1) return local[0];
+  if (local.length > 1) die(`Question ID prefix "${idOrPrefix}" is ambiguous. Use more characters.`);
+
+  const root = mailboxRoot();
+  if (!existsSync(root)) return null;
+  const matches: FoundQuestion[] = [];
+  for (const workspaceName of readdirSync(root)) {
+    const candidateDir = join(root, workspaceName, "questions");
+    if (candidateDir === localDir) continue;
+    try {
+      matches.push(...matchesIn(candidateDir));
+    } catch (e) {
+      // A sibling workspace's mailbox failing its safety checks must not
+      // block answering in a healthy one.
+      console.error(`[codex] Warning: skipping mailbox ${candidateDir}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  if (matches.length > 1) {
+    die(`Question ${idOrPrefix} matches in multiple workspaces. Re-run from the workspace directory or pass -d <workspace>.`);
+  }
+  return matches[0] ?? null;
+}
+
+export async function handleAnswer(args: string[]): Promise<void> {
+  const { positional, options } = parseOptions(args);
+  const idArg = positional[0];
+  if (!idArg) die('Usage: codex-collab answer <question-id> "<text>"  (or: answer <id> - for stdin)');
+  validateIdOrDie(idArg);
+
+  let text = positional.slice(1).join(" ");
+  if (text === "-") {
+    if (process.stdin.isTTY) console.error("[codex] Reading answer from stdin — end with Ctrl-D.");
+    text = readFileSync(0, "utf-8");
+  }
+  if (!text.trim()) {
+    die('Empty answer\nUsage: codex-collab answer <question-id> "<text>"');
+  }
+
+  const found = findQuestion(options.dir, idArg);
+  if (!found) die(`No pending question: ${idArg} (list them with: codex-collab questions)`);
+  const { mailboxDir, record } = found;
+
+  // An answer is a small act of trust — the responder deserves to know
+  // whether it landed. Never silently swallow a late answer.
+  const expiresAtMs = Date.parse(record.expiresAt);
+  if (record.expired || (Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now())) {
+    die(
+      `Question ${record.id} expired${Number.isFinite(expiresAtMs) ? ` ${formatAge(expiresAtMs / 1000)}` : ""} — Codex proceeded on its own judgment.\n` +
+      `To steer now, wait for the run to finish and resume the thread: codex-collab run --resume <id> "..."`,
+    );
+  }
+  // A run killed or timed out mid-ask leaves the question file behind with
+  // no process waiting on the answer — delivering into the void would be a
+  // false "Codex picks it up" promise.
+  if (!isAskerAlive(record)) {
+    die(
+      `Question ${record.id} is orphaned — the asking process is gone (its run was killed, timed out, or crashed), so the answer cannot be delivered.\n` +
+      `To steer instead, resume the thread: codex-collab run --resume <id> "..."`,
+    );
+  }
+  if (existsSync(answerPath(mailboxDir, record.id))) {
+    die(`Question ${record.id} was already answered.`);
+  }
+
+  let claimed: boolean;
+  try {
+    claimed = writeAnswerExclusive(mailboxDir, record.id, text);
+  } catch (e) {
+    die(`Failed to write answer: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (!claimed) {
+    die(`Question ${record.id} was already answered.`);
+  }
+  // The pre-claim checks are a snapshot; an answer landing in the final
+  // second (or after the asker died mid-wait) is written but may never be
+  // read. Re-check after the claim and be honest about uncertain delivery.
+  const deliveredLate = Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now();
+  if (deliveredLate || !isAskerAlive(record)) {
+    console.log(
+      `Answered ${record.id}, but ${deliveredLate ? "the deadline passed while writing" : "the asking process is gone"} — ` +
+      `Codex may have already proceeded on its own judgment. Check the run output; to steer instead, resume the thread once the run ends.`,
+    );
+    return;
+  }
+  console.log(`Answered ${record.id} — Codex picks it up within a second.`);
+}
+
+export async function handleQuestions(args: string[]): Promise<void> {
+  const { options } = parseOptions(args);
+  const mailboxDir = resolveMailboxDir(options.dir);
+  const pending = listPendingQuestions(mailboxDir);
+
+  if (pending.length === 0) {
+    console.log("No pending questions.");
+    return;
+  }
+  console.log("Pending questions:");
+  for (const record of pending) {
+    const askedAtMs = Date.parse(record.askedAt);
+    const expiresAtMs = Date.parse(record.expiresAt);
+    const asked = Number.isFinite(askedAtMs) ? formatAge(askedAtMs / 1000).replace(" ago", "") : "?";
+    const remainingSec = Number.isFinite(expiresAtMs)
+      ? Math.max(0, Math.round((expiresAtMs - Date.now()) / 1000))
+      : null;
+    const remaining = remainingSec === null ? ""
+      : remainingSec >= 60 ? `  expires in ${Math.round(remainingSec / 60)}m`
+      : `  expires in ${remainingSec}s`;
+    console.log(
+      `  ${record.id}  asked ${asked} ago${remaining}  ${questionSummary(record.question, 100)}`,
+    );
+  }
+  console.log('\nAnswer with: codex-collab answer <id> "<text>"');
+}

--- a/src/commands/answer.ts
+++ b/src/commands/answer.ts
@@ -124,7 +124,32 @@ export async function handleAnswer(args: string[]): Promise<void> {
 }
 
 export async function handleQuestions(args: string[]): Promise<void> {
-  const { options } = parseOptions(args);
+  const { positional, options } = parseOptions(args);
+
+  // `questions <id>` — the full record for one question. The list view and
+  // the live prompt both clip long questions and point here, so this path
+  // must never truncate.
+  const idArg = positional[0];
+  if (idArg) {
+    validateIdOrDie(idArg);
+    const found = findQuestion(options.dir, idArg);
+    if (!found) die(`No pending question: ${idArg} (list them with: codex-collab questions)`);
+    const { record } = found;
+    const expiresAtMs = Date.parse(record.expiresAt);
+    const remainingSec = Number.isFinite(expiresAtMs)
+      ? Math.max(0, Math.round((expiresAtMs - Date.now()) / 1000))
+      : null;
+    console.log(`Question ${record.id}  asked ${formatAge(Date.parse(record.askedAt) / 1000)}${
+      remainingSec === null ? "" : remainingSec >= 60
+        ? `  expires in ${Math.round(remainingSec / 60)}m`
+        : `  expires in ${remainingSec}s`
+    }`);
+    console.log("");
+    console.log(record.question);
+    console.log(`\nAnswer with: codex-collab answer ${record.id} "<text>"  (or: answer ${record.id} - for stdin)`);
+    return;
+  }
+
   const mailboxDir = resolveMailboxDir(options.dir);
   const pending = listPendingQuestions(mailboxDir);
 
@@ -147,5 +172,5 @@ export async function handleQuestions(args: string[]): Promise<void> {
       `  ${record.id}  asked ${asked} ago${remaining}  ${questionSummary(record.question, 100)}`,
     );
   }
-  console.log('\nAnswer with: codex-collab answer <id> "<text>"');
+  console.log('\nFull text: codex-collab questions <id>   Answer with: codex-collab answer <id> "<text>"');
 }

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -1,0 +1,96 @@
+// src/commands/ask.ts — ask command handler (invoked BY CODEX inside a turn)
+//
+// Posts a question to the workspace mailbox, waits up to the deadline for an
+// answer, and resolves exactly one of two ways — both on stdout, which lands
+// in Codex's context: an answer (steering), or a graceful "no answer,
+// proceed on your best judgment". Exit 0 in both cases: from Codex's point
+// of view the tool always succeeds; only the advice differs. Non-zero exits
+// are reserved for genuine failures (unwritable mailbox, bad arguments),
+// which Codex should see as loud errors, not silent expiry.
+
+import { readFileSync } from "fs";
+import { resolveMailboxDir, resolveWorkspaceDir } from "../config";
+import {
+  DEFAULT_ASK_TIMEOUT_SEC,
+  generateQuestionId,
+  markerAnswered,
+  markerExpired,
+  markerPosted,
+  pollForAnswer,
+  removeQuestion,
+  sanitizeForTerminal,
+  updateQuestion,
+  writeQuestion,
+} from "../questions";
+import { die, formatDuration, parseOptions } from "./shared";
+import type { QuestionRecord } from "../types";
+
+export async function handleAsk(args: string[]): Promise<void> {
+  const { positional, options } = parseOptions(args);
+  // Deliberately no applyUserConfig: the config `timeout` is the TURN
+  // timeout; the ask deadline is its own budget with its own default.
+  const deadlineSec = options.explicit.has("timeout") ? options.timeout : DEFAULT_ASK_TIMEOUT_SEC;
+
+  let question = positional.join(" ");
+  if (question === "-") {
+    if (process.stdin.isTTY) console.error("[codex] Reading question from stdin — end with Ctrl-D.");
+    question = readFileSync(0, "utf-8");
+  }
+  question = sanitizeForTerminal(question).trim();
+  if (!question) {
+    die('No question provided\nUsage: codex-collab ask "question" [--timeout <sec>]');
+  }
+
+  const mailboxDir = resolveMailboxDir(options.dir);
+  const id = generateQuestionId();
+  const askedAt = Date.now();
+  const record: QuestionRecord = {
+    id,
+    question,
+    askedAt: new Date(askedAt).toISOString(),
+    expiresAt: new Date(askedAt + deadlineSec * 1000).toISOString(),
+    workspaceDir: resolveWorkspaceDir(options.dir),
+    pid: process.pid,
+  };
+  try {
+    writeQuestion(mailboxDir, record);
+  } catch (e) {
+    die(`Could not post question (mailbox ${mailboxDir}): ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  // First line is the attribution marker the turn owner parses from the
+  // command's output stream; the second is for Codex itself.
+  console.log(markerPosted(id, deadlineSec));
+  console.log(
+    `Question posted. Waiting up to ${formatDuration(deadlineSec * 1000)} for an answer` +
+    ` (collaborator answers with: codex-collab answer ${id} "<text>").`,
+  );
+
+  const answer = await pollForAnswer(mailboxDir, id, askedAt + deadlineSec * 1000);
+
+  if (answer !== null) {
+    const latencySec = Math.max(1, Math.round((Date.now() - askedAt) / 1000));
+    console.log(markerAnswered(id, latencySec));
+    console.log("");
+    console.log(`ANSWER FROM YOUR COLLABORATOR (after ${formatDuration(latencySec * 1000)}):`);
+    // Indented so no answer line can sit at column 0 and be mistaken for a
+    // marker by the turn owner's line parser.
+    for (const line of sanitizeForTerminal(answer).trimEnd().split("\n")) {
+      console.log(`  ${line}`);
+    }
+    removeQuestion(mailboxDir, id);
+  } else {
+    // Fail open: stamp expired (kept for the audit trail until `clean`
+    // sweeps it) and tell Codex to carry on.
+    try {
+      updateQuestion(mailboxDir, { ...record, expired: true });
+    } catch (e) {
+      console.error(`[codex] Warning: could not mark question expired: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    console.log(markerExpired(id, deadlineSec));
+    console.log("");
+    console.log(`NO ANSWER within ${formatDuration(deadlineSec * 1000)}. Proceed on your best judgment.`);
+    console.log("Record this open question and the decision you took in your final summary.");
+  }
+  process.exit(0);
+}

--- a/src/commands/next.test.ts
+++ b/src/commands/next.test.ts
@@ -1,0 +1,77 @@
+// src/commands/next.test.ts — Tests for the next command's liveness logic
+
+import { describe, expect, test, afterAll } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { spawnSync } from "node:child_process";
+import { isRunAlive } from "./next";
+import type { RunRecord } from "../types";
+
+const tmpRoot = join(process.env.TMPDIR ?? "/tmp", "next-test-" + process.pid);
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+let dirCounter = 0;
+function freshPidsDir(): string {
+  const dir = join(tmpRoot, `pids-${dirCounter++}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeRun(overrides?: Partial<RunRecord>): RunRecord {
+  return {
+    runId: "run-test", threadId: "thr_x", shortId: "abcd1234", kind: "task",
+    phase: "running", status: "running", sessionId: null,
+    logFile: "logs/abcd1234/run-test.log", logOffset: 0, prompt: null,
+    model: null, startedAt: new Date().toISOString(), completedAt: null,
+    elapsed: null, output: null, filesChanged: null, commandsRun: null, error: null,
+    ...overrides,
+  };
+}
+
+function deadPid(): number {
+  const result = spawnSync(process.execPath, ["--version"], { stdio: "ignore" });
+  if (typeof result.pid !== "number" || result.pid <= 0) throw new Error("could not obtain dead pid");
+  return result.pid;
+}
+
+describe("isRunAlive", () => {
+  test("a record with a live pid is alive; with a dead pid it is not", () => {
+    const pidsDir = freshPidsDir();
+    expect(isRunAlive(makeRun({ pid: process.pid }), pidsDir)).toBe(true);
+    expect(isRunAlive(makeRun({ pid: deadPid() }), pidsDir)).toBe(false);
+  });
+
+  test("a legacy record without a pid and without a PID file is NOT alive", () => {
+    // The thread-level display check treats a missing PID file as alive;
+    // for next's idle detection that would make a stale crashed record
+    // hold the watcher open forever.
+    const pidsDir = freshPidsDir();
+    expect(isRunAlive(makeRun(), pidsDir)).toBe(false);
+  });
+
+  test("a legacy record follows its PID file's liveness", () => {
+    const pidsDir = freshPidsDir();
+    const run = makeRun();
+    writeFileSync(join(pidsDir, run.shortId), String(process.pid), { mode: 0o600 });
+    expect(isRunAlive(run, pidsDir)).toBe(true);
+    writeFileSync(join(pidsDir, run.shortId), String(deadPid()), { mode: 0o600 });
+    expect(isRunAlive(run, pidsDir)).toBe(false);
+  });
+});
+
+describe("findLiveApproval", () => {
+  const { findLiveApproval } = require("./next") as typeof import("./next");
+
+  test("fires only for approvals a live run is actually blocked on", () => {
+    const stale = { id: "aaaa1111", kind: "commandExecution", summary: "rm -rf x" };
+    const live = { id: "bbbb2222", kind: "commandExecution", summary: "npm publish" };
+    const aliveRuns = [
+      makeRun({ pendingApproval: { id: "bbbb2222", kind: "commandExecution", summary: "npm publish", requestedAt: new Date().toISOString() } }),
+      makeRun({ pendingApproval: null }),
+    ];
+    expect(findLiveApproval([stale, live], aliveRuns)?.id).toBe("bbbb2222");
+    // A killed run's leftover file, with no live run referencing it: nothing fires.
+    expect(findLiveApproval([stale], aliveRuns)).toBeUndefined();
+    expect(findLiveApproval([stale, live], [])).toBeUndefined();
+  });
+});

--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -1,0 +1,153 @@
+// src/commands/next.ts — next command handler (the attention primitive)
+//
+// Blocks until the first attention-worthy event in the workspace — a pending
+// ask-channel question or a pending interactive approval — prints ONE JSON
+// event line, and exits. Replaces the POSIX `until`-loop the skill used to
+// document for approvals with a single command that behaves identically on
+// macOS, Linux, and Windows, and self-terminates when the workspace goes
+// idle so a watcher armed alongside a run never dangles after the run ends.
+//
+// Exit codes: 0 = event delivered · 10 = workspace idle (nothing running,
+// nothing pending) · 3 = --timeout elapsed with no event.
+
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { resolveMailboxDir } from "../config";
+import { listPendingQuestions, questionSummary, QUESTION_POLL_INTERVAL_MS } from "../questions";
+import { listRuns } from "../threads";
+import { getWorkspacePaths, parseOptions, readPidFile } from "./shared";
+import type { RunRecord } from "../types";
+
+export const NEXT_EXIT_CODES = {
+  event: 0,
+  timeout: 3,
+  idle: 10,
+} as const;
+
+/** Grace window before an idle exit when no run has been observed yet —
+ *  covers the race where `next` is armed in the same breath as the run it
+ *  watches, before that run has created its ledger record. */
+const LAUNCH_GRACE_MS = 30_000;
+
+export interface PendingApprovalFile {
+  id: string;
+  kind: string | null;
+  summary: string | null;
+}
+
+/** The approval `next` should fire on, if any: one whose raising run is
+ *  alive and still blocked on it. Exported for tests. */
+export function findLiveApproval(
+  approvals: PendingApprovalFile[],
+  aliveRuns: RunRecord[],
+): PendingApprovalFile | undefined {
+  return approvals.find((a) => aliveRuns.some((r) => r.pendingApproval?.id === a.id));
+}
+
+/** Pending approvals = request `.json` files with no `.decision` sibling.
+ *  Same on-disk contract InteractiveApprovalHandler maintains. Exported for
+ *  tests. */
+export function listPendingApprovals(approvalsDir: string): PendingApprovalFile[] {
+  if (!existsSync(approvalsDir)) return [];
+  const pending: PendingApprovalFile[] = [];
+  for (const file of readdirSync(approvalsDir)) {
+    if (!file.endsWith(".json")) continue;
+    const id = file.slice(0, -".json".length);
+    if (existsSync(join(approvalsDir, `${id}.decision`))) continue;
+    let kind: string | null = null;
+    let summary: string | null = null;
+    try {
+      const parsed = JSON.parse(readFileSync(join(approvalsDir, file), "utf-8"));
+      if (parsed && typeof parsed === "object") {
+        kind = typeof parsed.type === "string" ? parsed.type : null;
+        summary = typeof parsed.command === "string" ? parsed.command
+          : typeof parsed.reason === "string" ? parsed.reason : null;
+      }
+    } catch { /* corrupt request file — still report its existence */ }
+    pending.push({ id, kind, summary });
+  }
+  return pending;
+}
+
+/** Exported for tests. */
+export function isRunAlive(run: RunRecord, pidsDir: string): boolean {
+  if (typeof run.pid === "number" && run.pid > 0) {
+    return pidAlive(run.pid);
+  }
+  // Legacy records without a pid: only a live PID file counts. The
+  // thread-level check treats a MISSING file as alive (conservative for
+  // display), but a watcher must not dangle forever on a stale record from
+  // a crash or an older version — every live run writes a PID file.
+  const filePid = readPidFile(pidsDir, run.shortId);
+  return filePid !== null && pidAlive(filePid);
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function emit(event: Record<string, unknown>, code: number): never {
+  console.log(JSON.stringify(event));
+  process.exit(code);
+}
+
+export async function handleNext(args: string[]): Promise<void> {
+  const { options } = parseOptions(args);
+  const ws = getWorkspacePaths(options.dir);
+  const mailboxDir = resolveMailboxDir(options.dir);
+  // No --timeout means wait until an event or idle — the idle exit is the
+  // self-cleaning path, so an unbounded wait cannot dangle forever.
+  const timeoutMs = options.explicit.has("timeout") ? options.timeout * 1000 : Infinity;
+  const startedAt = Date.now();
+  let sawActiveRun = false;
+
+  while (true) {
+    const question = listPendingQuestions(mailboxDir)[0];
+    if (question) {
+      emit({
+        type: "question",
+        id: question.id,
+        summary: questionSummary(question.question),
+        askedAt: question.askedAt,
+        expiresAt: question.expiresAt,
+        workspaceDir: question.workspaceDir,
+        answerWith: `codex-collab answer ${question.id} "<text>"`,
+      }, NEXT_EXIT_CODES.event);
+    }
+
+    const aliveRuns = listRuns(ws.stateDir).filter(
+      (r) => r.status === "running" && isRunAlive(r, ws.pidsDir),
+    );
+
+    // An approval is only answerable while the run that raised it is alive
+    // and still blocked on it — its poller lives inside the run process, so
+    // a request file left behind by a killed run would otherwise make every
+    // later `next` fire instantly with a dead event.
+    const approval = findLiveApproval(listPendingApprovals(ws.approvalsDir), aliveRuns);
+    if (approval) {
+      emit({
+        type: "approval",
+        id: approval.id,
+        kind: approval.kind,
+        summary: approval.summary,
+        answerWith: `codex-collab approve ${approval.id} (or decline)`,
+      }, NEXT_EXIT_CODES.event);
+    }
+
+    if (aliveRuns.length > 0) {
+      sawActiveRun = true;
+    } else if (sawActiveRun || Date.now() - startedAt > LAUNCH_GRACE_MS) {
+      emit({ type: "idle" }, NEXT_EXIT_CODES.idle);
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      emit({ type: "timeout" }, NEXT_EXIT_CODES.timeout);
+    }
+    await new Promise((r) => setTimeout(r, QUESTION_POLL_INTERVAL_MS));
+  }
+}

--- a/src/commands/peek.ts
+++ b/src/commands/peek.ts
@@ -2,6 +2,8 @@
 
 import type { Turn, ThreadItem, Thread, UserMessageItem, AgentMessageItem } from "../types";
 
+import { sanitizeForTerminal } from "../questions";
+
 import {
   die,
   parseOptions,
@@ -143,7 +145,10 @@ export function formatPeekHuman(
   }
   void shortId;
   void thread;
-  return lines.join("\n");
+  // The human view renders server-side conversation content (messages,
+  // command lines) straight to a terminal — strip escape sequences at the
+  // boundary. --json output stays verbatim for programmatic consumers.
+  return sanitizeForTerminal(lines.join("\n"));
 }
 
 export async function handlePeek(args: string[]): Promise<void> {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -14,6 +14,7 @@ import {
   resolveDefaults,
   startOrResumeThread,
   createDispatcher,
+  armQuestionChannel,
   getApprovalHandler,
   getWorkspacePaths,
   recordTerminalRunState,
@@ -106,6 +107,10 @@ export async function handleReview(args: string[]): Promise<void> {
     // thread/resume on the dead thread would fail. Denials still show in the
     // progress stream and log.
     const dispatcher = createDispatcher(join(ws.stateDir, runLogRelPath(shortId, runId)), options);
+    // Reviews arm the ask channel too: `review --resume` on a thread that
+    // was taught the channel leaves the instructions in Codex's history, so
+    // a mid-review ask must surface instead of silently stalling.
+    armQuestionChannel(dispatcher, ws, runId, options.dir);
 
     // Note: model/cwd/approval/sandbox already reached the server via the
     // thread start/fork params in startOrResumeThread; review/start itself
@@ -137,6 +142,8 @@ export async function handleReview(args: string[]): Promise<void> {
       recordRunFailure(ws, threadId, runId, e);
       throw e;
     } finally {
+      // Same disposal contract as handleRun — see armQuestionChannel.
+      dispatcher.setQuestionContext(null);
       setActiveThreadId(undefined);
       setActiveReviewThreadId(undefined);
       setActiveShortId(undefined);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -15,6 +15,7 @@ import {
   resolveDefaults,
   startOrResumeThread,
   createDispatcher,
+  armQuestionChannel,
   getApprovalHandler,
   getWorkspacePaths,
   turnOverrides,
@@ -249,6 +250,7 @@ export async function handleRun(args: string[]): Promise<void> {
     writePidFile(ws.pidsDir, shortId);
 
     const dispatcher = createDispatcher(join(ws.stateDir, runLogRelPath(shortId, runId)), options, ws.guardianDir);
+    armQuestionChannel(dispatcher, ws, runId, options.dir);
 
     try {
       const result = await runTurn(
@@ -303,6 +305,12 @@ export async function handleRun(args: string[]): Promise<void> {
       }
       throw e;
     } finally {
+      // Disarm the ask channel BEFORE the run record goes terminal — its
+      // watchers are unref'd timers that survive the turn, and a late
+      // callback would stamp pendingQuestion onto a terminal record (the
+      // broker-busy retry path would even aim the old dispatcher's timers
+      // at this same sticky runId).
+      dispatcher.setQuestionContext(null);
       setActiveThreadId(undefined);
       setActiveShortId(undefined);
       setActiveTurnId(undefined);

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -3,6 +3,7 @@
 import {
   config,
   resolveStateDir,
+  resolveMailboxDir,
   resolveModel,
   validateId,
   type ReasoningEffort,
@@ -27,6 +28,7 @@ import {
   loadRun,
   pruneRuns,
   migrateGlobalState,
+  appendRunQuestion,
 } from "../threads";
 import type { PendingApproval } from "../types";
 import { RpcError, TurnTimeoutError } from "../types";
@@ -700,6 +702,39 @@ export function createDispatcher(
   );
 }
 
+/** Arm the ask channel on a dispatcher: `codex-collab ask` inside the turn
+ *  surfaces via mailbox watchers and output markers, mirrored onto this run
+ *  record (pendingQuestion while waiting, questions[] audit trail on
+ *  resolution). Callers MUST call dispatcher.setQuestionContext(null) in
+ *  their finally — the watchers are unref'd timers that outlive the turn,
+ *  and a late callback would otherwise stamp pendingQuestion onto a record
+ *  already written terminal. Observers never throw into the event path. */
+export function armQuestionChannel(
+  dispatcher: EventDispatcher,
+  ws: WorkspacePaths,
+  runId: string,
+  workspaceDir: string,
+): void {
+  dispatcher.setQuestionContext({
+    mailboxDir: resolveMailboxDir(workspaceDir),
+    workspaceDir,
+    onPending: (pending) => {
+      try {
+        updateRun(ws.stateDir, runId, { pendingQuestion: pending });
+      } catch (e) {
+        console.error(`[codex] Warning: could not mirror pending question: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    },
+    onResolved: (resolved) => {
+      try {
+        appendRunQuestion(ws.stateDir, runId, resolved);
+      } catch (e) {
+        console.error(`[codex] Warning: could not record resolved question: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Model auto-selection
 // ---------------------------------------------------------------------------
@@ -1153,8 +1188,9 @@ export function recordTerminalRunState(
       error: result.error ?? null,
       // A kill/timeout can end the run while the approval poll is asleep and
       // the process exits before its cleanup tick — never leave a terminal
-      // record claiming an approval is still pending.
+      // record claiming an approval (or ask-channel question) is still pending.
       pendingApproval: null,
+      pendingQuestion: null,
     });
   } catch (e) {
     console.error(`[codex] CRITICAL: could not save run state for ${runId}: ${e instanceof Error ? e.message : String(e)}`);
@@ -1198,8 +1234,9 @@ export function recordRunFailure(
       completedAt: new Date().toISOString(),
       error: error instanceof Error ? error.message : String(error),
       // Same guarantee as recordTerminalRunState: terminal records never
-      // claim a pending approval.
+      // claim a pending approval or question.
       pendingApproval: null,
+      pendingQuestion: null,
     });
   } catch (e) {
     console.error(`[codex] Warning: could not record run failure for ${runId}: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -13,7 +13,8 @@ import {
   listRunsForThread,
 } from "../threads";
 import { getCurrentSessionId } from "../broker";
-import { resolveWorkspaceDir } from "../config";
+import { resolveWorkspaceDir, resolveMailboxDir } from "../config";
+import { sweepQuestions } from "../questions";
 import type { AppServerClient } from "../client";
 import type { Thread, RunRecord } from "../types";
 import {
@@ -549,6 +550,9 @@ export async function handleClean(args: string[]): Promise<void> {
   const approvalsDeleted = deleteOldFiles(ws.approvalsDir, oneDayMs);
   const killSignalsDeleted = deleteOldFiles(ws.killSignalsDir, oneDayMs);
   const pidsDeleted = deleteOldFiles(ws.pidsDir, oneDayMs);
+  // Ask-channel mailbox: answered questions delete themselves; this catches
+  // expired ones (kept for the audit trail) and orphans from killed askers.
+  const questionsDeleted = sweepQuestions(resolveMailboxDir(options.dir), oneDayMs);
 
   // Clean stale thread mappings — use log file mtime as proxy for last
   // activity so recently-used threads aren't pruned just because they
@@ -583,6 +587,8 @@ export async function handleClean(args: string[]): Promise<void> {
     parts.push(`${killSignalsDeleted} kill signal files deleted`);
   if (pidsDeleted > 0)
     parts.push(`${pidsDeleted} stale PID files deleted`);
+  if (questionsDeleted > 0)
+    parts.push(`${questionsDeleted} old question files deleted`);
   if (mappingsRemoved > 0)
     parts.push(`${mappingsRemoved} stale mappings removed`);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 // src/config.ts — Configuration for codex-collab
 
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { join, basename, resolve, sep } from "path";
 import { createHash } from "crypto";
 import { realpathSync, existsSync, readFileSync, readdirSync } from "fs";
@@ -160,13 +160,15 @@ export function resolveWorkspaceDir(cwd: string): string {
 }
 
 /**
- * Compute per-workspace state directory:
- * `~/.codex-collab/workspaces/{slug}-{hash}/`
+ * `{slug}-{hash}` key identifying a workspace:
  *
  * - slug: sanitized lowercase basename of the workspace root
  * - hash: first 16 chars of SHA-256 of the canonical (realpath) path
+ *
+ * Shared by the state dir and the ask-channel mailbox so any process that
+ * knows the workspace can derive both.
  */
-export function resolveStateDir(cwd: string): string {
+export function workspaceKey(cwd: string): string {
   const wsRoot = resolveWorkspaceDir(cwd);
   let canonical: string;
   try {
@@ -176,7 +178,32 @@ export function resolveStateDir(cwd: string): string {
   }
   const slug = basename(canonical).replace(/[^a-zA-Z0-9_-]/g, "_").toLowerCase();
   const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
-  return join(getHome(), ".codex-collab", "workspaces", `${slug}-${hash}`);
+  return `${slug}-${hash}`;
+}
+
+/**
+ * Compute per-workspace state directory:
+ * `~/.codex-collab/workspaces/{slug}-{hash}/`
+ */
+export function resolveStateDir(cwd: string): string {
+  return join(getHome(), ".codex-collab", "workspaces", workspaceKey(cwd));
+}
+
+/** Root under which every workspace's ask-channel mailbox lives. Temp space,
+ *  not ~/.codex-collab: the mailbox writer (`codex-collab ask`) runs INSIDE
+ *  Codex's sandbox, where the home state dir is not writable but the temp
+ *  dir is (verified: the sandbox propagates TMPDIR verbatim and permits
+ *  writes under it). The uid suffix keeps the root private on multi-user
+ *  hosts where the temp dir is shared. */
+export function mailboxRoot(): string {
+  const uid = typeof process.getuid === "function" ? String(process.getuid()) : "u";
+  return join(tmpdir(), `codex-collab-${uid}`);
+}
+
+/** Ask-channel question mailbox for a workspace:
+ *  `{tmp}/codex-collab-{uid}/{slug}-{hash}/questions/` */
+export function resolveMailboxDir(cwd: string): string {
+  return join(mailboxRoot(), workspaceKey(cwd), "questions");
 }
 
 /**

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -810,9 +810,11 @@ describe("ask-channel answer hint quoting", () => {
     });
     dispatcher.reset();
 
+    const { shellQuote } = require("./approvals") as typeof import("./approvals");
     const log = readFileSync(logPath, "utf-8");
-    // POSIX escaping: '…it'\''s ws' — the raw -d '/tmp/it's ws' form must not appear.
-    expect(log).toContain(`-d '/tmp/it'\\''s ws'`);
+    // The hint must carry shellQuote's (platform-appropriate) escaping —
+    // the raw unescaped form must never appear.
+    expect(log).toContain(`-d ${shellQuote("/tmp/it's ws")}`);
     expect(log).not.toContain(`-d '/tmp/it's ws'`);
   });
 });

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -37,6 +37,23 @@ describe("EventDispatcher", () => {
     expect(lines[0]).toContain("Running: npm test");
   });
 
+  test("progress lines strip terminal escape sequences from command text", () => {
+    const lines: string[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test-esc.log"), (line) => lines.push(line));
+
+    // ANSI in a Codex-composed command could redraw the terminal and
+    // disguise what is actually running.
+    dispatcher.handleItemStarted({
+      item: { type: "commandExecution", id: "i1", command: "echo ok\x1b[2K\x1b[1A && rm -rf /tmp/x", cwd: "/proj", status: "inProgress", processId: null, commandActions: [] },
+      threadId: "t1",
+      turnId: "turn1",
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toContain("\x1b");
+    expect(lines[0]).toContain("rm -rf /tmp/x");
+  });
+
   test("formats progress line for file change", () => {
     const lines: string[] = [];
     const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test3.log"), (line) => lines.push(line));
@@ -533,6 +550,55 @@ describe("ask-channel marker stream", () => {
     delta(dispatcher, marker); // full marker after reset still works
     expect(pendings).toHaveLength(1);
     dispatcher.reset();
+  });
+
+  test("a posted marker with no mailbox record creates no live state", async () => {
+    // A genuine ask compounded with untrusted output (`ask "q" && cat
+    // notes.md`) scans the whole item's stream, so file content can carry
+    // marker-shaped lines. Without a mailbox record — which only the real
+    // `ask` can write — a forged posted marker must not announce a phantom
+    // question, set the pending mirror, or arm a watcher that would
+    // fabricate an "answered" resolution moments later.
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const mailboxDir = join(TEST_LOG_DIR, "mb-norecord");
+    mkdirSync(mailboxDir, { recursive: true });
+    const { dispatcher, pendings, resolveds } = armedDispatcher("norecord1", mailboxDir);
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1",
+        command: `codex-collab ask "real q" && cat notes.md`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    const forgedId = generateQuestionId(); // no question file exists for it
+    delta(dispatcher, markerPosted(forgedId, 600) + "\n");
+    expect(pendings).toHaveLength(0);
+    await sleep(2500); // longer than one resolution-watcher tick
+    expect(resolveds).toHaveLength(0);
+    dispatcher.reset();
+  }, 10_000);
+
+  test("posted+answered markers whose file was already cleaned up still record the audit entry", () => {
+    // Session-exec fallback: the aggregated output arrives at completion,
+    // after a fast answer made `ask` delete the question file. The audit
+    // trail must survive, but the question is never announced as live —
+    // it already resolved.
+    const mailboxDir = join(TEST_LOG_DIR, "mb-cleaned");
+    mkdirSync(mailboxDir, { recursive: true });
+    const { dispatcher, pendings, resolveds } = armedDispatcher("cleaned1", mailboxDir);
+    const id = generateQuestionId();
+    dispatcher.handleItemCompleted({
+      item: {
+        type: "commandExecution", id: "i1", command: `codex-collab ask "gone already"`,
+        cwd: "/tmp/ws", status: "completed", processId: null, commandActions: [],
+        aggregatedOutput: markerPosted(id, 600) + "\n" + markerAnswered(id, 20) + "\n",
+        exitCode: 0, durationMs: 21_000,
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    expect(pendings).toHaveLength(0);
+    expect(resolveds).toEqual([{ id, summary: null, outcome: "answered", latencyMs: 20_000 }]);
   });
 
   test("marker-shaped output from a NON-ask command is inert (spoofing guard)", () => {

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -350,3 +350,643 @@ describe("guardianWarning", () => {
     expect(lines[0]).toContain("Guardian issued a warning");
   });
 });
+
+describe("ask-channel marker stream", () => {
+  const { markerPosted, markerAnswered, markerExpired, writeQuestion, generateQuestionId } =
+    require("./questions") as typeof import("./questions");
+
+  function mailboxWithQuestion(name: string, id: string, question: string) {
+    const mailboxDir = join(TEST_LOG_DIR, name);
+    mkdirSync(mailboxDir, { recursive: true });
+    writeQuestion(mailboxDir, {
+      id,
+      question,
+      askedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      workspaceDir: "/tmp/ws",
+      pid: process.pid,
+    });
+    return mailboxDir;
+  }
+
+  function armedDispatcher(name: string, mailboxDir: string) {
+    const pendings: unknown[] = [];
+    const resolveds: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, `${name}.log`), () => {});
+    dispatcher.setQuestionContext({
+      mailboxDir,
+      workspaceDir: "/tmp/ws",
+      onPending: (p) => pendings.push(p),
+      onResolved: (r) => resolveds.push(r),
+    });
+    return { dispatcher, pendings, resolveds };
+  }
+
+  const delta = (dispatcher: EventDispatcher, text: string) =>
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1", delta: text,
+    });
+
+  // Marker parsing is gated to registered ask command items (spoofing
+  // guard), so tests must start an ask item before streaming its deltas.
+  const startAsk = (dispatcher: EventDispatcher, itemId = "i1") =>
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: itemId, command: `/bin/zsh -lc 'codex-collab ask "q"'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+
+  test("posted marker split across delta chunks fires onPending with the summary", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-split", id, "Drop FKs or dual-write?\nContext here.");
+    const { dispatcher, pendings } = armedDispatcher("ask1", mailboxDir);
+    startAsk(dispatcher);
+
+    const marker = markerPosted(id, 600) + "\n";
+    delta(dispatcher, marker.slice(0, 20));
+    expect(pendings).toHaveLength(0); // line not complete yet
+    delta(dispatcher, marker.slice(20));
+
+    expect(pendings).toHaveLength(1);
+    expect(pendings[0]).toMatchObject({ id, summary: "Drop FKs or dual-write?" });
+    dispatcher.reset();
+  });
+
+  test("answered marker clears pending and records latency", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-ans", id, "Which approach?");
+    const { dispatcher, pendings, resolveds } = armedDispatcher("ask2", mailboxDir);
+    startAsk(dispatcher);
+
+    delta(dispatcher, markerPosted(id, 600) + "\n" + markerAnswered(id, 161) + "\n");
+
+    expect(pendings).toEqual([
+      expect.objectContaining({ id }),
+      null,
+    ]);
+    expect(resolveds).toEqual([
+      { id, summary: "Which approach?", outcome: "answered", latencyMs: 161_000 },
+    ]);
+  });
+
+  test("expired marker resolves with outcome expired and no latency", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-exp", id, "Anyone there?");
+    const { dispatcher, resolveds } = armedDispatcher("ask3", mailboxDir);
+    startAsk(dispatcher);
+
+    delta(dispatcher, markerPosted(id, 60) + "\n" + markerExpired(id, 60) + "\n");
+
+    expect(resolveds).toEqual([
+      { id, summary: "Anyone there?", outcome: "expired" },
+    ]);
+  });
+
+  test("aggregatedOutput fallback dedupes against the delta path", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-dedupe", id, "Steer me?");
+    const { dispatcher, pendings, resolveds } = armedDispatcher("ask4", mailboxDir);
+    startAsk(dispatcher);
+
+    const fullOutput = markerPosted(id, 600) + "\nsome output\n" + markerAnswered(id, 30) + "\n";
+    delta(dispatcher, fullOutput);
+    dispatcher.handleItemCompleted({
+      item: {
+        type: "commandExecution", id: "i1", command: `codex-collab ask "Steer me?"`,
+        cwd: "/tmp/ws", status: "completed", processId: null, commandActions: [],
+        aggregatedOutput: fullOutput, exitCode: 0, durationMs: 31_000,
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+
+    expect(pendings).toHaveLength(2); // posted + cleared, once each
+    expect(resolveds).toHaveLength(1);
+  });
+
+  test("aggregatedOutput alone (no deltas delivered) still resolves the question", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-agg", id, "Fallback path?");
+    const { dispatcher, pendings, resolveds } = armedDispatcher("ask5", mailboxDir);
+
+    dispatcher.handleItemCompleted({
+      item: {
+        type: "commandExecution", id: "i1", command: `codex-collab ask "Fallback path?"`,
+        cwd: "/tmp/ws", status: "completed", processId: null, commandActions: [],
+        aggregatedOutput: markerPosted(id, 600) + "\n" + markerAnswered(id, 45) + "\n",
+        exitCode: 0, durationMs: 46_000,
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+
+    expect(pendings).toEqual([expect.objectContaining({ id }), null]);
+    expect(resolveds).toHaveLength(1);
+  });
+
+  test("indented lines (answer echo) never match markers", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-indent", id, "q");
+    const { dispatcher, pendings } = armedDispatcher("ask6", mailboxDir);
+    startAsk(dispatcher);
+
+    delta(dispatcher, "  " + markerPosted(id, 600) + "\n");
+    expect(pendings).toHaveLength(0);
+    dispatcher.reset();
+  });
+
+  test("without a question context, marker lines are inert", () => {
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "ask7.log"), () => {});
+    const id = generateQuestionId();
+    // Must not throw or log-crash
+    delta(dispatcher, markerPosted(id, 600) + "\n");
+  });
+
+  test("a throwing observer does not break the event path", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-throw", id, "q");
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "ask8.log"), () => {});
+    dispatcher.setQuestionContext({
+      mailboxDir,
+      onPending: () => { throw new Error("boom"); },
+      onResolved: () => { throw new Error("boom"); },
+    });
+    startAsk(dispatcher);
+    delta(dispatcher, markerPosted(id, 600) + "\n" + markerAnswered(id, 5) + "\n");
+    // Reaching here without an exception is the assertion.
+    dispatcher.reset();
+  });
+
+  test("reset clears the partial-line tail, seen markers, and item registrations", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-reset", id, "q");
+    const { dispatcher, pendings } = armedDispatcher("ask9", mailboxDir);
+    startAsk(dispatcher);
+
+    const marker = markerPosted(id, 600) + "\n";
+    delta(dispatcher, marker.slice(0, 15));
+    dispatcher.reset();
+    startAsk(dispatcher); // reset dropped the registration too — re-register
+    delta(dispatcher, marker.slice(15)); // tail was dropped — no complete marker forms
+    expect(pendings).toHaveLength(0);
+
+    delta(dispatcher, marker); // full marker after reset still works
+    expect(pendings).toHaveLength(1);
+    dispatcher.reset();
+  });
+
+  test("marker-shaped output from a NON-ask command is inert (spoofing guard)", () => {
+    const id = generateQuestionId();
+    const mailboxDir = mailboxWithQuestion("mb-spoof", id, "real question");
+    const { dispatcher, pendings, resolveds } = armedDispatcher("ask10", mailboxDir);
+
+    // A cat/grep-style command whose stdout happens to contain marker lines
+    // (a log replay, repository test output, prompt-injected file content).
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i9", command: "cat notes.md",
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i9",
+      delta: markerPosted(id, 600) + "\n" + markerExpired(id, 600) + "\n",
+    });
+    dispatcher.handleItemCompleted({
+      item: {
+        type: "commandExecution", id: "i9", command: "cat notes.md",
+        cwd: "/tmp/ws", status: "completed", processId: null, commandActions: [],
+        aggregatedOutput: markerPosted(id, 600) + "\n", exitCode: 0, durationMs: 5,
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+
+    expect(pendings).toHaveLength(0);
+    expect(resolveds).toHaveLength(0);
+  });
+});
+
+describe("ask-channel mailbox watch (live path under session-based exec)", () => {
+  const { markerPosted, writeQuestion, writeAnswer, generateQuestionId } =
+    require("./questions") as typeof import("./questions");
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  test("ask command starting → question surfaced from mailbox → answer resolves it", async () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-watch");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const resolveds: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "watch1.log"), () => {});
+    dispatcher.setQuestionContext({
+      mailboxDir,
+      onPending: (p) => pendings.push(p),
+      onResolved: (r) => resolveds.push(r),
+    });
+
+    // A stale question from "another run" — must NOT be attributed here.
+    const staleId = generateQuestionId();
+    writeQuestion(mailboxDir, {
+      id: staleId, question: "old question",
+      askedAt: new Date(Date.now() - 60_000).toISOString(),
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+      workspaceDir: "/tmp/ws", pid: process.pid,
+    });
+
+    // The ask command starts; its question file lands a moment later.
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1",
+        command: `/bin/zsh -lc 'codex-collab ask "which way?"'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    const id = generateQuestionId();
+    writeQuestion(mailboxDir, {
+      id, question: "which way?",
+      askedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      workspaceDir: "/tmp/ws", pid: process.pid,
+    });
+
+    await sleep(1300); // one scan tick
+    expect(pendings).toHaveLength(1);
+    expect(pendings[0]).toMatchObject({ id, summary: "which way?" });
+
+    writeAnswer(mailboxDir, id, "this way");
+    await sleep(2300); // one resolution tick
+    expect(pendings).toEqual([expect.objectContaining({ id }), null]);
+    expect(resolveds).toHaveLength(1);
+    expect(resolveds[0]).toMatchObject({ id, summary: "which way?", outcome: "answered" });
+
+    // A late marker (aggregated output at command completion) must not double-fire.
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1", delta: markerPosted(id, 600) + "\n",
+    });
+    expect(pendings).toHaveLength(2);
+    dispatcher.reset();
+  }, 10_000);
+});
+
+describe("ask-channel multi-question runs", () => {
+  const { writeQuestion, writeAnswer, generateQuestionId } =
+    require("./questions") as typeof import("./questions");
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  test("two sequential asks in one turn both post and resolve, in order", async () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-multi");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const resolveds: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "multi1.log"), () => {});
+    dispatcher.setQuestionContext({
+      mailboxDir,
+      onPending: (p) => pendings.push(p),
+      onResolved: (r) => resolveds.push(r),
+    });
+
+    const startAsk = (n: number) => dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: `i${n}`,
+        command: `/bin/zsh -lc 'codex-collab ask "question ${n}?"'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    const post = (id: string, n: number) => writeQuestion(mailboxDir, {
+      id, question: `question ${n}?`,
+      askedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      workspaceDir: "/tmp/ws", pid: process.pid,
+    });
+
+    // First ask: post → surface → answer → resolve
+    const id1 = generateQuestionId();
+    startAsk(1);
+    post(id1, 1);
+    await sleep(1300);
+    expect(pendings).toEqual([expect.objectContaining({ id: id1, summary: "question 1?" })]);
+    writeAnswer(mailboxDir, id1, "answer 1");
+    await sleep(2300);
+    expect(resolveds).toEqual([expect.objectContaining({ id: id1, outcome: "answered" })]);
+
+    // Second ask later in the same turn: the scan re-arms, the dedupe set
+    // must not swallow the new id, and the trail appends in order.
+    const id2 = generateQuestionId();
+    startAsk(2);
+    post(id2, 2);
+    await sleep(1300);
+    expect(pendings).toEqual([
+      expect.objectContaining({ id: id1 }),
+      null,
+      expect.objectContaining({ id: id2, summary: "question 2?" }),
+    ]);
+    writeAnswer(mailboxDir, id2, "answer 2");
+    await sleep(2300);
+    expect(resolveds).toEqual([
+      expect.objectContaining({ id: id1, outcome: "answered" }),
+      expect.objectContaining({ id: id2, outcome: "answered" }),
+    ]);
+    dispatcher.reset();
+  }, 15_000);
+});
+
+describe("ask-channel concurrent-run attribution", () => {
+  const { markerPosted, markerAnswered, writeQuestion, generateQuestionId } =
+    require("./questions") as typeof import("./questions");
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  const post = (mailboxDir: string, id: string, question: string) => writeQuestion(mailboxDir, {
+    id, question,
+    askedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    workspaceDir: "/tmp/ws", pid: process.pid,
+  });
+
+  test("with two in-window questions, the scan picks the one embedded in its own command", async () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-xattr");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "xattr1.log"), () => {});
+    dispatcher.setQuestionContext({ mailboxDir, onPending: (p) => pendings.push(p) });
+
+    // The OTHER run's question lands first (older = would win a naive
+    // oldest-first pick), then ours.
+    const otherId = generateQuestionId();
+    post(mailboxDir, otherId, "should the other run drop the cache?");
+    const ourId = generateQuestionId();
+
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1",
+        command: `/bin/zsh -lc 'codex-collab ask "which schema version should I target?"'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    post(mailboxDir, ourId, "which schema version should I target?");
+
+    await sleep(1300);
+    expect(pendings).toHaveLength(1);
+    expect(pendings[0]).toMatchObject({ id: ourId });
+    dispatcher.reset();
+  }, 10_000);
+
+  test("multiple unmatched candidates are left for the marker path, which attributes exactly", async () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-ambig");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const resolveds: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "ambig1.log"), () => {});
+    dispatcher.setQuestionContext({
+      mailboxDir,
+      onPending: (p) => pendings.push(p),
+      onResolved: (r) => resolveds.push(r),
+    });
+
+    // A stdin ask: the command carries no question text, and two questions
+    // are pending in-window — guessing would cross-attribute.
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1",
+        command: `/bin/zsh -lc 'cat q.md | codex-collab ask -'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    const idA = generateQuestionId();
+    const idB = generateQuestionId();
+    post(mailboxDir, idA, "question from run A");
+    post(mailboxDir, idB, "question from run B");
+
+    await sleep(1300);
+    expect(pendings).toHaveLength(0); // ambiguous — correctly declined to guess
+
+    // Command completion delivers the markers: per-command, so attribution
+    // is exact even in the ambiguous case.
+    dispatcher.handleItemCompleted({
+      item: {
+        type: "commandExecution", id: "i1", command: `/bin/zsh -lc 'cat q.md | codex-collab ask -'`,
+        cwd: "/tmp/ws", status: "completed", processId: null, commandActions: [],
+        aggregatedOutput: markerPosted(idB, 600) + "\n" + markerAnswered(idB, 12) + "\n",
+        exitCode: 0, durationMs: 13_000,
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    expect(pendings).toEqual([expect.objectContaining({ id: idB }), null]);
+    expect(resolveds).toEqual([expect.objectContaining({ id: idB, outcome: "answered" })]);
+    dispatcher.reset();
+  }, 10_000);
+});
+
+describe("ask-channel answer hint quoting", () => {
+  const { markerPosted, writeQuestion, generateQuestionId } =
+    require("./questions") as typeof import("./questions");
+
+  test("a workspace path containing a single quote is shell-quoted in the hint", () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-quote");
+    mkdirSync(mailboxDir, { recursive: true });
+    const id = generateQuestionId();
+    writeQuestion(mailboxDir, {
+      id, question: "q",
+      askedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      workspaceDir: "/tmp/it's ws", pid: process.pid,
+    });
+
+    const logPath = join(TEST_LOG_DIR, "quote1.log");
+    const dispatcher = new EventDispatcher(logPath, () => {});
+    dispatcher.setQuestionContext({ mailboxDir, workspaceDir: "/tmp/it's ws" });
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1", command: `codex-collab ask "q"`,
+        cwd: "/tmp/it's ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1", delta: markerPosted(id, 600) + "\n",
+    });
+    dispatcher.reset();
+
+    const log = readFileSync(logPath, "utf-8");
+    // POSIX escaping: '…it'\''s ws' — the raw -d '/tmp/it's ws' form must not appear.
+    expect(log).toContain(`-d '/tmp/it'\\''s ws'`);
+    expect(log).not.toContain(`-d '/tmp/it's ws'`);
+  });
+});
+
+describe("ask-channel invocation gating (mention vs invocation)", () => {
+  const { markerPosted, markerAnswered, writeQuestion, generateQuestionId } =
+    require("./questions") as typeof import("./questions");
+
+  test("a command that merely MENTIONS codex-collab ask cannot feed marker state", () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-mention");
+    mkdirSync(mailboxDir, { recursive: true });
+    const id = generateQuestionId();
+    writeQuestion(mailboxDir, {
+      id, question: "real pending question",
+      askedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      workspaceDir: "/tmp/ws", pid: process.pid,
+    });
+    const pendings: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "mention1.log"), () => {});
+    dispatcher.setQuestionContext({ mailboxDir, onPending: (p) => pendings.push(p) });
+
+    // grep over docs/logs — contains the literal, emits marker-shaped lines.
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1", command: `grep -rh "codex-collab ask" logs/`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1", delta: markerPosted(id, 600) + "\n",
+    });
+    dispatcher.handleItemCompleted({
+      item: {
+        type: "commandExecution", id: "i1", command: `grep -rh "codex-collab ask" logs/`,
+        cwd: "/tmp/ws", status: "completed", processId: null, commandActions: [],
+        aggregatedOutput: markerPosted(id, 600) + "\n", exitCode: 0, durationMs: 5,
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+
+    expect(pendings).toHaveLength(0); // not registered, scan not armed by a mention
+    dispatcher.reset();
+  });
+
+  test("a resolution marker for a question never posted this turn is inert", () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-lone");
+    mkdirSync(mailboxDir, { recursive: true });
+    const resolveds: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "lone1.log"), () => {});
+    dispatcher.setQuestionContext({ mailboxDir, onResolved: (r) => resolveds.push(r) });
+
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1", command: `codex-collab ask "q"`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1",
+      delta: markerAnswered(generateQuestionId(), 5) + "\n", // never posted
+    });
+
+    expect(resolveds).toHaveLength(0);
+    dispatcher.reset();
+  });
+});
+
+describe("ask-channel review-hardening regressions", () => {
+  const { writeQuestion, writeAnswer, generateQuestionId, markerPosted, markerAnswered } =
+    require("./questions") as typeof import("./questions");
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  const post = (mailboxDir: string, id: string, question: string, askedAtMs = Date.now()) =>
+    writeQuestion(mailboxDir, {
+      id, question,
+      askedAt: new Date(askedAtMs).toISOString(),
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      workspaceDir: "/tmp/ws", pid: process.pid,
+    });
+
+  test("a text-bearing ask never claims a non-matching sole candidate; it waits for its own file", async () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-nosteal");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "nosteal1.log"), () => {});
+    dispatcher.setQuestionContext({ mailboxDir, onPending: (p) => pendings.push(p) });
+
+    // A concurrent run's question is already there when our ask starts…
+    const otherId = generateQuestionId();
+    post(mailboxDir, otherId, "the other run's question");
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1",
+        command: `/bin/zsh -lc 'codex-collab ask "our own question"'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    await sleep(1300); // a tick with only the foreign candidate visible
+    expect(pendings).toHaveLength(0); // not stolen, scan still armed
+
+    // …then our own file lands and gets picked by text.
+    const ourId = generateQuestionId();
+    post(mailboxDir, ourId, "our own question");
+    await sleep(1300);
+    expect(pendings).toEqual([expect.objectContaining({ id: ourId })]);
+    dispatcher.reset();
+  }, 10_000);
+
+  test("a stdin ask's fallback only trusts questions posted after the command started", async () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-stdinwin");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "stdinwin1.log"), () => {});
+    dispatcher.setQuestionContext({ mailboxDir, onPending: (p) => pendings.push(p) });
+
+    // Posted 1s BEFORE the stdin ask starts — inside the backdated window,
+    // but before armedAt: must not be claimed.
+    const beforeId = generateQuestionId();
+    post(mailboxDir, beforeId, "posted before arming", Date.now() - 1000);
+    dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: "i1",
+        command: `/bin/zsh -lc 'cat q.md | codex-collab ask -'`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    await sleep(1300);
+    expect(pendings).toHaveLength(0);
+
+    const ownId = generateQuestionId();
+    post(mailboxDir, ownId, "stdin question body"); // now the sole post-arming candidate… plus the stale one
+    await sleep(1300);
+    expect(pendings).toEqual([expect.objectContaining({ id: ownId })]);
+    dispatcher.reset();
+  }, 10_000);
+
+  test("resolving one question keeps the mirror on the other still-live question", () => {
+    const mailboxDir = join(TEST_LOG_DIR, "mb-overlap");
+    mkdirSync(mailboxDir, { recursive: true });
+    const pendings: unknown[] = [];
+    const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "overlap1.log"), () => {});
+    dispatcher.setQuestionContext({ mailboxDir, onPending: (p) => pendings.push(p) });
+    const startAsk = (itemId: string) => dispatcher.handleItemStarted({
+      item: {
+        type: "commandExecution", id: itemId, command: `codex-collab ask "q"`,
+        cwd: "/tmp/ws", status: "inProgress", processId: null, commandActions: [],
+      },
+      threadId: "t1", turnId: "turn1",
+    });
+    const idA = generateQuestionId();
+    const idB = generateQuestionId();
+    post(mailboxDir, idA, "question A");
+    post(mailboxDir, idB, "question B");
+    startAsk("i1");
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1",
+      delta: markerPosted(idA, 600) + "\n",
+    });
+    startAsk("i2");
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i2",
+      delta: markerPosted(idB, 600) + "\n",
+    });
+    // A resolves while B is still live: the mirror must land on B, not null.
+    dispatcher.handleDelta("item/commandExecution/outputDelta", {
+      threadId: "t1", turnId: "turn1", itemId: "i1",
+      delta: markerAnswered(idA, 5) + "\n",
+    });
+    expect(pendings[pendings.length - 1]).toMatchObject({ id: idB });
+    dispatcher.reset();
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -7,7 +7,7 @@ import {
   type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
   type ErrorNotificationParams, type AutoApprovalReviewParams,
   type FileChange, type CommandExec,
-  type PendingQuestion, type ResolvedQuestion,
+  type PendingQuestion, type QuestionRecord, type ResolvedQuestion,
 } from "./types";
 import { saveGuardianDenial } from "./guardian";
 import { shellQuote } from "./approvals";
@@ -19,6 +19,7 @@ import {
   looksLikeAskInvocation,
   parseQuestionMarker,
   questionSummary,
+  sanitizeForTerminal,
 } from "./questions";
 
 type ProgressCallback = (line: string) => void;
@@ -221,7 +222,7 @@ export class EventDispatcher {
    *  observers that don't own this process's stdout — `follow`, Monitor
    *  scripts, `output` — see the same event stream. */
   logLine(text: string): void {
-    this.log(`[codex] ${text}`);
+    this.log(`[codex] ${sanitizeForTerminal(text)}`);
     this.flush();
   }
 
@@ -269,7 +270,27 @@ export class EventDispatcher {
     const marker = parseQuestionMarker(line);
     if (!marker) return;
     if (marker.kind === "posted") {
-      this.emitPosted(marker.id, loadQuestion(this.questionCtx.mailboxDir, marker.id), marker.seconds);
+      const record = loadQuestion(this.questionCtx.mailboxDir, marker.id);
+      if (record) {
+        this.emitPosted(marker.id, record);
+      } else {
+        // No mailbox record backs this marker: either the question already
+        // resolved and `ask` cleaned up (the aggregated-output fallback runs
+        // after the fact), or the line is forged — an ask compounded with
+        // another command (`ask "q" && cat notes.md`) scans the whole item's
+        // stream, and file content can carry marker-shaped lines. Only the
+        // real `ask` can write the privacy-verified mailbox, so without a
+        // record NO live state is created: no announce, no pending mirror,
+        // no resolution watcher. The id is still tracked so a resolution
+        // marker in the same stream completes the audit entry (the legit
+        // already-cleaned-up case); a forged posted/resolved pair can
+        // pollute at most that trail, never a live question prompt.
+        const key = `${marker.id}:posted`;
+        if (!this.seenQuestionMarkers.has(key)) {
+          this.seenQuestionMarkers.add(key);
+          this.postedQuestions.set(marker.id, { summary: null, askedAt: new Date().toISOString() });
+        }
+      }
     } else {
       // Resolution markers only count for questions posted in THIS turn —
       // a resolved-marker for an unknown id must not append audit entries.
@@ -378,17 +399,16 @@ export class EventDispatcher {
     }
   }
 
-  private emitPosted(id: string, record: ReturnType<typeof loadQuestion>, deadlineSec?: number): void {
+  private emitPosted(id: string, record: QuestionRecord): void {
     const ctx = this.questionCtx;
     if (!ctx) return;
     const key = `${id}:posted`;
     if (this.seenQuestionMarkers.has(key)) return;
     this.seenQuestionMarkers.add(key);
 
-    const summary = record ? questionSummary(record.question) : null;
-    const askedAt = record?.askedAt ?? new Date().toISOString();
-    const expiresAt = record?.expiresAt
-      ?? new Date(Date.now() + (deadlineSec ?? 600) * 1000).toISOString();
+    const summary = questionSummary(record.question);
+    const askedAt = record.askedAt;
+    const expiresAt = record.expiresAt;
     this.postedQuestions.set(id, { summary, askedAt });
 
     const remainingSec = Math.max(0, Math.round((Date.parse(expiresAt) - Date.now()) / 1000));
@@ -396,12 +416,10 @@ export class EventDispatcher {
     // visible even under --content-only — announce bypasses the progress
     // console gate but still lands in the thread log for follow/next/output.
     this.announce(`QUESTION FROM CODEX (expires in ${formatSeconds(remainingSec)})`);
-    if (record) {
-      const questionLines = record.question.split("\n");
-      for (const qLine of questionLines.slice(0, 6)) this.announce(`  ${qLine}`);
-      if (questionLines.length > 6) {
-        this.announce(`  … (${questionLines.length - 6} more lines — \`codex-collab questions ${id}\` shows the full text)`);
-      }
+    const questionLines = record.question.split("\n");
+    for (const qLine of questionLines.slice(0, 6)) this.announce(`  ${qLine}`);
+    if (questionLines.length > 6) {
+      this.announce(`  … (${questionLines.length - 6} more lines — \`codex-collab questions ${id}\` shows the full text)`);
     }
     // shellQuote, not naive interpolation — a quote in the workspace path
     // would break the hint or worse (it's meant to be copy-pasted).
@@ -431,10 +449,14 @@ export class EventDispatcher {
       resolved = { id, summary, outcome };
     }
     // The mirror shows the newest still-live question; only blank it when
-    // nothing else from this turn is awaiting an answer.
-    this.livePendingQuestions.delete(id);
-    const remaining = [...this.livePendingQuestions.values()];
-    this.notifyQuestionPending(remaining.length > 0 ? remaining[remaining.length - 1] : null);
+    // nothing else from this turn is awaiting an answer. A question that was
+    // never live (recordless marker tracking) never touched the mirror, so
+    // its resolution must not touch it either.
+    const wasLive = this.livePendingQuestions.delete(id);
+    if (wasLive) {
+      const remaining = [...this.livePendingQuestions.values()];
+      this.notifyQuestionPending(remaining.length > 0 ? remaining[remaining.length - 1] : null);
+    }
     try {
       this.questionCtx?.onResolved?.(resolved);
     } catch (e) {
@@ -454,8 +476,9 @@ export class EventDispatcher {
    *  must stay visible under --content-only, mirroring how approval prompts
    *  bypass the progress gate. */
   private announce(text: string): void {
-    console.log(`[codex] ${text}`);
-    this.log(`[codex] ${text}`);
+    const clean = sanitizeForTerminal(text);
+    console.log(`[codex] ${clean}`);
+    this.log(`[codex] ${clean}`);
     this.flush();
   }
 
@@ -587,9 +610,14 @@ export class EventDispatcher {
     }
   }
 
+  /** Progress lines carry Codex-controlled text (command lines, message
+   *  previews, guardian rationale) into terminals — live here, and replayed
+   *  by follow/output from the log. Strip escape sequences at this single
+   *  boundary so embedded ANSI can't redraw or disguise what's shown. */
   private progress(text: string): void {
-    this.onProgress(text);
-    this.log(`[codex] ${text}`);
+    const clean = sanitizeForTerminal(text);
+    this.onProgress(clean);
+    this.log(`[codex] ${clean}`);
     this.flush();
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -400,7 +400,7 @@ export class EventDispatcher {
       const questionLines = record.question.split("\n");
       for (const qLine of questionLines.slice(0, 6)) this.announce(`  ${qLine}`);
       if (questionLines.length > 6) {
-        this.announce(`  … (${questionLines.length - 6} more lines — \`codex-collab questions\` shows the full text)`);
+        this.announce(`  … (${questionLines.length - 6} more lines — \`codex-collab questions ${id}\` shows the full text)`);
       }
     }
     // shellQuote, not naive interpolation — a quote in the workspace path

--- a/src/events.ts
+++ b/src/events.ts
@@ -7,10 +7,35 @@ import {
   type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
   type ErrorNotificationParams, type AutoApprovalReviewParams,
   type FileChange, type CommandExec,
+  type PendingQuestion, type ResolvedQuestion,
 } from "./types";
 import { saveGuardianDenial } from "./guardian";
+import { shellQuote } from "./approvals";
+import {
+  answerPath,
+  isStdinAskInvocation,
+  listPendingQuestions,
+  loadQuestion,
+  looksLikeAskInvocation,
+  parseQuestionMarker,
+  questionSummary,
+} from "./questions";
 
 type ProgressCallback = (line: string) => void;
+
+/** Wiring for the ask channel: where to read question files from and how to
+ *  mirror pending/resolved state onto the run record. Set by the turn owner
+ *  once the runId is known (setQuestionContext). */
+export interface QuestionStreamContext {
+  mailboxDir: string;
+  /** Echoed in the answer hint (falls back to the question's workspaceDir). */
+  workspaceDir?: string;
+  /** Fired with the question when one is posted, and with null on every
+   *  resolution — mirrors PendingApproval's onPending contract. */
+  onPending?: (pending: PendingQuestion | null) => void;
+  /** Fired once per question when it resolves (answered or expired). */
+  onResolved?: (resolved: ResolvedQuestion) => void;
+}
 
 export class EventDispatcher {
   private accumulatedOutput = "";
@@ -27,6 +52,56 @@ export class EventDispatcher {
   /** When set, denied Guardian reviews are persisted here so the user can
    *  override them later with `approve --guardian`. */
   private guardianDir: string | null;
+  /** Ask-channel wiring; null until the turn owner calls setQuestionContext. */
+  private questionCtx: QuestionStreamContext | null = null;
+  /** Item IDs of commands that are `codex-collab ask` invocations. Marker
+   *  parsing is restricted to THESE items' output — without the gate, any
+   *  command whose stdout contains a marker-shaped line (a cat of a log, a
+   *  grep, prompt-injected output) could fabricate or fake-resolve question
+   *  state on the run record. */
+  private askCommandItems = new Set<string>();
+  /** Partial trailing line of each ask command's output stream, keyed by
+   *  item ID — markers can split across delta chunks, and concurrent
+   *  commands' deltas interleave. Bounded (a marker line is short; anything
+   *  longer is not a marker). */
+  private commandOutputTails = new Map<string, string>();
+  /** Summaries of questions seen posted this turn, so resolved entries carry
+   *  them without re-reading a (possibly deleted) question file. */
+  private postedQuestions = new Map<string, { summary: string | null; askedAt: string }>();
+  /** Question events already handled (`id:kind`), shared by every detection
+   *  path — output-delta markers, aggregated-output markers, and the mailbox
+   *  watchers — so each event fires exactly once no matter which path wins. */
+  private seenQuestionMarkers = new Set<string>();
+  /** Mailbox watchers. Codex ≥0.142 runs commands through session-based
+   *  exec, where output deltas are not a reliable LIVE channel — the posted
+   *  marker may only surface at command completion, long after the question
+   *  needed announcing. The mailbox is the source of truth, so an `ask`
+   *  command *starting* arms a short scan for its question file, and each
+   *  posted question gets a resolution watcher. Markers remain the fast
+   *  path and refine latency when they do arrive. All timers are unref'd
+   *  (they must never hold the process open) and cleared on reset. */
+  private askScanTimer: ReturnType<typeof setInterval> | null = null;
+  private askScanDeadline = 0;
+  private askScanSince = 0;
+  /** When the current scan was armed (no clock-skew backdate) — the
+   *  sole-candidate fallback only trusts questions posted after this, so a
+   *  concurrent run's slightly-older question can't be claimed while our
+   *  own ask hasn't written its file yet. */
+  private askScanArmedAt = 0;
+  /** The ask command line the scan was armed for. `ask "…"` embeds the
+   *  question text in the command, so candidates can be matched to THIS
+   *  run's ask — without it, two workspace runs asking within the same
+   *  window could attribute each other's questions. */
+  private askScanCommand = "";
+  /** Armed command is a stdin ask (`ask -`) — the only form where text
+   *  matching is impossible and the sole-candidate fallback is justified. */
+  private askScanStdin = false;
+  /** Questions posted this turn that have not yet resolved — the run
+   *  record's pendingQuestion mirror shows the newest of these, so
+   *  resolving one question must not blank the mirror while another is
+   *  still awaiting an answer. */
+  private livePendingQuestions = new Map<string, PendingQuestion>();
+  private resolutionWatchers = new Map<string, ReturnType<typeof setInterval>>();
 
   constructor(
     logPath: string,
@@ -46,6 +121,15 @@ export class EventDispatcher {
 
     if (item.type === "commandExecution") {
       this.progress(`Running: ${item.command}`);
+      // An `ask` starting is the live signal a question is imminent. Session
+      // -based exec makes output deltas unreliable as a LIVE channel, so the
+      // question is surfaced from the mailbox itself.
+      // Invocation detection, not substring match — a grep/echo that merely
+      // MENTIONS the command must not feed marker parsing or arm the scan.
+      if (this.questionCtx && looksLikeAskInvocation(item.command)) {
+        this.askCommandItems.add(item.id);
+        this.armAskScan(item.command);
+      }
     }
 
     // Separate consecutive messages
@@ -79,6 +163,20 @@ export class EventDispatcher {
 
     switch (item.type) {
       case "commandExecution": {
+        // Fallback marker scan: if the output deltas were not delivered for
+        // this command, the aggregated output still carries the ask markers
+        // (seenQuestionMarkers dedupes against the delta path). Gated on the
+        // command itself being an ask — same spoofing concern as the deltas.
+        if (
+          this.questionCtx &&
+          looksLikeAskInvocation(item.command) &&
+          typeof item.aggregatedOutput === "string" &&
+          item.aggregatedOutput.includes("[codex-collab] question ")
+        ) {
+          for (const line of item.aggregatedOutput.split("\n")) this.handleMarkerLine(line);
+        }
+        this.askCommandItems.delete(item.id);
+        this.commandOutputTails.delete(item.id);
         if (item.status !== "completed") {
           this.progress(`Command ${item.status}: ${item.command}`);
           break;
@@ -133,8 +231,232 @@ export class EventDispatcher {
       // Final-answer text is captured whole from item/completed (deltas
       // always precede their item's completion), so no per-delta routing
       // into finalAnswerOutput is needed here.
+    } else if (method === "item/commandExecution/outputDelta") {
+      // The ask channel's attribution path: `codex-collab ask` prints marker
+      // lines to stdout. Only ask commands' output is scanned — marker-shaped
+      // text in any other command's output must stay inert.
+      if (this.askCommandItems.has(params.itemId)) {
+        this.scanCommandOutput(params.itemId, params.delta);
+      }
     }
     // No per-character logging — accumulated text is logged at flush
+  }
+
+  // -------------------------------------------------------------------------
+  // Ask channel — question markers in the command output stream
+  // -------------------------------------------------------------------------
+
+  /** Arm ask-channel handling. Called by the turn owner once the runId is
+   *  known; without it, marker lines in command output are ignored. */
+  setQuestionContext(ctx: QuestionStreamContext | null): void {
+    this.questionCtx = ctx;
+  }
+
+  private scanCommandOutput(itemId: string, chunk: string): void {
+    if (!this.questionCtx) return;
+    let tail = (this.commandOutputTails.get(itemId) ?? "") + chunk;
+    const lines = tail.split("\n");
+    tail = lines.pop() ?? "";
+    // A marker line is <100 chars; a longer tail can't become one. Keep the
+    // buffer bounded against commands that stream huge single-line output.
+    if (tail.length > 512) tail = tail.slice(-512);
+    this.commandOutputTails.set(itemId, tail);
+    for (const line of lines) this.handleMarkerLine(line);
+  }
+
+  private handleMarkerLine(line: string): void {
+    if (!this.questionCtx) return;
+    const marker = parseQuestionMarker(line);
+    if (!marker) return;
+    if (marker.kind === "posted") {
+      this.emitPosted(marker.id, loadQuestion(this.questionCtx.mailboxDir, marker.id), marker.seconds);
+    } else {
+      // Resolution markers only count for questions posted in THIS turn —
+      // a resolved-marker for an unknown id must not append audit entries.
+      if (!this.postedQuestions.has(marker.id)) return;
+      this.emitResolved(marker.id, marker.kind, marker.kind === "answered" ? marker.seconds * 1000 : undefined);
+    }
+  }
+
+  /** An `ask` command has started: scan the mailbox briefly for the question
+   *  file it is about to write. The askedAt window keeps a concurrent run's
+   *  pre-existing question from being attributed to this command. */
+  private armAskScan(command: string): void {
+    this.askScanArmedAt = Date.now();
+    this.askScanSince = this.askScanArmedAt - 2000;
+    this.askScanDeadline = this.askScanArmedAt + 20_000;
+    this.askScanCommand = normalizeForMatch(command);
+    this.askScanStdin = isStdinAskInvocation(command);
+    if (this.askScanTimer !== null) return; // already scanning — window extended above
+    this.askScanTimer = setInterval(() => this.scanMailboxForPosted(), 1000);
+    unrefTimer(this.askScanTimer);
+  }
+
+  private stopAskScan(): void {
+    if (this.askScanTimer !== null) {
+      clearInterval(this.askScanTimer);
+      this.askScanTimer = null;
+    }
+  }
+
+  private scanMailboxForPosted(): void {
+    const ctx = this.questionCtx;
+    if (!ctx) {
+      this.stopAskScan();
+      return;
+    }
+    try {
+      const candidates = listPendingQuestions(ctx.mailboxDir).filter((record) => {
+        const askedAtMs = Date.parse(record.askedAt);
+        return Number.isFinite(askedAtMs)
+          && askedAtMs >= this.askScanSince
+          && !this.seenQuestionMarkers.has(`${record.id}:posted`);
+      });
+      // Prefer the candidate whose text appears in the armed command line —
+      // that's THIS run's ask. The sole-candidate fallback applies ONLY to
+      // stdin asks (where text matching is impossible) and only to
+      // questions posted after the command started: a text-bearing ask
+      // whose candidate doesn't match must keep scanning until its own
+      // file appears, or a concurrent run's question gets claimed and the
+      // scan stops before the real one is ever announced. Ambiguity is
+      // left for the marker path, which is per-command and cannot
+      // misattribute.
+      const matched = candidates.find(
+        (record) => this.askScanCommand.includes(normalizeForMatch(record.question).slice(0, 80)),
+      );
+      const fallback = this.askScanStdin
+        ? candidates.filter((record) => Date.parse(record.askedAt) >= this.askScanArmedAt)
+        : [];
+      const pick = matched ?? (fallback.length === 1 ? fallback[0] : undefined);
+      if (pick) {
+        this.emitPosted(pick.id, pick);
+        this.stopAskScan(); // one ask command posts exactly one question
+        return;
+      }
+    } catch (e) {
+      console.error(`[codex] Warning: mailbox scan failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    if (Date.now() > this.askScanDeadline) this.stopAskScan();
+  }
+
+  /** Watch a posted question until it resolves. `ask` deletes the files on
+   *  answer and stamps `expired` on timeout, so the mailbox state alone
+   *  distinguishes the outcomes; a resolution marker (when the output stream
+   *  does deliver one) short-circuits this via the shared dedupe set. */
+  private armResolutionWatcher(id: string): void {
+    if (this.resolutionWatchers.has(id)) return;
+    const timer = setInterval(() => {
+      const ctx = this.questionCtx;
+      if (!ctx || this.seenQuestionMarkers.has(`${id}:resolved`)) {
+        this.stopResolutionWatcher(id);
+        return;
+      }
+      try {
+        const record = loadQuestion(ctx.mailboxDir, id);
+        if (record?.expired) {
+          this.emitResolved(id, "expired");
+        } else if (!record || existsSync(answerPath(ctx.mailboxDir, id))) {
+          const askedAtMs = Date.parse(this.postedQuestions.get(id)?.askedAt ?? "");
+          const latencyMs = Number.isFinite(askedAtMs)
+            ? Math.max(1000, Math.round((Date.now() - askedAtMs) / 1000) * 1000)
+            : undefined;
+          this.emitResolved(id, "answered", latencyMs);
+        }
+      } catch (e) {
+        console.error(`[codex] Warning: question watcher failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }, 2000);
+    unrefTimer(timer);
+    this.resolutionWatchers.set(id, timer);
+  }
+
+  private stopResolutionWatcher(id: string): void {
+    const timer = this.resolutionWatchers.get(id);
+    if (timer !== undefined) {
+      clearInterval(timer);
+      this.resolutionWatchers.delete(id);
+    }
+  }
+
+  private emitPosted(id: string, record: ReturnType<typeof loadQuestion>, deadlineSec?: number): void {
+    const ctx = this.questionCtx;
+    if (!ctx) return;
+    const key = `${id}:posted`;
+    if (this.seenQuestionMarkers.has(key)) return;
+    this.seenQuestionMarkers.add(key);
+
+    const summary = record ? questionSummary(record.question) : null;
+    const askedAt = record?.askedAt ?? new Date().toISOString();
+    const expiresAt = record?.expiresAt
+      ?? new Date(Date.now() + (deadlineSec ?? 600) * 1000).toISOString();
+    this.postedQuestions.set(id, { summary, askedAt });
+
+    const remainingSec = Math.max(0, Math.round((Date.parse(expiresAt) - Date.now()) / 1000));
+    // Like approval prompts, question prompts are actionable and must stay
+    // visible even under --content-only — announce bypasses the progress
+    // console gate but still lands in the thread log for follow/next/output.
+    this.announce(`QUESTION FROM CODEX (expires in ${formatSeconds(remainingSec)})`);
+    if (record) {
+      const questionLines = record.question.split("\n");
+      for (const qLine of questionLines.slice(0, 6)) this.announce(`  ${qLine}`);
+      if (questionLines.length > 6) {
+        this.announce(`  … (${questionLines.length - 6} more lines — \`codex-collab questions\` shows the full text)`);
+      }
+    }
+    // shellQuote, not naive interpolation — a quote in the workspace path
+    // would break the hint or worse (it's meant to be copy-pasted).
+    const dirHint = ctx.workspaceDir ? ` -d ${shellQuote(ctx.workspaceDir)}` : "";
+    this.announce(`  Answer: codex-collab answer ${id} "<text>"${dirHint}`);
+    const pending: PendingQuestion = { id, summary, askedAt, expiresAt };
+    this.livePendingQuestions.set(id, pending);
+    this.notifyQuestionPending(pending);
+    this.armResolutionWatcher(id);
+  }
+
+  private emitResolved(id: string, outcome: "answered" | "expired", latencyMs?: number): void {
+    // Single resolution key regardless of outcome: whichever detection path
+    // fires first wins, and a late marker can't double-record or contradict.
+    const key = `${id}:resolved`;
+    if (this.seenQuestionMarkers.has(key)) return;
+    this.seenQuestionMarkers.add(key);
+    this.stopResolutionWatcher(id);
+
+    const summary = this.postedQuestions.get(id)?.summary ?? null;
+    let resolved: ResolvedQuestion;
+    if (outcome === "answered") {
+      this.announce(`Question ${id} answered${latencyMs !== undefined ? ` after ${formatSeconds(Math.round(latencyMs / 1000))}` : ""}.`);
+      resolved = { id, summary, outcome, ...(latencyMs !== undefined ? { latencyMs } : {}) };
+    } else {
+      this.announce(`Question ${id} expired unanswered — Codex proceeds on its own judgment.`);
+      resolved = { id, summary, outcome };
+    }
+    // The mirror shows the newest still-live question; only blank it when
+    // nothing else from this turn is awaiting an answer.
+    this.livePendingQuestions.delete(id);
+    const remaining = [...this.livePendingQuestions.values()];
+    this.notifyQuestionPending(remaining.length > 0 ? remaining[remaining.length - 1] : null);
+    try {
+      this.questionCtx?.onResolved?.(resolved);
+    } catch (e) {
+      console.error(`[codex] Warning: question-resolved observer failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  private notifyQuestionPending(pending: PendingQuestion | null): void {
+    try {
+      this.questionCtx?.onPending?.(pending);
+    } catch (e) {
+      console.error(`[codex] Warning: pending-question observer failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  /** Console + log, unconditionally — for actionable lines (questions) that
+   *  must stay visible under --content-only, mirroring how approval prompts
+   *  bypass the progress gate. */
+  private announce(text: string): void {
+    console.log(`[codex] ${text}`);
+    this.log(`[codex] ${text}`);
+    this.flush();
   }
 
   /** Surface Guardian (auto_review) approval reviews in the progress stream
@@ -238,6 +560,13 @@ export class EventDispatcher {
     this.reviewOutput = "";
     this.filesChanged = [];
     this.commandsRun = [];
+    this.askCommandItems.clear();
+    this.commandOutputTails.clear();
+    this.postedQuestions.clear();
+    this.livePendingQuestions.clear();
+    this.seenQuestionMarkers.clear();
+    this.stopAskScan();
+    for (const id of [...this.resolutionWatchers.keys()]) this.stopResolutionWatcher(id);
   }
 
   /** Write accumulated agent output to the log (called before final flush). */
@@ -270,6 +599,29 @@ export class EventDispatcher {
     // Auto-flush every 20 entries
     if (this.logBuffer.length >= 20) this.flush();
   }
+}
+
+/** Collapse shell-quoting differences so question text can be matched
+ *  against the command line it was embedded in: strip quotes, backslashes,
+ *  and whitespace runs, which `zsh -lc '…'` wrapping and argv re-quoting
+ *  rewrite freely. */
+function normalizeForMatch(text: string): string {
+  return text.replace(/[\\'"]/g, "").replace(/\s+/g, " ");
+}
+
+/** Timers here observe state for the user's benefit; they must never hold
+ *  the process open after the turn's real work is done. */
+function unrefTimer(timer: ReturnType<typeof setInterval>): void {
+  (timer as unknown as { unref?: () => void }).unref?.();
+}
+
+/** "90s" → "1m 30s"; sub-minute values stay in seconds. Local to avoid an
+ *  import cycle with commands/shared (which imports this module). */
+function formatSeconds(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const min = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  return rem === 0 ? `${min}m` : `${min}m ${rem}s`;
 }
 
 /** JSON.stringify that never throws (circular refs) and bounds entry size —

--- a/src/prompts/collab.md
+++ b/src/prompts/collab.md
@@ -1,0 +1,22 @@
+---
+name: collab
+description: Long or autonomous task with the ask channel — a collaborator stays reachable mid-run via codex-collab ask
+---
+
+{{PROMPT}}
+
+---
+
+COLLABORATION — you are not working alone. The collaborator who launched this task is reachable while you work:
+
+    codex-collab ask "<your question>"
+
+Channel mechanics and costs:
+
+- The command posts your question and waits. It ALWAYS exits on its own: with an answer, or after ~10 minutes (`--timeout <sec>` to change) with NO ANSWER — which means nobody was available, not that asking was wrong. Keep polling the running command until it exits.
+- Answers cost your collaborator real attention and minutes of your run; expiries cost only the wait.
+- Your collaborator sees only what you write — the context you include is the context they answer with. For long questions, pipe them on stdin: `codex-collab ask -`.
+- An answer is their judgment, possibly informed by context you lack. Weigh it against what you know; if you disagree, say so — ask a follow-up or record the disagreement — rather than silently complying.
+- If a decision genuinely blocks you, ending your turn with `QUESTION FOR COLLABORATOR:` on its own line pauses the task until the collaborator resumes it.
+
+Whether to consult, when, how often, and what to do with the answers is yours to decide.

--- a/src/questions.test.ts
+++ b/src/questions.test.ts
@@ -1,0 +1,376 @@
+// src/questions.test.ts — Tests for the ask-channel question mailbox
+
+import { describe, expect, test, afterAll } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { join } from "path";
+import {
+  DEFAULT_ASK_TIMEOUT_SEC,
+  answerPath,
+  generateQuestionId,
+  isQuestionPending,
+  listPendingQuestions,
+  listQuestions,
+  loadQuestion,
+  markerAnswered,
+  markerExpired,
+  markerPosted,
+  parseQuestionMarker,
+  pollForAnswer,
+  questionPath,
+  questionSummary,
+  removeQuestion,
+  sanitizeForTerminal,
+  sweepQuestions,
+  updateQuestion,
+  writeAnswer,
+  writeQuestion,
+} from "./questions";
+import type { QuestionRecord } from "./types";
+
+const tmpRoot = join(process.env.TMPDIR ?? "/tmp", "questions-test-" + process.pid);
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+let dirCounter = 0;
+function freshMailbox(): string {
+  const dir = join(tmpRoot, `mb-${dirCounter++}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeRecord(overrides?: Partial<QuestionRecord>): QuestionRecord {
+  const now = Date.now();
+  return {
+    id: generateQuestionId(),
+    question: "Drop the FK constraints or dual-write?\nContext: audit_log references sessions.",
+    askedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + DEFAULT_ASK_TIMEOUT_SEC * 1000).toISOString(),
+    workspaceDir: "/tmp/ws",
+    pid: process.pid,
+    ...overrides,
+  };
+}
+
+describe("question IDs", () => {
+  test("are q + 7 hex chars and marker-parseable", () => {
+    const id = generateQuestionId();
+    expect(id).toMatch(/^q[0-9a-f]{7}$/);
+  });
+});
+
+describe("mailbox roundtrip", () => {
+  test("write, load, answer, remove", async () => {
+    const dir = freshMailbox();
+    const record = makeRecord();
+    writeQuestion(dir, record);
+
+    const loaded = loadQuestion(dir, record.id);
+    expect(loaded).toEqual(record);
+    expect(isQuestionPending(dir, loaded!)).toBe(true);
+
+    writeAnswer(dir, record.id, "Dual-write. The audit trail feeds compliance.");
+    expect(isQuestionPending(dir, loaded!)).toBe(false);
+
+    const answer = await pollForAnswer(dir, record.id, Date.now() + 1000, 10);
+    expect(answer).toBe("Dual-write. The audit trail feeds compliance.");
+
+    removeQuestion(dir, record.id);
+    expect(existsSync(questionPath(dir, record.id))).toBe(false);
+    expect(existsSync(answerPath(dir, record.id))).toBe(false);
+  });
+
+  test("writeQuestion creates the mailbox dir on demand", () => {
+    const dir = join(freshMailbox(), "nested", "questions");
+    const record = makeRecord();
+    writeQuestion(dir, record);
+    expect(loadQuestion(dir, record.id)).toEqual(record);
+  });
+
+  test("pollForAnswer returns null when the deadline lapses", async () => {
+    const dir = freshMailbox();
+    const record = makeRecord();
+    writeQuestion(dir, record);
+    const answer = await pollForAnswer(dir, record.id, Date.now() + 40, 10);
+    expect(answer).toBeNull();
+  });
+
+  test("loadQuestion rejects corrupt and wrong-shape files", () => {
+    const dir = freshMailbox();
+    writeFileSync(join(dir, "qbadjson1.json"), "{nope", { mode: 0o600 });
+    writeFileSync(join(dir, "qbadshape.json"), JSON.stringify({ id: 42 }), { mode: 0o600 });
+    expect(loadQuestion(dir, "qbadjson1")).toBeNull();
+    expect(loadQuestion(dir, "qbadshape")).toBeNull();
+    // And listQuestions skips them without throwing
+    expect(listQuestions(dir)).toEqual([]);
+  });
+});
+
+describe("pending semantics", () => {
+  test("expired flag, past deadline, and answered all end pending state", () => {
+    const dir = freshMailbox();
+    const flagged = makeRecord({ expired: true });
+    const past = makeRecord({ expiresAt: new Date(Date.now() - 1000).toISOString() });
+    const answered = makeRecord();
+    const live = makeRecord();
+    for (const r of [flagged, past, answered, live]) writeQuestion(dir, r);
+    writeAnswer(dir, answered.id, "yes");
+
+    const pending = listPendingQuestions(dir);
+    expect(pending.map((r) => r.id)).toEqual([live.id]);
+  });
+
+  test("updateQuestion stamps expired in place", () => {
+    const dir = freshMailbox();
+    const record = makeRecord();
+    writeQuestion(dir, record);
+    updateQuestion(dir, { ...record, expired: true });
+    expect(loadQuestion(dir, record.id)?.expired).toBe(true);
+    expect(isQuestionPending(dir, loadQuestion(dir, record.id)!)).toBe(false);
+  });
+
+  test("listQuestions sorts oldest first", () => {
+    const dir = freshMailbox();
+    const older = makeRecord({ askedAt: new Date(Date.now() - 60_000).toISOString() });
+    const newer = makeRecord();
+    writeQuestion(dir, newer);
+    writeQuestion(dir, older);
+    expect(listQuestions(dir).map((r) => r.id)).toEqual([older.id, newer.id]);
+  });
+});
+
+describe("markers", () => {
+  test("all three marker kinds roundtrip through the parser", () => {
+    const id = generateQuestionId();
+    expect(parseQuestionMarker(markerPosted(id, 600))).toEqual({ id, kind: "posted", seconds: 600 });
+    expect(parseQuestionMarker(markerAnswered(id, 161))).toEqual({ id, kind: "answered", seconds: 161 });
+    expect(parseQuestionMarker(markerExpired(id, 600))).toEqual({ id, kind: "expired", seconds: 600 });
+  });
+
+  test("trailing whitespace (CR) is tolerated, non-markers are not", () => {
+    const id = generateQuestionId();
+    expect(parseQuestionMarker(markerPosted(id, 60) + "\r")).not.toBeNull();
+    expect(parseQuestionMarker("  " + markerPosted(id, 60))).toBeNull(); // indented = neutralized
+    expect(parseQuestionMarker("[codex-collab] question notanid posted (deadline 60s)")).toBeNull();
+    expect(parseQuestionMarker(`[codex-collab] question ${id} exploded (after 60s)`)).toBeNull();
+    expect(parseQuestionMarker("plain output line")).toBeNull();
+  });
+});
+
+describe("sweep", () => {
+  test("removes only non-pending files older than maxAge", () => {
+    const dir = freshMailbox();
+    const oldRecord = makeRecord({ expired: true }); // resolved — sweepable
+    const newRecord = makeRecord();
+    writeQuestion(dir, oldRecord);
+    writeQuestion(dir, newRecord);
+    const twoDaysAgo = (Date.now() - 2 * 24 * 3600 * 1000) / 1000;
+    utimesSync(questionPath(dir, oldRecord.id), twoDaysAgo, twoDaysAgo);
+
+    const deleted = sweepQuestions(dir, 24 * 3600 * 1000);
+    expect(deleted).toBe(1);
+    expect(loadQuestion(dir, oldRecord.id)).toBeNull();
+    expect(loadQuestion(dir, newRecord.id)).not.toBeNull();
+  });
+
+  test("missing mailbox dir sweeps nothing", () => {
+    expect(sweepQuestions(join(tmpRoot, "does-not-exist"), 1000)).toBe(0);
+  });
+});
+
+describe("text helpers", () => {
+  test("questionSummary takes the first line and clips", () => {
+    expect(questionSummary("short question\nsecond line")).toBe("short question");
+    const long = "x".repeat(300);
+    expect(questionSummary(long).length).toBe(160);
+    expect(questionSummary(long).endsWith("…")).toBe(true);
+  });
+
+  test("sanitizeForTerminal strips control chars but keeps newlines and tabs", () => {
+    expect(sanitizeForTerminal("a\x1b[31mred\x07\nb\tc")).toBe("a[31mred\nb\tc");
+  });
+});
+
+describe("orphaned questions (review round 2)", () => {
+  const { isAskerAlive } = require("./questions") as typeof import("./questions");
+  const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
+
+  /** A PID guaranteed dead: spawn a no-op process and wait for it to exit. */
+  function deadPid(): number {
+    const result = spawnSync(process.execPath, ["--version"], { stdio: "ignore" });
+    if (typeof result.pid !== "number" || result.pid <= 0) throw new Error("could not obtain dead pid");
+    return result.pid;
+  }
+
+  test("a question whose asker died is not pending, not listed, not answerable-looking", () => {
+    const dir = freshMailbox();
+    const orphan = makeRecord({ pid: deadPid() });
+    const live = makeRecord(); // our own pid — alive
+    writeQuestion(dir, orphan);
+    writeQuestion(dir, live);
+
+    expect(isAskerAlive(orphan)).toBe(false);
+    expect(isAskerAlive(live)).toBe(true);
+    expect(isQuestionPending(dir, orphan)).toBe(false);
+    expect(listPendingQuestions(dir).map((r) => r.id)).toEqual([live.id]);
+  });
+
+  test("legacy records without a usable pid are never suppressed", () => {
+    expect(isAskerAlive(makeRecord({ pid: 0 }))).toBe(true);
+    expect(isAskerAlive(makeRecord({ pid: -1 }))).toBe(true);
+    expect(isAskerAlive({ ...makeRecord(), pid: undefined as unknown as number })).toBe(true);
+  });
+});
+
+describe("exclusive answer claim (review round 2)", () => {
+  const { writeAnswerExclusive } = require("./questions") as typeof import("./questions");
+
+  test("first responder wins, second is rejected, first answer survives", async () => {
+    const dir = freshMailbox();
+    const record = makeRecord();
+    writeQuestion(dir, record);
+
+    expect(writeAnswerExclusive(dir, record.id, "first answer")).toBe(true);
+    expect(writeAnswerExclusive(dir, record.id, "second answer")).toBe(false);
+
+    const answer = await pollForAnswer(dir, record.id, Date.now() + 500, 10);
+    expect(answer).toBe("first answer");
+  });
+
+  test("removeQuestion cleans the claim so files never linger", () => {
+    const dir = freshMailbox();
+    const record = makeRecord();
+    writeQuestion(dir, record);
+    writeAnswerExclusive(dir, record.id, "answer");
+    removeQuestion(dir, record.id);
+    const { readdirSync } = require("fs") as typeof import("fs");
+    expect(readdirSync(dir)).toEqual([]);
+  });
+});
+
+describe("ask invocation detection", () => {
+  const { looksLikeAskInvocation } = require("./questions") as typeof import("./questions");
+
+  test("recognizes genuine invocations", () => {
+    expect(looksLikeAskInvocation(`codex-collab ask "which way?"`)).toBe(true);
+    expect(looksLikeAskInvocation(`/bin/zsh -lc 'codex-collab ask "which way?"'`)).toBe(true);
+    expect(looksLikeAskInvocation(`sh -c "codex-collab ask 'q'"`)).toBe(true);
+    expect(looksLikeAskInvocation(`/bin/zsh -lc 'cat q.md | codex-collab ask -'`)).toBe(true);
+    expect(looksLikeAskInvocation(`cd /repo && codex-collab ask "q"`)).toBe(true);
+  });
+
+  test("rejects mere mentions", () => {
+    expect(looksLikeAskInvocation(`grep -rh "codex-collab ask" docs/`)).toBe(false);
+    expect(looksLikeAskInvocation(`echo 'codex-collab ask'`)).toBe(false);
+    expect(looksLikeAskInvocation(`cat "/notes/codex-collab ask.md"`)).toBe(false);
+    expect(looksLikeAskInvocation(`git log --grep 'codex-collab ask stuff'`)).toBe(false);
+    expect(looksLikeAskInvocation(`codex-collab answer q1234567 "text"`)).toBe(false);
+  });
+});
+
+describe("mailbox privacy verification", () => {
+  const { verifyMailboxDir } = require("./questions") as typeof import("./questions");
+  const { chmodSync, symlinkSync } = require("fs") as typeof import("fs");
+
+  test("a private mailbox passes and roundtrips", () => {
+    const dir = freshMailbox();
+    verifyMailboxDir(dir); // must not throw
+    const record = makeRecord();
+    writeQuestion(dir, record);
+    expect(loadQuestion(dir, record.id)).toEqual(record);
+  });
+
+  test("a group/world-writable mailbox is refused", () => {
+    const dir = freshMailbox();
+    chmodSync(dir, 0o777);
+    expect(() => verifyMailboxDir(dir)).toThrow(/not private/);
+    expect(() => writeQuestion(dir, makeRecord())).toThrow(/not private/);
+    expect(() => listQuestions(dir)).toThrow(/not private/);
+    chmodSync(dir, 0o700); // restore for cleanup
+  });
+
+  test("a symlinked mailbox is refused", () => {
+    const realDir = freshMailbox();
+    const linkPath = join(tmpRoot, `mb-link-${Date.now()}`);
+    symlinkSync(realDir, linkPath);
+    expect(() => verifyMailboxDir(linkPath)).toThrow(/not private/);
+  });
+});
+
+describe("sweep safety", () => {
+  const { symlinkSync } = require("fs") as typeof import("fs");
+
+  test("a symlinked mailbox is not swept and its target stays intact", () => {
+    const realDir = freshMailbox();
+    const record = makeRecord();
+    writeQuestion(realDir, record);
+    const old = (Date.now() - 2 * 24 * 3600 * 1000) / 1000;
+    utimesSync(questionPath(realDir, record.id), old, old);
+
+    const linkPath = join(tmpRoot, `mb-sweep-link-${Date.now()}`);
+    symlinkSync(realDir, linkPath);
+
+    expect(sweepQuestions(linkPath, 24 * 3600 * 1000)).toBe(0);
+    expect(loadQuestion(realDir, record.id)).not.toBeNull(); // untouched
+  });
+
+  test("unexpected filenames are never deleted, even when old", () => {
+    const dir = freshMailbox();
+    const strayPath = join(dir, "unrelated.txt");
+    writeFileSync(strayPath, "not ours to delete", { mode: 0o600 });
+    const old = (Date.now() - 2 * 24 * 3600 * 1000) / 1000;
+    utimesSync(strayPath, old, old);
+
+    expect(sweepQuestions(dir, 24 * 3600 * 1000)).toBe(0);
+    expect(existsSync(strayPath)).toBe(true);
+  });
+});
+
+describe("review-hardening regressions", () => {
+  const { looksLikeAskInvocation, isStdinAskInvocation, isAskerAlive } =
+    require("./questions") as typeof import("./questions");
+
+  test("unquoted mentions are rejected; prefix wrappers are accepted false negatives", () => {
+    // The whitespace hole: an unquoted grep pattern is a mention, not an invocation.
+    expect(looksLikeAskInvocation(`grep -rh codex-collab ask logs/`)).toBe(false);
+    expect(looksLikeAskInvocation(`echo codex-collab ask`)).toBe(false);
+    // Documented degradation: prefix commands are missed — enrichment-only cost.
+    expect(looksLikeAskInvocation(`timeout 600 codex-collab ask "q"`)).toBe(false);
+    // Command positions still recognized.
+    expect(looksLikeAskInvocation(`codex-collab ask "q"`)).toBe(true);
+    expect(looksLikeAskInvocation(`cd /repo && codex-collab ask "q"`)).toBe(true);
+    expect(looksLikeAskInvocation(`/bin/zsh -lc 'cat q.md | codex-collab ask -'`)).toBe(true);
+  });
+
+  test("stdin ask detection", () => {
+    expect(isStdinAskInvocation(`/bin/zsh -lc 'cat q.md | codex-collab ask -'`)).toBe(true);
+    expect(isStdinAskInvocation(`codex-collab ask - --timeout 60`)).toBe(true);
+    expect(isStdinAskInvocation(`codex-collab ask "a question"`)).toBe(false);
+  });
+
+  test("loadQuestion rejects a record missing askedAt instead of crashing listQuestions", () => {
+    const dir = freshMailbox();
+    const id = generateQuestionId();
+    writeFileSync(join(dir, `${id}.json`), JSON.stringify({
+      id, question: "q", expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      workspaceDir: "/tmp/ws", pid: process.pid,
+    }), { mode: 0o600 });
+    expect(loadQuestion(dir, id)).toBeNull();
+    expect(listQuestions(dir)).toEqual([]); // sorts without throwing
+  });
+
+  test("sweep never deletes a still-pending question with a live asker", () => {
+    const dir = freshMailbox();
+    const longAsk = makeRecord({ expiresAt: new Date(Date.now() + 48 * 3600 * 1000).toISOString() });
+    writeQuestion(dir, longAsk);
+    const old = (Date.now() - 2 * 24 * 3600 * 1000) / 1000;
+    utimesSync(questionPath(dir, longAsk.id), old, old);
+
+    expect(isAskerAlive(longAsk)).toBe(true);
+    expect(sweepQuestions(dir, 24 * 3600 * 1000)).toBe(0);
+    expect(loadQuestion(dir, longAsk.id)).not.toBeNull();
+
+    // …but an expired one of the same age is swept.
+    updateQuestion(dir, { ...longAsk, expired: true });
+    utimesSync(questionPath(dir, longAsk.id), old, old);
+    expect(sweepQuestions(dir, 24 * 3600 * 1000)).toBe(1);
+  });
+});

--- a/src/questions.test.ts
+++ b/src/questions.test.ts
@@ -346,6 +346,15 @@ describe("review-hardening regressions", () => {
     expect(isStdinAskInvocation(`/bin/zsh -lc 'cat q.md | codex-collab ask -'`)).toBe(true);
     expect(isStdinAskInvocation(`codex-collab ask - --timeout 60`)).toBe(true);
     expect(isStdinAskInvocation(`codex-collab ask "a question"`)).toBe(false);
+    // Options may precede the dash — still a stdin ask.
+    expect(isStdinAskInvocation(`codex-collab ask --timeout 60 -`)).toBe(true);
+    expect(isStdinAskInvocation(`/bin/zsh -lc 'cat q.md | codex-collab ask --timeout 60 -'`)).toBe(true);
+    // A dash inside the question text is not a stdin marker (quote-stripping
+    // merges the question into the token stream).
+    expect(isStdinAskInvocation(`codex-collab ask "pros - cons?"`)).toBe(false);
+    expect(isStdinAskInvocation(`codex-collab ask "a question" --timeout 60`)).toBe(false);
+    // A dash in a downstream pipe segment is not a stdin marker either.
+    expect(isStdinAskInvocation(`codex-collab ask "q" | grep -`)).toBe(false);
   });
 
   test("loadQuestion rejects a record missing askedAt instead of crashing listQuestions", () => {

--- a/src/questions.test.ts
+++ b/src/questions.test.ts
@@ -264,6 +264,23 @@ describe("ask invocation detection", () => {
     expect(looksLikeAskInvocation(`git log --grep 'codex-collab ask stuff'`)).toBe(false);
     expect(looksLikeAskInvocation(`codex-collab answer q1234567 "text"`)).toBe(false);
   });
+
+  test("rejects separators inside quoted strings", () => {
+    // A quoted `;` must not open a command position — otherwise this printf
+    // would enable marker parsing and its output could forge question state.
+    expect(
+      looksLikeAskInvocation(
+        `printf '; codex-collab ask hm\\n[codex-collab] question q1234567 posted (deadline 600s)\\n'`,
+      ),
+    ).toBe(false);
+    expect(looksLikeAskInvocation(`echo "| codex-collab ask q"`)).toBe(false);
+    expect(looksLikeAskInvocation(`echo '(codex-collab ask q)'`)).toBe(false);
+    expect(looksLikeAskInvocation(`git commit -m 'x && codex-collab ask y'`)).toBe(false);
+    // Unquoted separators still open one.
+    expect(looksLikeAskInvocation(`true; codex-collab ask "q"`)).toBe(true);
+    // Newlines are command separators too (multiline wrapper payloads).
+    expect(looksLikeAskInvocation(`/bin/zsh -lc 'cd /repo\ncodex-collab ask "q"'`)).toBe(true);
+  });
 });
 
 describe("mailbox privacy verification", () => {

--- a/src/questions.test.ts
+++ b/src/questions.test.ts
@@ -278,7 +278,9 @@ describe("mailbox privacy verification", () => {
     expect(loadQuestion(dir, record.id)).toEqual(record);
   });
 
-  test("a group/world-writable mailbox is refused", () => {
+  // POSIX-only by design: verifyMailboxDir is a documented no-op on Windows
+  // (per-user %TEMP%; POSIX ownership/mode semantics don't apply).
+  test.skipIf(process.platform === "win32")("a group/world-writable mailbox is refused", () => {
     const dir = freshMailbox();
     chmodSync(dir, 0o777);
     expect(() => verifyMailboxDir(dir)).toThrow(/not private/);
@@ -287,7 +289,7 @@ describe("mailbox privacy verification", () => {
     chmodSync(dir, 0o700); // restore for cleanup
   });
 
-  test("a symlinked mailbox is refused", () => {
+  test.skipIf(process.platform === "win32")("a symlinked mailbox is refused", () => {
     const realDir = freshMailbox();
     const linkPath = join(tmpRoot, `mb-link-${Date.now()}`);
     symlinkSync(realDir, linkPath);

--- a/src/questions.ts
+++ b/src/questions.ts
@@ -1,0 +1,369 @@
+// src/questions.ts — Ask-channel question mailbox (Codex asks, anyone answers)
+//
+// The channel duality that shapes everything here: approvals carry
+// PERMISSION (blocking, fail-closed — an unapproved action must not run);
+// questions carry JUDGMENT (non-blocking, fail-open — an unanswered question
+// expires and the asker proceeds on its own). `codex-collab ask` runs INSIDE
+// Codex's sandbox as a child of its exec tool, so the mailbox lives in temp
+// space (config.resolveMailboxDir), not the workspace state dir.
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { dirname, join } from "path";
+import { randomBytes } from "crypto";
+import { isPathInside, mailboxRoot } from "./config";
+import type { QuestionRecord } from "./types";
+
+/** Default answer deadline for `ask` (seconds). Kept an order of magnitude
+ *  below the default turn timeout so a question can expire gracefully well
+ *  before it endangers the turn budget. */
+export const DEFAULT_ASK_TIMEOUT_SEC = 600;
+
+/** Poll cadence for both the asker's answer wait and `next`'s event watch —
+ *  same 1s rhythm as the approvals decision poll. */
+export const QUESTION_POLL_INTERVAL_MS = 1000;
+
+// ---------------------------------------------------------------------------
+// Marker lines
+// ---------------------------------------------------------------------------
+// `ask` prints these to stdout. The host-side turn owner sees every byte the
+// command prints via item/commandExecution/outputDelta, so the markers are
+// how a question gets bound to its thread and run — attribution rides the
+// output stream, no host-side dir watching. Durations are integer seconds so
+// the host can parse them back; human-friendly text goes on separate lines.
+
+const MARKER_PREFIX = "[codex-collab] question ";
+
+export const QUESTION_MARKER_RE =
+  /^\[codex-collab\] question (q[0-9a-f]{7}) (posted \(deadline (\d+)s\)|answered \(after (\d+)s\)|expired \(after (\d+)s\))$/;
+
+export interface QuestionMarker {
+  id: string;
+  kind: "posted" | "answered" | "expired";
+  seconds: number;
+}
+
+export function markerPosted(id: string, deadlineSec: number): string {
+  return `${MARKER_PREFIX}${id} posted (deadline ${deadlineSec}s)`;
+}
+
+export function markerAnswered(id: string, latencySec: number): string {
+  return `${MARKER_PREFIX}${id} answered (after ${latencySec}s)`;
+}
+
+export function markerExpired(id: string, deadlineSec: number): string {
+  return `${MARKER_PREFIX}${id} expired (after ${deadlineSec}s)`;
+}
+
+/** Parse a single output line; null when it isn't a question marker. */
+export function parseQuestionMarker(line: string): QuestionMarker | null {
+  const m = QUESTION_MARKER_RE.exec(line.trimEnd());
+  if (!m) return null;
+  const kind = m[2].startsWith("posted") ? "posted" : m[2].startsWith("answered") ? "answered" : "expired";
+  const seconds = Number(m[3] ?? m[4] ?? m[5]);
+  return { id: m[1], kind, seconds };
+}
+
+/** True iff a command line looks like it INVOKES `codex-collab ask`, as
+ *  opposed to merely mentioning it (grep over docs, echo, a path segment).
+ *  `codex-collab` must sit at a command position: start of string, after a
+ *  shell separator (`;`, `&`, `|`, `(`), or at the start of a `sh -c` /
+ *  `zsh -lc` wrapper string. Bare whitespace is deliberately NOT a command
+ *  position — `grep -rh codex-collab ask logs/` is a mention, and prefix
+ *  forms like `timeout 600 codex-collab ask` are accepted false negatives:
+ *  a miss only degrades run-record enrichment (the mailbox watchers and
+ *  `next` see the question file regardless), while a false positive feeds
+ *  marker parsing from arbitrary command output. */
+const ASK_INVOCATION_RE = /(?:^|[;&|(]|-l?c\s+['"])\s*codex-collab\s+ask(?:\s|$)/;
+
+export function looksLikeAskInvocation(command: string): boolean {
+  return ASK_INVOCATION_RE.test(command);
+}
+
+/** True iff the ask invocation reads its question from stdin (`ask -`) —
+ *  the one form whose question text cannot be matched against the command
+ *  line. Quote/whitespace-normalized before testing. */
+export function isStdinAskInvocation(command: string): boolean {
+  return /codex-collab ask -(?:\s|$)/.test(
+    command.replace(/[\\'"]/g, "").replace(/\s+/g, " "),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox I/O
+// ---------------------------------------------------------------------------
+
+/** `q` + 7 hex chars — visually distinct from 8-hex thread short IDs, and
+ *  matches validateId's character set. */
+export function generateQuestionId(): string {
+  return `q${randomBytes(4).toString("hex").slice(0, 7)}`;
+}
+
+export function questionPath(mailboxDir: string, id: string): string {
+  return join(mailboxDir, `${id}.json`);
+}
+
+export function answerPath(mailboxDir: string, id: string): string {
+  return join(mailboxDir, `${id}.answer`);
+}
+
+function atomicWrite(filePath: string, content: string): void {
+  const tmpPath = filePath + ".tmp";
+  writeFileSync(tmpPath, content, { mode: 0o600 });
+  renameSync(tmpPath, filePath);
+}
+
+/** A directory is trustworthy iff it is a real directory (not a symlink),
+ *  owned by this uid, and not group/world-writable. */
+function assertPrivateDir(path: string): void {
+  const st = lstatSync(path);
+  if (st.isSymbolicLink() || !st.isDirectory()) {
+    throw new Error(`${path} is not a real directory`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (uid === null) return;
+  if (st.uid !== uid) {
+    throw new Error(`${path} is owned by uid ${st.uid}, not ${uid}`);
+  }
+  if ((st.mode & 0o022) !== 0) {
+    throw new Error(`${path} is group/world-writable (mode ${(st.mode & 0o777).toString(8)})`);
+  }
+}
+
+/** Refuse to use a mailbox whose directory chain isn't privately ours. The
+ *  root lives at a predictable path in shared temp space, so another local
+ *  user could pre-create it before our first use — recursive mkdir accepts
+ *  existing ancestors silently, and write access to the directory would let
+ *  them forge answer files (a steering channel into Codex). For mailboxes
+ *  under the standard root, every level from the root down is verified;
+ *  other paths (tests, explicit overrides) verify the mailbox dir itself. */
+export function verifyMailboxDir(mailboxDir: string): void {
+  if (process.platform === "win32") return; // per-user %TEMP%; POSIX modes don't apply
+  const root = mailboxRoot();
+  const levels = isPathInside(mailboxDir, root) && mailboxDir !== root
+    ? [...new Set([root, dirname(mailboxDir), mailboxDir])]
+    : [mailboxDir];
+  for (const level of levels) {
+    try {
+      assertPrivateDir(level);
+    } catch (e) {
+      throw new Error(
+        `ask-channel mailbox is not private — refusing to use it: ${e instanceof Error ? e.message : String(e)}\n` +
+        `Remove or fix the directory and retry.`,
+      );
+    }
+  }
+}
+
+export function writeQuestion(mailboxDir: string, record: QuestionRecord): void {
+  if (!existsSync(mailboxDir)) mkdirSync(mailboxDir, { recursive: true, mode: 0o700 });
+  verifyMailboxDir(mailboxDir);
+  atomicWrite(questionPath(mailboxDir, record.id), JSON.stringify(record, null, 2));
+}
+
+export function loadQuestion(mailboxDir: string, id: string): QuestionRecord | null {
+  const filePath = questionPath(mailboxDir, id);
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(content);
+    if (
+      typeof parsed !== "object" || parsed === null ||
+      typeof parsed.id !== "string" ||
+      typeof parsed.question !== "string" ||
+      typeof parsed.askedAt !== "string" ||
+      typeof parsed.expiresAt !== "string"
+    ) {
+      return null;
+    }
+    return parsed as QuestionRecord;
+  } catch {
+    return null;
+  }
+}
+
+/** Rewrite a question record in place (e.g. to stamp `expired`). */
+export function updateQuestion(mailboxDir: string, record: QuestionRecord): void {
+  atomicWrite(questionPath(mailboxDir, record.id), JSON.stringify(record, null, 2));
+}
+
+/** All question records in a mailbox, oldest first. Corrupt files skipped.
+ *  Throws when the mailbox directory chain isn't privately ours — reading
+ *  an attacker-controlled mailbox would surface forged questions. */
+export function listQuestions(mailboxDir: string): QuestionRecord[] {
+  if (!existsSync(mailboxDir)) return [];
+  verifyMailboxDir(mailboxDir);
+  const records: QuestionRecord[] = [];
+  for (const file of readdirSync(mailboxDir)) {
+    if (!file.endsWith(".json")) continue;
+    const record = loadQuestion(mailboxDir, file.slice(0, -".json".length));
+    if (record) records.push(record);
+  }
+  records.sort((a, b) => a.askedAt.localeCompare(b.askedAt));
+  return records;
+}
+
+/** True iff the asking process is still alive (EPERM counts as alive; a
+ *  missing/invalid pid — legacy records — counts as alive so nothing is
+ *  wrongly suppressed). PID reuse can produce a false positive, but the
+ *  question's own expiry deadline bounds how long that can matter. */
+export function isAskerAlive(record: QuestionRecord): boolean {
+  if (typeof record.pid !== "number" || !Number.isInteger(record.pid) || record.pid <= 0) return true;
+  try {
+    process.kill(record.pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+/** True iff the question is still awaiting an answer: not stamped expired,
+ *  deadline in the future, no answer file yet, and the asking process is
+ *  still alive — a run killed or timed out mid-ask leaves an orphaned
+ *  question file that nobody can receive an answer to, and advertising it
+ *  as pending would invite answers into the void. */
+export function isQuestionPending(mailboxDir: string, record: QuestionRecord, now = Date.now()): boolean {
+  if (record.expired) return false;
+  const expiresAt = Date.parse(record.expiresAt);
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return false;
+  if (existsSync(answerPath(mailboxDir, record.id))) return false;
+  return isAskerAlive(record);
+}
+
+export function listPendingQuestions(mailboxDir: string, now = Date.now()): QuestionRecord[] {
+  return listQuestions(mailboxDir).filter((r) => isQuestionPending(mailboxDir, r, now));
+}
+
+export function writeAnswer(mailboxDir: string, id: string, text: string): void {
+  atomicWrite(answerPath(mailboxDir, id), text);
+}
+
+function answerClaimPath(mailboxDir: string, id: string): string {
+  return answerPath(mailboxDir, id) + ".claim";
+}
+
+/** Claim and write the answer; returns false when another responder already
+ *  claimed it. The claim file is created with O_EXCL so exactly one writer
+ *  wins the race (a bare existsSync check is TOCTOU — two responders can
+ *  both pass it, and atomicWrite's shared temp name would let the LAST
+ *  rename win silently). Content is still published via tmp+rename so the
+ *  polling asker never reads a torn file. */
+export function writeAnswerExclusive(mailboxDir: string, id: string, text: string): boolean {
+  verifyMailboxDir(mailboxDir);
+  try {
+    writeFileSync(answerClaimPath(mailboxDir, id), String(process.pid), { flag: "wx", mode: 0o600 });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "EEXIST") return false;
+    throw e;
+  }
+  atomicWrite(answerPath(mailboxDir, id), text);
+  return true;
+}
+
+export function readAnswer(mailboxDir: string, id: string): string | null {
+  try {
+    return readFileSync(answerPath(mailboxDir, id), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/** Remove a question, its answer file, and the answer claim. ENOENT-tolerant. */
+export function removeQuestion(mailboxDir: string, id: string): void {
+  for (const filePath of [questionPath(mailboxDir, id), answerPath(mailboxDir, id), answerClaimPath(mailboxDir, id)]) {
+    try {
+      unlinkSync(filePath);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error(`[codex] Warning: could not remove ${filePath}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+}
+
+/** Wait for an answer file, polling at the approvals cadence. Resolves with
+ *  the answer text, or null when the deadline lapses — the fail-open path. */
+export async function pollForAnswer(
+  mailboxDir: string,
+  id: string,
+  deadlineMs: number,
+  pollIntervalMs = QUESTION_POLL_INTERVAL_MS,
+): Promise<string | null> {
+  while (Date.now() < deadlineMs) {
+    const answer = readAnswer(mailboxDir, id);
+    if (answer !== null) return answer;
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  return readAnswer(mailboxDir, id);
+}
+
+/** Filenames the mailbox legitimately contains — the sweep must never
+ *  delete anything else, even inside a directory that passed verification. */
+const MAILBOX_FILE_RE = /^q[0-9a-f]{7}\.(json|answer|answer\.claim)(\.tmp)?$/;
+
+/** Delete mailbox files older than maxAgeMs (mtime). Expired questions are
+ *  kept until this sweep so `questions`/post-mortems can still show them.
+ *  Returns the number of files deleted. Refuses (with a warning, not an
+ *  error — `clean` is best-effort) to sweep a mailbox that fails the
+ *  privacy checks: deletion is the one operation where following a planted
+ *  symlink does real damage to files outside the mailbox. */
+export function sweepQuestions(mailboxDir: string, maxAgeMs: number, now = Date.now()): number {
+  if (!existsSync(mailboxDir)) return 0;
+  try {
+    verifyMailboxDir(mailboxDir);
+  } catch (e) {
+    console.error(`[codex] Warning: skipping question sweep: ${e instanceof Error ? e.message : String(e)}`);
+    return 0;
+  }
+  let deleted = 0;
+  for (const file of readdirSync(mailboxDir)) {
+    if (!MAILBOX_FILE_RE.test(file)) continue;
+    const filePath = join(mailboxDir, file);
+    // Never sweep a question that is still pending with a live asker —
+    // `ask --timeout` can legitimately outlast the sweep age, and deleting
+    // the file mid-wait would make the run's resolution watcher read the
+    // absence as "answered".
+    if (file.endsWith(".json")) {
+      const record = loadQuestion(mailboxDir, file.slice(0, -".json".length));
+      if (record && isQuestionPending(mailboxDir, record, now)) continue;
+    }
+    try {
+      if (now - statSync(filePath).mtimeMs > maxAgeMs) {
+        unlinkSync(filePath);
+        deleted++;
+      }
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error(`[codex] Warning: could not sweep ${filePath}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+  return deleted;
+}
+
+/** First line of a question, clipped — the summary used in progress lines,
+ *  run records, and `next` events. */
+export function questionSummary(question: string, maxLen = 160): string {
+  const firstLine = question.split("\n", 1)[0].trim();
+  return firstLine.length > maxLen ? firstLine.slice(0, maxLen - 1) + "…" : firstLine;
+}
+
+/** Strip control characters (keep \n and \t) from text that untrusted model
+ *  output will render into terminals and logs. */
+export function sanitizeForTerminal(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+}

--- a/src/questions.ts
+++ b/src/questions.ts
@@ -75,18 +75,89 @@ export function parseQuestionMarker(line: string): QuestionMarker | null {
 
 /** True iff a command line looks like it INVOKES `codex-collab ask`, as
  *  opposed to merely mentioning it (grep over docs, echo, a path segment).
- *  `codex-collab` must sit at a command position: start of string, after a
- *  shell separator (`;`, `&`, `|`, `(`), or at the start of a `sh -c` /
- *  `zsh -lc` wrapper string. Bare whitespace is deliberately NOT a command
- *  position — `grep -rh codex-collab ask logs/` is a mention, and prefix
- *  forms like `timeout 600 codex-collab ask` are accepted false negatives:
- *  a miss only degrades run-record enrichment (the mailbox watchers and
- *  `next` see the question file regardless), while a false positive feeds
- *  marker parsing from arbitrary command output. */
-const ASK_INVOCATION_RE = /(?:^|[;&|(]|-l?c\s+['"])\s*codex-collab\s+ask(?:\s|$)/;
-
+ *  `codex-collab` must sit at a command position: start of string, or after
+ *  a shell separator (`;`, `&`, `|`, `(`, newline) that is OUTSIDE quotes —
+ *  a separator inside a quoted argument (`printf '; codex-collab ask …'`)
+ *  is data, and treating it as a command position would let arbitrary
+ *  command output feed marker parsing. `sh -c` / `zsh -lc` wrapper payloads
+ *  are scanned as command lines in their own right. Bare whitespace is
+ *  deliberately NOT a command position — `grep -rh codex-collab ask logs/`
+ *  is a mention, and prefix forms like `timeout 600 codex-collab ask` are
+ *  accepted false negatives: a miss only degrades run-record enrichment
+ *  (the mailbox watchers and `next` see the question file regardless),
+ *  while a false positive feeds marker parsing from untrusted output. */
 export function looksLikeAskInvocation(command: string): boolean {
-  return ASK_INVOCATION_RE.test(command);
+  // Wrapper payloads (`-c`/`-lc` string arguments) queue up for their own
+  // scan; one level of nesting per payload, no recursion depth to blow.
+  const commandLines = [command];
+  while (commandLines.length > 0) {
+    if (scanCommandLineForAsk(commandLines.pop()!, commandLines)) return true;
+  }
+  return false;
+}
+
+const WORD_BREAK_CHARS = " \t\n\r;&|()<>";
+
+function scanCommandLineForAsk(cmd: string, wrapperPayloads: string[]): boolean {
+  let i = 0;
+  let atCommandPos = true;   // next word starts a simple command
+  let expectAsk = false;     // previous word was command-position `codex-collab`
+  let expectPayload = false; // previous word was a `-c`/`-lc` wrapper flag
+  while (i < cmd.length) {
+    const ch = cmd[i];
+    if (ch === " " || ch === "\t") {
+      i++;
+      continue;
+    }
+    if (ch === ";" || ch === "&" || ch === "|" || ch === "(" || ch === "\n" || ch === "\r") {
+      atCommandPos = true;
+      expectAsk = false;
+      expectPayload = false;
+      i++;
+      continue;
+    }
+    if (ch === ")" || ch === "<" || ch === ">") {
+      expectAsk = false;
+      expectPayload = false;
+      i++;
+      continue;
+    }
+    // Read one word, resolving quotes and backslash escapes so quoted
+    // separators stay inside the word instead of opening a command position.
+    let word = "";
+    while (i < cmd.length && !WORD_BREAK_CHARS.includes(cmd[i])) {
+      const c = cmd[i];
+      if (c === "'") {
+        const end = cmd.indexOf("'", i + 1);
+        word += end === -1 ? cmd.slice(i + 1) : cmd.slice(i + 1, end);
+        i = end === -1 ? cmd.length : end + 1;
+      } else if (c === '"') {
+        let j = i + 1;
+        while (j < cmd.length && cmd[j] !== '"') {
+          if (cmd[j] === "\\" && j + 1 < cmd.length) {
+            word += cmd[j + 1];
+            j += 2;
+          } else {
+            word += cmd[j];
+            j++;
+          }
+        }
+        i = j < cmd.length ? j + 1 : cmd.length;
+      } else if (c === "\\" && i + 1 < cmd.length) {
+        word += cmd[i + 1];
+        i += 2;
+      } else {
+        word += c;
+        i++;
+      }
+    }
+    if (expectAsk && word === "ask") return true;
+    if (expectPayload) wrapperPayloads.push(word);
+    expectAsk = atCommandPos && word === "codex-collab";
+    expectPayload = /^-l?c$/.test(word);
+    atCommandPos = false;
+  }
+  return false;
 }
 
 /** True iff the ask invocation reads its question from stdin (`ask -`) —

--- a/src/questions.ts
+++ b/src/questions.ts
@@ -91,11 +91,30 @@ export function looksLikeAskInvocation(command: string): boolean {
 
 /** True iff the ask invocation reads its question from stdin (`ask -`) —
  *  the one form whose question text cannot be matched against the command
- *  line. Quote/whitespace-normalized before testing. */
+ *  line. Quote/whitespace-normalized before testing. The dash may follow
+ *  options (`ask --timeout 60 -`), so skip leading option/value pairs and
+ *  decide on the first positional token: `-` means stdin, anything else is
+ *  the question text (quote-stripping merges it into the token stream, so
+ *  a dash *inside* the question must not count). Tokens are cut at the
+ *  first shell operator so a `-` in a downstream pipe segment can't match.
+ *  A boolean flag directly before the dash reads it as the flag's value —
+ *  an accepted false negative (enrichment-only cost, like the prefix
+ *  wrappers above). */
 export function isStdinAskInvocation(command: string): boolean {
-  return /codex-collab ask -(?:\s|$)/.test(
-    command.replace(/[\\'"]/g, "").replace(/\s+/g, " "),
-  );
+  const normalized = command.replace(/[\\'"]/g, "").replace(/\s+/g, " ");
+  const match = normalized.match(/codex-collab ask (.*)$/);
+  if (!match) return false;
+  const tokens = match[1].split(/[;&|()<>]/, 1)[0].trim().split(" ");
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.length > 1 && token.startsWith("-")) {
+      // Option: also skip its value when the next token isn't dash-led.
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) i++;
+      continue;
+    }
+    return token === "-";
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/threads.test.ts
+++ b/src/threads.test.ts
@@ -12,6 +12,7 @@ import {
   createRun,
   loadRun,
   updateRun,
+  appendRunQuestion,
   listRuns,
   listRunsForThread,
   getLatestRun,
@@ -340,6 +341,46 @@ describe("run ledger", () => {
   test("updateRun throws on unknown run instead of silently no-op", () => {
     expect(() => updateRun(testDir, "run-does-not-exist", { status: "completed" }))
       .toThrow(/unknown run/i);
+  });
+
+  test("appendRunQuestion clears the pending mirror when it shows the resolved question", () => {
+    const run = makeRun({ status: "running" });
+    createRun(testDir, run);
+    const asked = new Date().toISOString();
+    const expires = new Date(Date.now() + 600_000).toISOString();
+    updateRun(testDir, run.runId, {
+      pendingQuestion: { id: "q1111111", summary: "first?", askedAt: asked, expiresAt: expires },
+    });
+    appendRunQuestion(testDir, run.runId, {
+      id: "q1111111", summary: "first?", outcome: "answered", latencyMs: 1000,
+    });
+    const loaded = loadRun(testDir, run.runId)!;
+    expect(loaded.pendingQuestion).toBeNull();
+    expect(loaded.questions).toEqual([
+      expect.objectContaining({ id: "q1111111", outcome: "answered" }),
+    ]);
+  });
+
+  test("appendRunQuestion preserves a different still-live pending question", () => {
+    // Overlapping asks: the dispatcher mirrors the remaining live question
+    // (q2) BEFORE q1's resolution is appended — the append must not wipe it.
+    const run = makeRun({ status: "running" });
+    createRun(testDir, run);
+    const asked = new Date().toISOString();
+    const expires = new Date(Date.now() + 600_000).toISOString();
+    updateRun(testDir, run.runId, {
+      pendingQuestion: { id: "q2222222", summary: "second?", askedAt: asked, expiresAt: expires },
+    });
+    appendRunQuestion(testDir, run.runId, {
+      id: "q1111111", summary: "first?", outcome: "answered", latencyMs: 1000,
+    });
+    const loaded = loadRun(testDir, run.runId)!;
+    expect(loaded.pendingQuestion).toEqual(
+      expect.objectContaining({ id: "q2222222", summary: "second?" }),
+    );
+    expect(loaded.questions).toEqual([
+      expect.objectContaining({ id: "q1111111", outcome: "answered" }),
+    ]);
   });
 
   test("listRuns returns all runs sorted by startedAt descending", () => {

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -398,13 +398,16 @@ export function updateRun(stateDir: string, runId: string, patch: RunPatch): voi
 }
 
 /** Append a resolved ask-channel question to a run's audit trail and clear
- *  the pending mirror in the same write. */
+ *  the pending mirror in the same write — unless the mirror already shows a
+ *  different (still-live) question, which must survive this resolution. */
 export function appendRunQuestion(stateDir: string, runId: string, entry: ResolvedQuestion): void {
   const record = loadRun(stateDir, runId);
   if (!record) throw new Error(`Cannot append question to unknown run ${runId}`);
   updateRun(stateDir, runId, {
     questions: [...(record.questions ?? []), entry],
-    pendingQuestion: null,
+    ...(record.pendingQuestion == null || record.pendingQuestion.id === entry.id
+      ? { pendingQuestion: null }
+      : {}),
   });
 }
 

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -13,7 +13,7 @@ import { randomBytes, createHash } from "crypto";
 import { basename, dirname, join, resolve } from "path";
 import { config, validateId, resolveWorkspaceDir, isPathInside, STATE_SCHEMA_VERSION, MIGRATION_STATE_FILENAME } from "./config";
 import { acquireLockSync, LockTimeoutError } from "./lock";
-import type { ThreadIndex, ThreadIndexEntry, RunRecord, RunStatus } from "./types";
+import type { ThreadIndex, ThreadIndexEntry, RunRecord, RunStatus, ResolvedQuestion } from "./types";
 
 // ─── Advisory file lock ────────────────────────────────────────────────────
 
@@ -367,7 +367,7 @@ export function loadRun(stateDir: string, runId: string): RunRecord | null {
 type RunPatch = Partial<Pick<RunRecord,
   "status" | "phase" | "sessionId" | "completedAt" | "elapsed" |
   "output" | "filesChanged" | "commandsRun" | "error" | "logOffset" |
-  "pendingApproval"
+  "pendingApproval" | "pendingQuestion" | "questions"
 >>;
 
 /**
@@ -395,6 +395,17 @@ export function updateRun(stateDir: string, runId: string, patch: RunPatch): voi
   } catch (e) {
     throw new Error(`Failed to write run ${runId}: ${e instanceof Error ? e.message : e}`);
   }
+}
+
+/** Append a resolved ask-channel question to a run's audit trail and clear
+ *  the pending mirror in the same write. */
+export function appendRunQuestion(stateDir: string, runId: string, entry: ResolvedQuestion): void {
+  const record = loadRun(stateDir, runId);
+  if (!record) throw new Error(`Cannot append question to unknown run ${runId}`);
+  updateRun(stateDir, runId, {
+    questions: [...(record.questions ?? []), entry],
+    pendingQuestion: null,
+  });
 }
 
 export function listRuns(stateDir: string, opts?: { sessionId?: string }): RunRecord[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -503,6 +503,25 @@ export interface PendingApproval {
   requestedAt: string;
 }
 
+// --- Ask channel (Codex asks mid-turn, anyone answers) ---
+
+/** On-disk shape of a mailbox question file (`{id}.json`). Written by
+ *  `codex-collab ask` from INSIDE Codex's sandbox — which is why the mailbox
+ *  lives in temp space (resolveMailboxDir), not the workspace state dir. */
+export interface QuestionRecord {
+  id: string;
+  question: string;
+  askedAt: string;
+  expiresAt: string;
+  workspaceDir: string;
+  /** PID of the asking process (orphan detection for sweeps). */
+  pid: number;
+  /** Set when the deadline lapsed unanswered; the file is kept for the
+   *  audit trail until `clean` sweeps it. */
+  expired?: boolean;
+}
+
+
 export interface RunRecord {
   runId: string;
   threadId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -521,6 +521,27 @@ export interface QuestionRecord {
   expired?: boolean;
 }
 
+/** A question awaiting an answer, mirrored onto the run record — the on-disk
+ *  signal observers (`next`, `follow`, Monitor scripts) use to see a run
+ *  asking for steering without owning its stdout. Unlike PendingApproval,
+ *  this never blocks the run terminally: questions fail open. */
+export interface PendingQuestion {
+  id: string;
+  summary: string | null;
+  askedAt: string;
+  expiresAt: string;
+}
+
+/** Terminal state of an ask-channel question, appended to the run record so
+ *  a long autonomous run's post-mortem says plainly how often it was steered
+ *  and how often it decided alone. */
+export interface ResolvedQuestion {
+  id: string;
+  summary: string | null;
+  outcome: "answered" | "expired";
+  /** Posting-to-answer latency; absent for expired questions. */
+  latencyMs?: number;
+}
 
 export interface RunRecord {
   runId: string;
@@ -548,6 +569,10 @@ export interface RunRecord {
   error: string | null;
   /** Set while an interactive approval is blocking the run; null/absent otherwise. */
   pendingApproval?: PendingApproval | null;
+  /** Set while a `codex-collab ask` question awaits an answer; null/absent otherwise. */
+  pendingQuestion?: PendingQuestion | null;
+  /** Resolved ask-channel questions, in resolution order. */
+  questions?: ResolvedQuestion[];
 }
 
 // --- Broker state (per-workspace) ---


### PR DESCRIPTION
## What

On long or autonomous runs, Codex can pause mid-turn to consult the collaborator who launched it — without betting the run on a reply. Questions are the judgment sibling of approvals: where approvals carry **permission** (blocking, fail-closed), questions carry **judgment** — non-blocking and fail-open. An unanswered question expires gracefully and Codex proceeds on its own.

## Commands

**Codex-facing** (taught by the built-in `collab` template):
- `ask "question" [--timeout <sec>]` — posts to a per-workspace mailbox and waits (default 600s). Always exits on its own: with the answer printed into Codex's context, or with proceed-on-your-judgment guidance.

**Responder-facing** (agent or human — whoever is watching):
- `answer <id> "text"` / `questions` — prefix matching, cross-workspace lookup, stdin for long answers.
- `next` — blocks until a question or approval needs a response, prints one JSON event line, exits (`0` event / `10` workspace idle / `3` timeout). One watcher command, identical on macOS, Linux, and Windows; the idle exit means it never dangles after runs end.
- Run records mirror `pendingQuestion` while waiting and keep a `questions[]` audit trail (outcome + latency), so a run's post-mortem states how often it was steered and how often it decided alone.

## Design notes

- **Mailbox in temp space, not the state dir** — the asker runs inside Codex's sandbox, where only the workspace and temp are writable. The directory chain is verified before use (owner, mode, no symlinks); the `clean` sweep applies the same checks, a filename whitelist, and never deletes a question still pending with a live asker.
- **Mailbox watchers are the source of truth for live surfacing** — session-based exec delivers command output too late, so stdout markers are a fast path only. Marker parsing accepts only real ask invocations (command-position detection, not substring mentions) and only resolutions of questions posted in the same turn; concurrent same-workspace runs bind questions to their own ask command via the question text embedded in the command line.
- **First answer wins** — answers are claimed with `O_EXCL`; the losing responder gets a clean already-answered error, and content publishes via tmp+rename so the polling asker never reads a torn file. Orphaned questions (asker killed or timed out) are suppressed via pid liveness instead of being advertised as answerable.
- **The template prescribes no rules** — it declares the channel, its mechanics, and its costs (answers cost collaborator attention; expiries cost only the wait), and leaves whether/when/how often to ask as Codex's call. Answers are framed as judgment to be weighed, with disagreement voiced rather than silently complied with.

## Verification

- 658 tests (unit coverage for the mailbox, markers, invocation gating, concurrency/attribution, orphan and race edges, `next` liveness); each of the three commits independently typechecks and passes the full suite.
- Live end-to-end against real Codex turns, including an unprompted-judgment test: given a task hinging on collaborator-only knowledge and no instruction to ask, Codex found the channel on its own, chose its own shorter `--timeout`, and followed the answer — on fresh and resumed threads, single- and multi-question runs.