### PR TITLE
Goal-mode support: a run spans the goal, not the first turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ codex-collab follow --watch
 | `run "prompt" [opts]` | Start thread, send prompt, wait, print output (`run -` reads the prompt from stdin — no shell-quoting hazards) |
 | `review [opts]` | Code review (PR, uncommitted, commit) |
 | `threads [--json] [--all]` | List threads (`--limit <n>` to cap, `--discover` to scan server, `--session` for only threads the current session has run) |
-| `kill <id>` | Interrupt running thread |
+| `kill <id> [--clear]` | Interrupt running thread. An active goal is paused first — interrupt alone would just respawn a continuation turn; `--clear` abandons the goal instead |
 | `follow [id]` | Live view of a running thread; exits with its status (replays the last run when already finished). Without an ID, attaches to the workspace's active run — or replays the most recent one. With `--watch`, stays open and follows each new run (every run shown once, in start order) |
 | `output <id> [--last]` | Full log for thread (`--last`: only the latest turn's output) |
 | `progress <id>` | Recent activity (tail of log) |
@@ -162,12 +162,14 @@ codex-collab follow --watch
 | `--content-only` | Suppress progress lines; with `output`, return only extracted content |
 | `--last` | (output) Only the latest turn's output instead of the whole thread history (implies `--content-only`) |
 | `--session` | (threads) Only threads the current session has run |
-| `--timeout <sec>` | Turn timeout (default: 1200, max 2147483). For `ask`: answer deadline (default: 600); for `next`: wait deadline (default: wait indefinitely) |
+| `--timeout <sec>` | Turn timeout (default: 1200, max 2147483). When a goal is active it scopes the whole goal, and expiry pauses the goal before exiting. For `ask`: answer deadline (default: 600); for `next`: wait deadline (default: wait indefinitely) |
 | `--base <branch>` | Base branch for PR review (default: auto-detected default branch) |
 | `--` | End of options; remaining arguments are treated as prompt text |
 | `-` | (run) Read the prompt from stdin |
 
-`run` and `review` exit with a status code that classifies the outcome: `0` completed, `1` failed, `3` timed out, `4` interrupted, `5` died blocked on an approval (the request is void — resume with a longer `--timeout` or `--approval auto`), `6` broker busy (transient — retry).
+`run` and `review` exit with a status code that classifies the outcome: `0` completed, `1` failed, `3` timed out, `4` interrupted, `5` died blocked on an approval (the request is void — resume with a longer `--timeout` or `--approval auto`), `6` broker busy (transient — retry), `7` goal ended blocked or usage/budget-limited — Codex needs steering (resume the thread, or `kill --clear` to abandon the goal).
+
+**Goal mode**: Codex's Goal mode (`goals = true` in `~/.codex/config.toml`) makes threads self-continue — the server starts a new turn the moment one completes while the goal is active. When a goal is (or becomes) active on the thread, a `run` follows every continuation turn in the same run record and log until the goal is terminal: the run corresponds to the unit of work, not just its first turn. `--timeout` then bounds the whole goal, and on expiry the goal is **paused** (resumable, no headless token burn) before the CLI exits `3`. `threads` shows each thread's latest goal state (`[goal active: 45k/100k tokens]`).
 
 `next` exits `0` when an event was delivered (JSON on stdout), `3` when `--timeout` elapsed with no event, and `10` when the workspace is idle — nothing running, nothing pending.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -220,7 +220,7 @@ codex-collab progress <id>              # Recent activity (tail of log)
 codex-collab threads [--all|--discover] # List threads (--discover: include server-side, top 5)
 codex-collab threads --session          # Only threads the current session has run
 codex-collab peek <id> [--limit N --full] # Recent conversation slice from server
-codex-collab kill <id>                  # Stop a running thread
+codex-collab kill <id> [--clear]        # Stop a running thread; an active goal is paused first (--clear abandons it)
 codex-collab delete <id>                # Archive thread (recoverable via `codex unarchive`), delete local files
 codex-collab delete <id> --purge        # Permanently delete server-side instead — NOT recoverable; needs explicit user intent
 codex-collab clean                      # Delete old logs, stale mappings, old question files
@@ -245,7 +245,7 @@ Note: `jobs` still works as a deprecated alias for `threads`.
 | `-s, --sandbox <mode>` | Sandbox: read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
 | `-d, --dir <path>` | Working directory (default: cwd) |
 | `--resume <id>` | Resume existing thread (run and review) |
-| `--timeout <sec>` | (run, review) Turn timeout in seconds (default: 1200). Do not lower this — Codex tasks routinely take 5-15 minutes; increase for large reviews or complex tasks. (ask) Answer deadline, default 600. (next) Wait bound, default none — it waits until an event or workspace idle. |
+| `--timeout <sec>` | (run, review) Turn timeout in seconds (default: 1200). Do not lower this — Codex tasks routinely take 5-15 minutes; increase for large reviews or complex tasks. When a goal is active the timeout scopes the WHOLE goal and expiry pauses it (see Goal Mode). (ask) Answer deadline, default 600. (next) Wait bound, default none — it waits until an event or workspace idle. |
 | `--approval <policy>` | never, on-request, on-failure, untrusted, auto (default: never) — see Approvals |
 | `--memory` | Let Codex's memory feature learn from threads this run creates (default: created threads are excluded so agent-driven sessions don't shape Codex's picture of the user) |
 | `--detach` | (run) Return once the turn is running — see Detached Runs |
@@ -267,7 +267,16 @@ Note: `jobs` still works as a deprecated alias for `threads`.
 
 ### Exit codes (run, review)
 
-`0` completed · `1` failed · `3` timed out · `4` interrupted (kill) · `5` died blocked on an approval — the request is void, so don't try to answer it; resume with a longer `--timeout` or `--approval auto` · `6` broker busy and fallback unavailable — transient, retry. For backgrounded runs, branch on the exit code instead of text-sniffing the output.
+`0` completed · `1` failed · `3` timed out (an active goal is paused, resumable) · `4` interrupted (kill) · `5` died blocked on an approval — the request is void, so don't try to answer it; resume with a longer `--timeout` or `--approval auto` · `6` broker busy and fallback unavailable — transient, retry · `7` goal ended blocked or usage/budget-limited — Codex needs steering: resume the thread with guidance, or `kill --clear` to abandon the goal. For backgrounded runs, branch on the exit code instead of text-sniffing the output.
+
+## Goal Mode
+
+If Codex creates a goal during a turn (its Goal mode, `goals = true` in the user's `~/.codex/config.toml`), the server keeps starting continuation turns on its own until the goal is done. `run` follows the whole goal: continuation turns stream into the same run record and log, `follow`/`output`/`threads` see them, and the run's exit code reflects the goal's end — completed (0), blocked/limited (7), timed out and paused (3). Practical implications:
+
+- Give goal runs a generous `--timeout` (hours, not minutes) — it bounds the whole goal, and expiry pauses the goal safely rather than leaving it running headless.
+- A paused goal resumes when a new turn runs on that thread (`run --resume <id> "..."`); `kill --clear` abandons it.
+- Mid-goal, the ask channel and approvals work normally — `next` sees questions from continuation turns too.
+- `threads` shows the latest goal state per thread: `[goal active: 45k/100k tokens]`.
 
 ## Templates
 

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -1282,7 +1282,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
         });
 
         await waitFor(() => notifications.some((n) => n.method === "turn/started"), 5000);
-        expect(notifications.some((n) => n.method === "item/agentMessage/delta")).toBe(true);
+        // The delta rides a separate chunk — await it rather than assert it.
+        await waitFor(() => notifications.some((n) => n.method === "item/agentMessage/delta"), 5000);
 
         await client.close();
       } finally {

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -73,6 +73,11 @@ function createMockCodex(dir: string, opts?: {
    *  goal/updated notification ever fires — the broker can only learn the
    *  goal from the get traffic. A continuation turn starts after turn 1. */
   goalPreexisting?: boolean;
+  /** If true, simulate the fast-turn race on a goal thread: goal/updated
+   *  (active) AND turn/completed are written BEFORE the turn/start
+   *  response, then a continuation turn starts. The broker must claim
+   *  ownership despite the already-completed first turn. */
+  goalFastFirstTurn?: boolean;
 }): string {
   const turnDelay = opts?.turnDelay ?? 0;
   const sendTurnCompleted = opts?.sendTurnCompleted ?? true;
@@ -83,6 +88,7 @@ function createMockCodex(dir: string, opts?: {
   const goalContinuation = opts?.goalContinuation ?? false;
   const goalPausedInGap = opts?.goalPausedInGap ?? false;
   const goalPreexisting = opts?.goalPreexisting ?? false;
+  const goalFastFirstTurn = opts?.goalFastFirstTurn ?? false;
 
   const interruptLog = join(dir, "interrupts.log");
   const scriptPath = join(dir, "codex");
@@ -147,6 +153,19 @@ process.stdin.on("data", (chunk) => {
 
       case "turn/start": {
         const threadId = msg.params?.threadId || "thread-001";
+        ${goalFastFirstTurn ? `
+        // Fast-turn race on a goal thread: goal becomes active and the turn
+        // completes BEFORE the turn/start response reaches the broker.
+        respond({ method: "thread/goal/updated", params: { threadId: threadId, turnId: "turn-001", goal: {
+          threadId: threadId, objective: "fast goal", status: "active", tokenBudget: 1000,
+          tokensUsed: 50, timeUsedSeconds: 1, createdAt: 1, updatedAt: 2,
+        }}});
+        respond({ method: "turn/completed", params: { threadId: threadId, turn: { id: "turn-001", items: [], status: "completed", error: null } } });
+        setTimeout(() => {
+          respond({ method: "turn/started", params: { threadId: threadId, turn: { id: "turn-002", items: [], status: "inProgress", error: null } } });
+          respond({ method: "item/agentMessage/delta", params: { threadId: threadId, turnId: "turn-002", itemId: "m2", delta: "continuation output" } });
+        }, 60);
+        ` : ""}
         ${completeBeforeResponse ? `
         // Fast-turn race: write turn/completed BEFORE the turn/start
         // response so they arrive at the broker in a single read chunk
@@ -1283,6 +1302,36 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
         await waitFor(() => notifications.some((n) => n.method === "turn/started"), 5000);
         // The delta rides a separate chunk — await it rather than assert it.
+        await waitFor(() => notifications.some((n) => n.method === "item/agentMessage/delta"), 5000);
+
+        await client.close();
+      } finally {
+        proc.kill();
+      }
+    }, 15_000);
+
+    test("a first goal turn completing before the turn/start response still claims ownership", async () => {
+      // Fast-turn race: turn/completed arrives in the same chunk as the
+      // turn/start response, so the normal claim is skipped — but the goal
+      // is active and continuations are coming. Pre-fix, they had no owner
+      // and the goal-following client waited blind until its timeout.
+      const sockPath = join(tempDir, "broker.sock");
+      const endpoint = `unix:${sockPath}`;
+      const mockDir = createMockCodex(tempDir, { sendTurnCompleted: false, goalFastFirstTurn: true });
+
+      const proc = spawnBroker(endpoint, mockDir);
+      await waitForSocket(sockPath);
+
+      try {
+        const client = await TestClient.connectAndInit(sockPath);
+        const notifications = collectNotifications(client);
+
+        await client.request("turn/start", {
+          threadId: "thread-001",
+          input: [{ type: "text", text: "work the goal" }],
+        });
+
+        await waitFor(() => notifications.some((n) => n.method === "turn/started"), 5000);
         await waitFor(() => notifications.some((n) => n.method === "item/agentMessage/delta"), 5000);
 
         await client.close();

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -68,6 +68,11 @@ function createMockCodex(dir: string, opts?: {
    *  active when turn 1 completes, but no continuation ever starts — a
    *  goal/updated(paused) lands instead (the kill/timeout brake). */
   goalPausedInGap?: boolean;
+  /** If true, simulate a PRE-EXISTING active goal (resumed goal-mode
+   *  thread): thread/goal/get answers with an active goal, but NO
+   *  goal/updated notification ever fires — the broker can only learn the
+   *  goal from the get traffic. A continuation turn starts after turn 1. */
+  goalPreexisting?: boolean;
 }): string {
   const turnDelay = opts?.turnDelay ?? 0;
   const sendTurnCompleted = opts?.sendTurnCompleted ?? true;
@@ -77,6 +82,7 @@ function createMockCodex(dir: string, opts?: {
   const reviewDelay = opts?.reviewDelay ?? 0;
   const goalContinuation = opts?.goalContinuation ?? false;
   const goalPausedInGap = opts?.goalPausedInGap ?? false;
+  const goalPreexisting = opts?.goalPreexisting ?? false;
 
   const interruptLog = join(dir, "interrupts.log");
   const scriptPath = join(dir, "codex");
@@ -125,6 +131,19 @@ process.stdin.on("data", (chunk) => {
           cwd: "/tmp", approvalPolicy: "never", sandbox: null,
         }});
         break;
+
+      case "thread/goal/get": {
+        ${goalPreexisting ? `
+        respond({ id: msg.id, result: { goal: {
+          threadId: msg.params?.threadId || "thread-001", objective: "pre-existing objective",
+          status: "active", tokenBudget: 1000, tokensUsed: 100, timeUsedSeconds: 1,
+          createdAt: 1, updatedAt: 2,
+        }}});
+        ` : `
+        respond({ id: msg.id, result: { goal: null } });
+        `}
+        break;
+      }
 
       case "turn/start": {
         const threadId = msg.params?.threadId || "thread-001";
@@ -199,6 +218,17 @@ process.stdin.on("data", (chunk) => {
           setTimeout(() => {
             respond({ method: "thread/goal/updated", params: { threadId: threadId, turnId: null, goal: goal("paused") } });
           }, ${turnCompletedDelay} + 40);
+          ` : goalPreexisting ? `
+          // Pre-existing goal: NO goal/updated notifications at all — the
+          // broker only knows the goal from thread/goal/get traffic. Turn 1
+          // completes, then the server starts the continuation.
+          setTimeout(() => {
+            respond({ method: "turn/completed", params: { threadId: threadId, turn: { id: "turn-001", items: [], status: "completed", error: null } } });
+          }, ${turnCompletedDelay});
+          setTimeout(() => {
+            respond({ method: "turn/started", params: { threadId: threadId, turn: { id: "turn-002", items: [], status: "inProgress", error: null } } });
+            respond({ method: "item/agentMessage/delta", params: { threadId: threadId, turnId: "turn-002", itemId: "m2", delta: "continuation output" } });
+          }, ${turnCompletedDelay} + 30);
           ` : sendTurnCompleted ? `
           setTimeout(() => {
             respond({
@@ -1221,6 +1251,68 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
         await client.close();
         await client2.close();
+      } finally {
+        proc.kill();
+      }
+    }, 15_000);
+
+    test("a PRE-EXISTING goal (no notifications) is learned from goal/get traffic and retains ownership", async () => {
+      // Resumed goal-mode thread: the goal predates every client, so no
+      // thread/goal/updated ever fires. The goal-following CLI's pre-turn
+      // thread/goal/get is the broker's only signal — pre-fix, ownership
+      // released at turn 1's completion and the continuation was invisible.
+      const sockPath = join(tempDir, "broker.sock");
+      const endpoint = `unix:${sockPath}`;
+      const mockDir = createMockCodex(tempDir, { goalPreexisting: true });
+
+      const proc = spawnBroker(endpoint, mockDir);
+      await waitForSocket(sockPath);
+
+      try {
+        const client = await TestClient.connectAndInit(sockPath);
+        const notifications = collectNotifications(client);
+
+        // The CLI's pre-turn goal read — this is what teaches the broker.
+        const goalRes = await client.request("thread/goal/get", { threadId: "thread-001" });
+        expect((goalRes as any)?.goal?.status).toBe("active");
+
+        await client.request("turn/start", {
+          threadId: "thread-001",
+          input: [{ type: "text", text: "resume the goal" }],
+        });
+
+        await waitFor(() => notifications.some((n) => n.method === "turn/started"), 5000);
+        expect(notifications.some((n) => n.method === "item/agentMessage/delta")).toBe(true);
+
+        await client.close();
+      } finally {
+        proc.kill();
+      }
+    }, 15_000);
+
+    test("goal ops are allowed through from another socket while a stream is owned", async () => {
+      // kill/kill --clear must be able to read and brake a goal whose
+      // following run owns the broker stream for the goal's whole lifetime.
+      const sockPath = join(tempDir, "broker.sock");
+      const endpoint = `unix:${sockPath}`;
+      const mockDir = createMockCodex(tempDir, { sendTurnCompleted: false });
+
+      const proc = spawnBroker(endpoint, mockDir);
+      await waitForSocket(sockPath);
+
+      try {
+        const owner = await TestClient.connectAndInit(sockPath);
+        await owner.request("turn/start", {
+          threadId: "thread-001",
+          input: [{ type: "text", text: "long turn" }],
+        });
+
+        const killer = await TestClient.connectAndInit(sockPath);
+        const res = await killer.request("thread/goal/get", { threadId: "thread-001" });
+        expect((res as any)).toHaveProperty("goal"); // forwarded, not busy-rejected
+
+        await owner.close();
+        await killer.close();
       } finally {
         proc.kill();
       }

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -60,6 +60,14 @@ function createMockCodex(dir: string, opts?: {
   /** Delay in ms before responding to review/start. Lets tests disconnect
    *  the client mid-request to exercise the orphan-turn cleanup path. */
   reviewDelay?: number;
+  /** If true, simulate a goal-mode thread: turn/start's completion is
+   *  followed by a server-driven continuation turn (turn/started → delta →
+   *  turn/completed) while the goal is active, then the goal completes. */
+  goalContinuation?: boolean;
+  /** If true, simulate a goal paused in the between-turns gap: the goal is
+   *  active when turn 1 completes, but no continuation ever starts — a
+   *  goal/updated(paused) lands instead (the kill/timeout brake). */
+  goalPausedInGap?: boolean;
 }): string {
   const turnDelay = opts?.turnDelay ?? 0;
   const sendTurnCompleted = opts?.sendTurnCompleted ?? true;
@@ -67,6 +75,8 @@ function createMockCodex(dir: string, opts?: {
   const turnCompletedDelay = opts?.turnCompletedDelay ?? 10;
   const completeBeforeResponse = opts?.completeBeforeResponse ?? false;
   const reviewDelay = opts?.reviewDelay ?? 0;
+  const goalContinuation = opts?.goalContinuation ?? false;
+  const goalPausedInGap = opts?.goalPausedInGap ?? false;
 
   const interruptLog = join(dir, "interrupts.log");
   const scriptPath = join(dir, "codex");
@@ -153,7 +163,43 @@ process.stdin.on("data", (chunk) => {
           }, 5);
           ` : ""}
 
-          ${sendTurnCompleted ? `
+          ${goalContinuation ? `
+          // Goal-mode cascade: goal active → turn 1 completes → the server
+          // starts a continuation on its own → continuation completes →
+          // goal complete. Timings compressed but ordered like the real one.
+          const goal = (status, tokensUsed) => ({
+            threadId: threadId, objective: "mock objective", status: status,
+            tokenBudget: 1000, tokensUsed: tokensUsed, timeUsedSeconds: 1,
+            createdAt: 1, updatedAt: 2,
+          });
+          setTimeout(() => {
+            respond({ method: "thread/goal/updated", params: { threadId: threadId, turnId: "turn-001", goal: goal("active", 100) } });
+            respond({ method: "turn/completed", params: { threadId: threadId, turn: { id: "turn-001", items: [], status: "completed", error: null } } });
+          }, ${turnCompletedDelay});
+          setTimeout(() => {
+            respond({ method: "turn/started", params: { threadId: threadId, turn: { id: "turn-002", items: [], status: "inProgress", error: null } } });
+            respond({ method: "item/agentMessage/delta", params: { threadId: threadId, turnId: "turn-002", itemId: "m2", delta: "continuation output" } });
+          }, ${turnCompletedDelay} + 30);
+          setTimeout(() => {
+            respond({ method: "thread/goal/updated", params: { threadId: threadId, turnId: "turn-002", goal: goal("complete", 200) } });
+            respond({ method: "turn/completed", params: { threadId: threadId, turn: { id: "turn-002", items: [], status: "completed", error: null } } });
+          }, ${turnCompletedDelay} + 60);
+          ` : goalPausedInGap ? `
+          // Goal active at turn 1's completion, then paused in the gap —
+          // no continuation turn ever starts.
+          const goal = (status) => ({
+            threadId: threadId, objective: "mock objective", status: status,
+            tokenBudget: 1000, tokensUsed: 100, timeUsedSeconds: 1,
+            createdAt: 1, updatedAt: 2,
+          });
+          setTimeout(() => {
+            respond({ method: "thread/goal/updated", params: { threadId: threadId, turnId: "turn-001", goal: goal("active") } });
+            respond({ method: "turn/completed", params: { threadId: threadId, turn: { id: "turn-001", items: [], status: "completed", error: null } } });
+          }, ${turnCompletedDelay});
+          setTimeout(() => {
+            respond({ method: "thread/goal/updated", params: { threadId: threadId, turnId: null, goal: goal("paused") } });
+          }, ${turnCompletedDelay} + 40);
+          ` : sendTurnCompleted ? `
           setTimeout(() => {
             respond({
               method: "turn/completed",
@@ -1125,6 +1171,94 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
         expect(notifications2.length).toBe(0);
 
         await client1.close();
+        await client2.close();
+      } finally {
+        proc.kill();
+      }
+    }, 15_000);
+  });
+
+  describe("goal-mode stream retention", () => {
+    test("continuation-turn notifications keep flowing to the owner while the goal is active, and ownership releases when it completes", async () => {
+      const sockPath = join(tempDir, "broker.sock");
+      const endpoint = `unix:${sockPath}`;
+      const mockDir = createMockCodex(tempDir, { goalContinuation: true });
+
+      const proc = spawnBroker(endpoint, mockDir);
+      await waitForSocket(sockPath);
+
+      try {
+        const client = await TestClient.connectAndInit(sockPath);
+        const notifications = collectNotifications(client);
+
+        await client.request("turn/start", {
+          threadId: "thread-001",
+          input: [{ type: "text", text: "work the goal" }],
+        });
+
+        // Pre-fix, ownership released at turn-001's completion and every
+        // continuation notification was dropped: the goal-following client
+        // never saw turn-002 start, stream, or complete.
+        await waitFor(() => notifications.some(
+          (n) => n.method === "turn/completed" && (n.params as any)?.turn?.id === "turn-002",
+        ), 5000);
+
+        const methods = notifications.map((n) => n.method);
+        expect(methods).toContain("turn/started");
+        expect(methods).toContain("item/agentMessage/delta");
+        expect(notifications.some(
+          (n) => n.method === "thread/goal/updated" && (n.params as any)?.goal?.status === "complete",
+        )).toBe(true);
+
+        // Goal complete + final turn/completed → ownership released: a
+        // second client's streaming request must not be rejected busy.
+        const client2 = await TestClient.connectAndInit(sockPath);
+        const res = await client2.request("turn/start", {
+          threadId: "thread-002",
+          input: [{ type: "text", text: "next" }],
+        });
+        expect((res as any)?.turn?.id).toBeDefined();
+
+        await client.close();
+        await client2.close();
+      } finally {
+        proc.kill();
+      }
+    }, 15_000);
+
+    test("a goal paused in the between-turns gap releases retained ownership", async () => {
+      // Retention holds ownership after turn/completed while the goal is
+      // active. If the goal is paused BEFORE the continuation starts (the
+      // kill/timeout brake), no turn/completed will ever arrive — pre-fix
+      // the broker stayed busy until the 30-minute orphan watchdog.
+      const sockPath = join(tempDir, "broker.sock");
+      const endpoint = `unix:${sockPath}`;
+      const mockDir = createMockCodex(tempDir, { goalPausedInGap: true });
+
+      const proc = spawnBroker(endpoint, mockDir);
+      await waitForSocket(sockPath);
+
+      try {
+        const client = await TestClient.connectAndInit(sockPath);
+        const notifications = collectNotifications(client);
+
+        await client.request("turn/start", {
+          threadId: "thread-001",
+          input: [{ type: "text", text: "work the goal" }],
+        });
+        await waitFor(() => notifications.some(
+          (n) => n.method === "thread/goal/updated" && (n.params as any)?.goal?.status === "paused",
+        ), 5000);
+
+        // Ownership must be free again: a second client can stream.
+        const client2 = await TestClient.connectAndInit(sockPath);
+        const res = await client2.request("turn/start", {
+          threadId: "thread-002",
+          input: [{ type: "text", text: "next" }],
+        });
+        expect((res as any)?.turn?.id).toBeDefined();
+
+        await client.close();
         await client2.close();
       } finally {
         proc.kill();

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -186,6 +186,7 @@ async function main() {
     if (activeStreamTargets?.has(threadId)) {
       activeStreamSocket = null;
       activeStreamTargets = null;
+      retainedAwaitingContinuation.clear(); // ownership is singular — nothing else awaits
       if (orphanWatchdog) {
         clearTimeout(orphanWatchdog);
         orphanWatchdog = null;
@@ -245,6 +246,7 @@ async function main() {
         if (activeStreamSocket !== null && activeStreamTargets === ownedTargets) {
           activeStreamSocket = null;
           activeStreamTargets = null;
+          retainedAwaitingContinuation.clear(); // ownership gone — no gap markers
           // Don't touch activeRequestSocket — a fresh non-streaming request
           // (kill, threads, etc.) may have claimed it during the await.
         }
@@ -391,7 +393,10 @@ async function main() {
         // continuation starts, releaseGapRetention frees the ownership.
         retainedAwaitingContinuation.add(threadId as string);
       } else if (matchesStream && (activeStreamSocket === target || activeStreamSocket === null)) {
-        if (typeof threadId === "string") retainedAwaitingContinuation.delete(threadId);
+        // Ownership is singular — releasing it means nothing is awaiting a
+        // continuation anymore; a stale entry would trigger a premature
+        // gap-release against a FUTURE owner of the same thread.
+        retainedAwaitingContinuation.clear();
         // If we're releasing actual stream ownership (activeStreamSocket was set),
         // also clean up the tracked turn ID so the bounded set stays small.
         // In the fast-turn race (activeStreamSocket is null), keep the entry
@@ -704,6 +709,7 @@ async function main() {
           if (reviewThreadId) orphanTargets.set(reviewThreadId, turnId);
           activeStreamSocket = socket;
           activeStreamTargets = orphanTargets;
+          retainedAwaitingContinuation.clear(); // fresh ownership — no stale gap markers
           armOrphanWatchdog(orphanTargets);
           try {
             await appClient.request("turn/interrupt", { threadId: interruptThreadId, turnId });
@@ -744,6 +750,7 @@ async function main() {
         if (!alreadyCompleted && streamTargets.size > 0) {
           activeStreamSocket = socket;
           activeStreamTargets = streamTargets;
+          retainedAwaitingContinuation.clear(); // fresh ownership — no stale gap markers
         }
         if (newTurnId) completedStreamTurnIds.delete(newTurnId);
       }

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -747,10 +747,23 @@ async function main() {
         // ownership: turn/completed matches by thread ID, so nothing could
         // ever release the slot and the broker would stay busy until the
         // owner disconnects.
-        if (!alreadyCompleted && streamTargets.size > 0) {
+        //
+        // Goal-mode exception to the fast-turn skip: the turn may already be
+        // over, but an ACTIVE goal means the server is about to start a
+        // continuation — skipping the claim would leave those notifications
+        // with no target, and the goal-following client would wait blind
+        // until its timeout pauses a goal that in fact continued. Claim
+        // anyway (owner still connected) and mark the between-turns gap so
+        // a pause landing before the continuation still releases the slot.
+        const goalThreadId = [...streamTargets.keys()].find((t) => goalActiveThreads.has(t)) ?? null;
+        const claimForGoal = alreadyCompleted && goalThreadId !== null && sockets.has(socket);
+        if ((!alreadyCompleted || claimForGoal) && streamTargets.size > 0) {
           activeStreamSocket = socket;
           activeStreamTargets = streamTargets;
           retainedAwaitingContinuation.clear(); // fresh ownership — no stale gap markers
+          if (claimForGoal && goalThreadId !== null) {
+            retainedAwaitingContinuation.add(goalThreadId);
+          }
         }
         if (newTurnId) completedStreamTurnIds.delete(newTurnId);
       }

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -140,6 +140,33 @@ async function main() {
    *  finished. Keyed by turnId (unique per turn) so a leaked entry from a
    *  prior turn cannot poison a future turn on the same thread. */
   const completedStreamTurnIds = new Set<string>();
+  /** Threads whose goal is currently active (tracked from thread/goal/*
+   *  notifications). Goal mode is server-driven multi-turn: a continuation
+   *  turn starts the instant one completes, so releasing stream ownership at
+   *  turn/completed would drop every continuation notification on the floor
+   *  — the goal-following client only ever sees turn 1. While the goal is
+   *  active and the owner is still connected, ownership spans the turns. */
+  const goalActiveThreads = new Set<string>();
+  /** Threads whose ownership was retained across a turn boundary and whose
+   *  continuation turn has NOT started yet. If the goal leaves `active` in
+   *  this gap (kill/timeout pausing it between turns), no continuation will
+   *  start and no turn/completed will ever arrive — ownership must be
+   *  released here or the broker reports busy until the orphan watchdog. */
+  const retainedAwaitingContinuation = new Set<string>();
+
+  /** Release retained stream ownership for a thread whose goal ended in the
+   *  between-turns gap. */
+  function releaseGapRetention(threadId: string): void {
+    if (!retainedAwaitingContinuation.delete(threadId)) return;
+    if (activeStreamTargets?.has(threadId)) {
+      activeStreamSocket = null;
+      activeStreamTargets = null;
+      if (orphanWatchdog) {
+        clearTimeout(orphanWatchdog);
+        orphanWatchdog = null;
+      }
+    }
+  }
   /** Pending forwarded requests (e.g. approval requests sent to a client socket,
    *  awaiting a response routed through the main data handler). */
   const pendingForwardedRequests = new Map<string, {
@@ -259,6 +286,40 @@ async function main() {
       send(target, message);
     }
 
+    // Track goal state per thread — it decides whether turn/completed
+    // releases stream ownership (see goalActiveThreads).
+    if (method === "thread/goal/updated") {
+      const p = notifParams as { threadId?: unknown; goal?: { status?: unknown } } | undefined;
+      if (typeof p?.threadId === "string") {
+        if (p.goal?.status === "active") {
+          goalActiveThreads.add(p.threadId);
+        } else {
+          goalActiveThreads.delete(p.threadId);
+          releaseGapRetention(p.threadId);
+        }
+      }
+    } else if (method === "thread/goal/cleared") {
+      const p = notifParams as { threadId?: unknown } | undefined;
+      if (typeof p?.threadId === "string") {
+        goalActiveThreads.delete(p.threadId);
+        releaseGapRetention(p.threadId);
+      }
+    }
+
+    // A goal continuation turn starting on an owned thread re-targets the
+    // orphan bookkeeping: if the owner later disconnects, the watchdog must
+    // interrupt the CURRENT turn, not the long-finished first one.
+    if (method === "turn/started") {
+      const p = notifParams as { threadId?: unknown; turn?: { id?: unknown } } | undefined;
+      if (
+        typeof p?.threadId === "string" && typeof p?.turn?.id === "string" &&
+        activeStreamSocket !== null && activeStreamTargets?.has(p.threadId)
+      ) {
+        activeStreamTargets.set(p.threadId, p.turn.id);
+        retainedAwaitingContinuation.delete(p.threadId);
+      }
+    }
+
     // If turn/completed, release the stream ownership — even if the owning
     // socket has disconnected (orphaned turn completing naturally).
     if (method === "turn/completed") {
@@ -286,7 +347,26 @@ async function main() {
         typeof threadId !== "string" ||
         !activeStreamTargets ||
         activeStreamTargets.has(threadId);
-      if (matchesStream && (activeStreamSocket === target || activeStreamSocket === null)) {
+      // Goal-mode retention: with an active goal, the server starts the next
+      // continuation turn within milliseconds. As long as the owning client
+      // is still CONNECTED (a disconnected sentinel means headless
+      // continuation — release as usual so recovery paths run), keep the
+      // stream ownership so continuation notifications keep flowing to it.
+      // The goal leaving `active` (complete/paused/blocked/limits/cleared)
+      // updates goalActiveThreads above, so the goal's final turn/completed
+      // releases normally.
+      const goalContinues =
+        typeof threadId === "string" &&
+        goalActiveThreads.has(threadId) &&
+        activeStreamSocket !== null &&
+        sockets.has(activeStreamSocket);
+      if (goalContinues) {
+        if (completedTurnId) completedStreamTurnIds.delete(completedTurnId);
+        // Between turns now — if the goal is paused/cleared before the
+        // continuation starts, releaseGapRetention frees the ownership.
+        retainedAwaitingContinuation.add(threadId as string);
+      } else if (matchesStream && (activeStreamSocket === target || activeStreamSocket === null)) {
+        if (typeof threadId === "string") retainedAwaitingContinuation.delete(threadId);
         // If we're releasing actual stream ownership (activeStreamSocket was set),
         // also clean up the tracked turn ID so the bounded set stays small.
         // In the fast-turn race (activeStreamSocket is null), keep the entry

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -154,6 +154,31 @@ async function main() {
    *  released here or the broker reports busy until the orphan watchdog. */
   const retainedAwaitingContinuation = new Set<string>();
 
+  /** Learn goal state from request/response traffic passing through the
+   *  broker. Notifications cover goals that CHANGE, but a goal that
+   *  predates every client (resumed goal-mode thread) may never fire one
+   *  before the first turn/completed — the goal-following client's own
+   *  pre-turn thread/goal/get is then the broker's only signal to retain
+   *  ownership across the continuation turns. */
+  function learnGoalFromTraffic(method: unknown, params: unknown, result: unknown): void {
+    if (method === "thread/goal/get" || method === "thread/goal/set") {
+      const goal = (result as { goal?: { threadId?: unknown; status?: unknown } } | undefined)?.goal;
+      if (!goal || typeof goal.threadId !== "string") return;
+      if (goal.status === "active") {
+        goalActiveThreads.add(goal.threadId);
+      } else {
+        goalActiveThreads.delete(goal.threadId);
+        releaseGapRetention(goal.threadId);
+      }
+    } else if (method === "thread/goal/clear") {
+      const threadId = (params as { threadId?: unknown } | undefined)?.threadId;
+      if (typeof threadId === "string") {
+        goalActiveThreads.delete(threadId);
+        releaseGapRetention(threadId);
+      }
+    }
+  }
+
   /** Release retained stream ownership for a thread whose goal ended in the
    *  between-turns gap. */
   function releaseGapRetention(threadId: string): void {
@@ -573,13 +598,20 @@ async function main() {
     const isReadOnly =
       typeof message.method === "string" &&
       (message.method === "thread/read" || message.method === "thread/list");
+    const isGoalOp =
+      typeof message.method === "string" &&
+      (message.method === "thread/goal/get" ||
+        message.method === "thread/goal/set" ||
+        message.method === "thread/goal/clear");
 
-    // Allow interrupt and read-only requests through even when another
-    // client owns the stream — but only when there's no pending request.
-    // Read-only methods are needed by `kill` (reads thread to get turn ID)
-    // and `threads` (lists threads while a turn is running).
+    // Allow interrupt, read-only, and goal requests through even when
+    // another client owns the stream — but only when there's no pending
+    // request. Read-only methods are needed by `kill` (reads thread to get
+    // turn ID) and `threads` (lists threads while a turn is running); goal
+    // ops are needed by `kill`/`kill --clear` to brake a goal whose
+    // following run owns the stream for the goal's whole lifetime.
     const allowDuringActiveStream =
-      (isInterrupt || isReadOnly) &&
+      (isInterrupt || isReadOnly || isGoalOp) &&
       activeStreamSocket !== null &&
       activeStreamSocket !== socket &&
       activeRequestSocket === null;
@@ -599,13 +631,14 @@ async function main() {
       return;
     }
 
-    // Forward interrupt/read-only during active stream (special path)
+    // Forward interrupt/read-only/goal ops during active stream (special path)
     if (allowDuringActiveStream) {
       try {
         const result = await appClient.request(
           message.method as string,
           (message.params ?? {}) as Record<string, unknown>,
         );
+        learnGoalFromTraffic(message.method, message.params, result);
         send(socket, { id: message.id, result });
       } catch (error) {
         send(socket, {
@@ -630,6 +663,7 @@ async function main() {
         message.method as string,
         (message.params ?? {}) as Record<string, unknown>,
       );
+      learnGoalFromTraffic(message.method, message.params, result);
 
       // If the requesting client disconnected while we were waiting for the
       // response, the turn has started on the app-server but nobody is

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { config } from "./config";
 import type { AppServerClient } from "./client";
 import { updateThreadStatus, updateRun } from "./threads";
 import { tryInterruptTurn } from "./turns";
+import { getThreadGoal, pauseThreadGoal } from "./goals";
 import {
   activeClient,
   activeThreadId,
@@ -66,7 +67,20 @@ async function handleShutdownSignal(exitCode: number): Promise<void> {
   // alone only detaches from the broker; the turn would keep running and
   // hold the broker stream busy. For reviews the turn lives on a review
   // subthread distinct from activeThreadId — route there when known.
+  // An active GOAL must be paused before the interrupt: interrupt alone
+  // makes the server start a fresh continuation turn, so Ctrl-C would
+  // leave the goal burning tokens headless after this process exits.
   const interruptThreadId = activeReviewThreadId ?? activeThreadId;
+  if (activeClient && activeThreadId && !activeReviewThreadId) {
+    try {
+      if ((await getThreadGoal(activeClient, activeThreadId))?.status === "active") {
+        await pauseThreadGoal(activeClient, activeThreadId);
+        console.error("[codex] Goal paused — a new turn on this thread resumes it.");
+      }
+    } catch (e) {
+      console.error(`[codex] Warning: could not check/pause goal during shutdown: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
   if (activeClient && interruptThreadId && activeTurnId) {
     await tryInterruptTurn(activeClient, interruptThreadId, activeTurnId);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { config } from "./config";
 import type { AppServerClient } from "./client";
 import { updateThreadStatus, updateRun } from "./threads";
 import { tryInterruptTurn } from "./turns";
-import { getThreadGoal, pauseThreadGoal } from "./goals";
+import { pauseThreadGoal, readThreadGoal } from "./goals";
 import {
   activeClient,
   activeThreadId,
@@ -73,9 +73,15 @@ async function handleShutdownSignal(exitCode: number): Promise<void> {
   const interruptThreadId = activeReviewThreadId ?? activeThreadId;
   if (activeClient && activeThreadId && !activeReviewThreadId) {
     try {
-      if ((await getThreadGoal(activeClient, activeThreadId))?.status === "active") {
-        await pauseThreadGoal(activeClient, activeThreadId);
-        console.error("[codex] Goal paused — a new turn on this thread resumes it.");
+      // Fail closed: skip the pause only when the read POSITIVELY says no
+      // active goal. A transient read failure must still attempt the pause —
+      // interrupting an active goal without pausing respawns a continuation
+      // that runs headless after this process exits.
+      const { goal, ok } = await readThreadGoal(activeClient, activeThreadId);
+      if (!ok || goal?.status === "active") {
+        if (await pauseThreadGoal(activeClient, activeThreadId)) {
+          console.error("[codex] Goal paused — a new turn on this thread resumes it.");
+        }
       }
     } catch (e) {
       console.error(`[codex] Warning: could not check/pause goal during shutdown: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,9 @@ Commands:
   review "instructions"   Custom review with specific focus
   threads [--json] [--all] List threads (--limit <n>, --discover,
                           --session: only threads this session has run)
-  kill <id>               Stop a running thread
+  kill <id> [--clear]     Stop a running thread. An active goal is paused
+                          first (interrupt alone would just respawn a
+                          continuation turn); --clear abandons the goal
   follow [id] [--watch]   Live view of a running thread; exits on completion
                           (no id: attach to the workspace's active run,
                           or replay the most recent one; --watch: keep the
@@ -144,7 +146,9 @@ Options:
                           (default: ${config.defaultSandbox})
   -d, --dir <path>        Working directory (default: cwd)
   --resume <id>           Resume existing thread
-  --timeout <sec>         Turn timeout in seconds (default: ${config.defaultTimeout})
+  --timeout <sec>         Turn timeout in seconds (default: ${config.defaultTimeout}).
+                          When a goal is active it scopes the WHOLE goal;
+                          on expiry the goal is paused, never left running
   --approval <policy>     Approval: ${config.approvalModes.join(", ")} (default: ${config.defaultApprovalPolicy})
                           "auto": Codex's Guardian reviewer approves or denies
                           each request autonomously (never blocks on a human)
@@ -168,11 +172,18 @@ Options:
   -v, --version           Print version and exit (before the command only)
 
 Exit codes (run, review):
-  0  turn completed        3  turn timed out (--timeout; resume with --resume <id>)
-  1  turn/command failed   4  turn interrupted (kill)
+  0  turn completed        3  turn/goal timed out (--timeout; goal is paused;
+  1  turn/command failed      resume with --resume <id>)
+                           4  turn interrupted (kill)
                            5  died blocked on an approval (request now void —
                               resume with a longer --timeout or --approval auto)
                            6  broker busy and fallback unavailable (transient; retry)
+                           7  goal ended blocked or usage/budget-limited —
+                              Codex needs you (steer with --resume, or kill --clear)
+
+Goal mode: when Codex creates a goal (goals = true in ~/.codex/config.toml),
+a run follows the server's continuation turns until the goal completes, is
+paused, or gets blocked — the run IS the goal, not just its first turn.
 
 Exit codes (next):
   0  event delivered (JSON on stdout)   3  --timeout elapsed with no event

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -6,6 +6,17 @@ import { join } from "path";
 import { pauseThreadGoal, clearThreadGoal, isGoalFeatureUnavailable } from "../goals";
 import type { AppServerClient } from "../client";
 import type { ThreadGoal } from "../types";
+import {
+  die,
+  parseOptions,
+  validateIdOrDie,
+  resolveThreadIdAllowRaw,
+  progress,
+  withClient,
+  readPidFile,
+  removePidFile,
+  getWorkspacePaths,
+} from "./shared";
 
 /** Read the thread goal with a few retries: a live goal-following run owns
  *  the broker stream and its own in-flight polls can transiently bounce our
@@ -28,17 +39,6 @@ async function readGoalWithRetry(
     }
   }
 }
-import {
-  die,
-  parseOptions,
-  validateIdOrDie,
-  resolveThreadIdAllowRaw,
-  progress,
-  withClient,
-  readPidFile,
-  removePidFile,
-  getWorkspacePaths,
-} from "./shared";
 
 export async function handleKill(args: string[]): Promise<void> {
   const { positional, options } = parseOptions(args);

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -99,12 +99,18 @@ export async function handleKill(args: string[]): Promise<void> {
       // alone just makes the server start a fresh continuation turn. Pause
       // keeps the goal resumable (a later turn continues it); --clear
       // abandons it entirely.
+      // Whether the goal is CONFIRMED gone server-side (cleared now, or the
+      // server said there is none). The ledger reconciliation below must not
+      // outrun reality: stamping "cleared" while the clear actually failed
+      // would leave a resumable server-side goal the user believes abandoned.
+      let goalKnownGone = false;
       try {
         const { goal, readFailed } = await readGoalWithRetry(client, threadId);
         if (goal) {
           if (options.clear) {
             if (await clearThreadGoal(client, threadId)) {
               goalStopped = true;
+              goalKnownGone = true;
               progress(`Cleared goal (was ${goal.status}): ${goal.objective.split("\n", 1)[0].slice(0, 80)}`);
             }
           } else if (goal.status === "active") {
@@ -118,12 +124,14 @@ export async function handleKill(args: string[]): Promise<void> {
           // (clearing a goal-less thread is a no-op server-side).
           if (await clearThreadGoal(client, threadId)) {
             goalStopped = true;
+            goalKnownGone = true;
             progress("Cleared goal (state was unreadable — cleared blindly).");
           }
         } else if (readFailed) {
           progress("Could not read goal state — if a goal is active, the running process pauses it on kill.");
-        } else if (options.clear) {
-          progress("No goal on this thread.");
+        } else {
+          goalKnownGone = true; // read succeeded: no goal on this thread
+          if (options.clear) progress("No goal on this thread.");
         }
       } catch (e) {
         console.error(`[codex] Warning: could not stop thread goal: ${e instanceof Error ? e.message : String(e)}`);
@@ -132,9 +140,9 @@ export async function handleKill(args: string[]): Promise<void> {
       // After --clear, reconcile the ledger: the latest run's goal mirror is
       // what `threads` shows, and leaving it "paused"/"active" would keep
       // advertising a goal that no longer exists (inviting a pointless
-      // resume). Stamped even when the server had no goal — that's exactly
-      // the stale-mirror case.
-      if (options.clear && shortId) {
+      // resume). Only once the server-side goal is confirmed gone — the
+      // no-goal-but-stale-mirror case included.
+      if (options.clear && goalKnownGone && shortId) {
         try {
           const latest = getLatestRun(ws.stateDir, shortId);
           if (latest?.goal && latest.goal.status !== "complete" && latest.goal.status !== "cleared") {

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -3,6 +3,7 @@
 import { loadThreadIndex, updateThreadStatus } from "../threads";
 import { writeFileSync } from "fs";
 import { join } from "path";
+import { getThreadGoal, pauseThreadGoal, clearThreadGoal } from "../goals";
 import {
   die,
   parseOptions,
@@ -19,36 +20,46 @@ export async function handleKill(args: string[]): Promise<void> {
   const { positional, options } = parseOptions(args);
   const ws = getWorkspacePaths(options.dir);
   const id = positional[0];
-  if (!id) die("Usage: codex-collab kill <id>");
+  if (!id) die("Usage: codex-collab kill <id> [--clear]");
   validateIdOrDie(id);
 
   const { threadId, shortId } = resolveThreadIdAllowRaw(ws.stateDir, id);
 
-  // Skip kill for threads that have already reached a terminal status
+  // A thread already at a terminal status has no run to kill — but with
+  // --clear the goal is the target, and a goal outlives its runs (that's
+  // the point of the timeout-pause), so fall through to the goal handling.
+  let threadRunning = true;
   if (shortId) {
     const index = loadThreadIndex(ws.stateDir);
     const localStatus = index[shortId]?.lastStatus;
     if (localStatus && localStatus !== "running") {
-      progress(`Thread ${id} is already ${localStatus}`);
-      return;
+      if (!options.clear) {
+        progress(`Thread ${id} is already ${localStatus}`);
+        return;
+      }
+      threadRunning = false;
     }
   }
 
   // Write kill signal file so the running process can detect the kill.
   // Tag with the target run's PID; falls back to "*" (wildcard — matches
-  // any active run on this thread) when no PID file is available.
+  // any active run on this thread) when no PID file is available. Skipped
+  // when nothing is running (--clear on a settled thread) — a lingering
+  // wildcard signal would target the thread's NEXT run.
   let killSignalWritten = false;
   const signalPath = join(ws.killSignalsDir, threadId);
-  const pid = shortId ? readPidFile(ws.pidsDir, shortId) : null;
-  const targetPid = pid !== null ? String(pid) : "*";
-  try {
-    writeFileSync(signalPath, targetPid, { mode: 0o600 });
-    killSignalWritten = true;
-  } catch (e) {
-    console.error(
-      `[codex] Warning: could not write kill signal: ${e instanceof Error ? e.message : String(e)}. ` +
-      `The running process may not detect the kill.`,
-    );
+  if (threadRunning) {
+    const pid = shortId ? readPidFile(ws.pidsDir, shortId) : null;
+    const targetPid = pid !== null ? String(pid) : "*";
+    try {
+      writeFileSync(signalPath, targetPid, { mode: 0o600 });
+      killSignalWritten = true;
+    } catch (e) {
+      console.error(
+        `[codex] Warning: could not write kill signal: ${e instanceof Error ? e.message : String(e)}. ` +
+        `The running process may not detect the kill.`,
+      );
+    }
   }
 
   // Try to interrupt the active turn on the server (immediate effect).
@@ -57,8 +68,34 @@ export async function handleKill(args: string[]): Promise<void> {
   // abort the command — the signal file is already written and the polling
   // run will still die, so fall through to report that.
   let serverInterrupted = false;
+  let goalStopped = false;
   try {
     await withClient(async (client) => {
+      // Goal FIRST, interrupt second: with an active goal, `turn/interrupt`
+      // alone just makes the server start a fresh continuation turn. Pause
+      // keeps the goal resumable (a later turn continues it); --clear
+      // abandons it entirely.
+      try {
+        const goal = await getThreadGoal(client, threadId);
+        if (goal) {
+          if (options.clear) {
+            if (await clearThreadGoal(client, threadId)) {
+              goalStopped = true;
+              progress(`Cleared goal (was ${goal.status}): ${goal.objective.split("\n", 1)[0].slice(0, 80)}`);
+            }
+          } else if (goal.status === "active") {
+            if (await pauseThreadGoal(client, threadId)) {
+              goalStopped = true;
+              progress("Paused goal — a new turn on this thread resumes it; `kill --clear` abandons it.");
+            }
+          }
+        } else if (options.clear) {
+          progress("No goal on this thread.");
+        }
+      } catch (e) {
+        console.error(`[codex] Warning: could not stop thread goal: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
       try {
         const { thread } = await client.request<{
           thread: {
@@ -97,6 +134,11 @@ export async function handleKill(args: string[]): Promise<void> {
       removePidFile(ws.pidsDir, shortId);
     }
     progress(`Stopped thread ${id}`);
+  } else if (goalStopped) {
+    // --clear on a settled thread: nothing was running, only the goal ended.
+    progress(`Goal ${options.clear ? "cleared" : "paused"} on thread ${id}`);
+  } else if (!threadRunning) {
+    progress(`Nothing to stop on thread ${id}.`);
   } else {
     progress(`Could not signal thread ${id} — try again.`);
   }

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -1,9 +1,33 @@
 // src/commands/kill.ts — kill command handler
 
-import { loadThreadIndex, updateThreadStatus } from "../threads";
+import { getLatestRun, loadThreadIndex, updateRun, updateThreadStatus } from "../threads";
 import { writeFileSync } from "fs";
 import { join } from "path";
-import { getThreadGoal, pauseThreadGoal, clearThreadGoal } from "../goals";
+import { pauseThreadGoal, clearThreadGoal, isGoalFeatureUnavailable } from "../goals";
+import type { AppServerClient } from "../client";
+import type { ThreadGoal } from "../types";
+
+/** Read the thread goal with a few retries: a live goal-following run owns
+ *  the broker stream and its own in-flight polls can transiently bounce our
+ *  request with "broker busy" — exactly the moment kill is most used. */
+async function readGoalWithRetry(
+  client: AppServerClient,
+  threadId: string,
+): Promise<{ goal: ThreadGoal | null; readFailed: boolean }> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const res = await client.request<{ goal: ThreadGoal | null }>("thread/goal/get", { threadId });
+      return { goal: res.goal ?? null, readFailed: false };
+    } catch (e) {
+      if (isGoalFeatureUnavailable(e)) return { goal: null, readFailed: false };
+      if (attempt >= 2) {
+        console.error(`[codex] Warning: could not read thread goal: ${e instanceof Error ? e.message : String(e)}`);
+        return { goal: null, readFailed: true };
+      }
+      await new Promise((r) => setTimeout(r, 400));
+    }
+  }
+}
 import {
   die,
   parseOptions,
@@ -76,7 +100,7 @@ export async function handleKill(args: string[]): Promise<void> {
       // keeps the goal resumable (a later turn continues it); --clear
       // abandons it entirely.
       try {
-        const goal = await getThreadGoal(client, threadId);
+        const { goal, readFailed } = await readGoalWithRetry(client, threadId);
         if (goal) {
           if (options.clear) {
             if (await clearThreadGoal(client, threadId)) {
@@ -89,11 +113,38 @@ export async function handleKill(args: string[]): Promise<void> {
               progress("Paused goal — a new turn on this thread resumes it; `kill --clear` abandons it.");
             }
           }
+        } else if (readFailed && options.clear) {
+          // Can't see the goal but the user asked for it gone — clear blindly
+          // (clearing a goal-less thread is a no-op server-side).
+          if (await clearThreadGoal(client, threadId)) {
+            goalStopped = true;
+            progress("Cleared goal (state was unreadable — cleared blindly).");
+          }
+        } else if (readFailed) {
+          progress("Could not read goal state — if a goal is active, the running process pauses it on kill.");
         } else if (options.clear) {
           progress("No goal on this thread.");
         }
       } catch (e) {
         console.error(`[codex] Warning: could not stop thread goal: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      // After --clear, reconcile the ledger: the latest run's goal mirror is
+      // what `threads` shows, and leaving it "paused"/"active" would keep
+      // advertising a goal that no longer exists (inviting a pointless
+      // resume). Stamped even when the server had no goal — that's exactly
+      // the stale-mirror case.
+      if (options.clear && shortId) {
+        try {
+          const latest = getLatestRun(ws.stateDir, shortId);
+          if (latest?.goal && latest.goal.status !== "complete" && latest.goal.status !== "cleared") {
+            updateRun(ws.stateDir, latest.runId, {
+              goal: { ...latest.goal, status: "cleared", updatedAt: new Date().toISOString() },
+            });
+          }
+        } catch (e) {
+          console.error(`[codex] Warning: could not update run record goal state: ${e instanceof Error ? e.message : String(e)}`);
+        }
       }
 
       try {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -309,7 +309,7 @@ export async function handleRun(args: string[]): Promise<void> {
 
       // Final goal snapshot: a goal that ended non-active keeps its wire
       // status; a goal that disappeared after being seen was cleared by the
-      // server = completed.
+      // server — record it with the wire's success status.
       const snapshot = goalSnapshot as RunGoalState | null; // local copy: closure mutation defeats narrowing
       const finalGoal: RunGoalState | null | undefined = !result.goalSeen || snapshot === null
         ? undefined
@@ -322,7 +322,7 @@ export async function handleRun(args: string[]): Promise<void> {
               turns: result.continuationTurns + 1,
               updatedAt: new Date().toISOString(),
             }
-          : { ...snapshot, status: "completed", turns: result.continuationTurns + 1, updatedAt: new Date().toISOString() };
+          : { ...snapshot, status: "complete", turns: result.continuationTurns + 1, updatedAt: new Date().toISOString() };
 
       const exit = recordTerminalRunState(ws, threadId, runId, result, "Turn", options.contentOnly, finalGoal);
       // A completed run whose goal ended blocked/limited still needs the

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,7 +4,9 @@ import { spawn as childSpawn, spawnSync } from "node:child_process";
 import { openSync, closeSync, readFileSync } from "fs";
 import { join } from "path";
 import { updateThreadStatus, generateRunId, loadRun, updateRun, runLogRelPath } from "../threads";
-import { runTurn } from "../turns";
+import { runTurnWithGoalFollow } from "../turns";
+import { goalNeedsAttention } from "../goals";
+import type { RunGoalState, ThreadGoal } from "../types";
 import { config, loadTemplateWithMeta, interpolateTemplate, type SandboxMode } from "../config";
 import { wrapBrokerBusy, isBrokerBusyError } from "../broker";
 import {
@@ -252,8 +254,30 @@ export async function handleRun(args: string[]): Promise<void> {
     const dispatcher = createDispatcher(join(ws.stateDir, runLogRelPath(shortId, runId)), options, ws.guardianDir);
     armQuestionChannel(dispatcher, ws, runId, options.dir);
 
+    // Live mirror of the thread goal onto the run record, so observers
+    // (threads/follow/next) can see a goal-mode run's progress without
+    // owning its stdout. Snapshot kept locally: a goal that COMPLETES is
+    // cleared server-side, and the record's final state is this snapshot
+    // re-labeled "completed".
+    let goalSnapshot: RunGoalState | null = null;
+    const mirrorGoal = (goal: ThreadGoal, continuationTurns: number): void => {
+      goalSnapshot = {
+        objective: goal.objective,
+        status: goal.status,
+        tokenBudget: goal.tokenBudget,
+        tokensUsed: goal.tokensUsed,
+        turns: continuationTurns + 1,
+        updatedAt: new Date().toISOString(),
+      };
+      try {
+        updateRun(ws.stateDir, runId, { goal: goalSnapshot });
+      } catch (e) {
+        console.error(`[codex] Warning: could not mirror goal state: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    };
+
     try {
-      const result = await runTurn(
+      const result = await runTurnWithGoalFollow(
         client,
         threadId,
         [{ type: "text", text: prompt }],
@@ -278,11 +302,36 @@ export async function handleRun(args: string[]): Promise<void> {
               console.error(`[codex] Warning: could not update run phase: ${e instanceof Error ? e.message : String(e)}`);
             }
           },
+          onGoalUpdate: mirrorGoal,
           ...turnOverrides(options),
         },
       );
 
-      return recordTerminalRunState(ws, threadId, runId, result, "Turn", options.contentOnly);
+      // Final goal snapshot: a goal that ended non-active keeps its wire
+      // status; a goal that disappeared after being seen was cleared by the
+      // server = completed.
+      const snapshot = goalSnapshot as RunGoalState | null; // local copy: closure mutation defeats narrowing
+      const finalGoal: RunGoalState | null | undefined = !result.goalSeen || snapshot === null
+        ? undefined
+        : result.goal !== null
+          ? {
+              objective: result.goal.objective,
+              status: result.goal.status,
+              tokenBudget: result.goal.tokenBudget,
+              tokensUsed: result.goal.tokensUsed,
+              turns: result.continuationTurns + 1,
+              updatedAt: new Date().toISOString(),
+            }
+          : { ...snapshot, status: "completed", turns: result.continuationTurns + 1, updatedAt: new Date().toISOString() };
+
+      const exit = recordTerminalRunState(ws, threadId, runId, result, "Turn", options.contentOnly, finalGoal);
+      // A completed run whose goal ended blocked/limited still needs the
+      // user — that outcome outranks the last turn's clean status.
+      if (exit === EXIT_CODES.ok && finalGoal && goalNeedsAttention(finalGoal.status)) {
+        progress(`Goal needs attention (${finalGoal.status}) — steer with: codex-collab run --resume ${shortId} "..."`);
+        return EXIT_CODES.goalBlocked;
+      }
+      return exit;
     } catch (e) {
       e = wrapBrokerBusy(e);
       // A broker-busy error here is about to be retried by withClient over a

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -30,7 +30,7 @@ import {
   migrateGlobalState,
   appendRunQuestion,
 } from "../threads";
-import type { PendingApproval } from "../types";
+import type { PendingApproval, RunGoalState } from "../types";
 import { RpcError, TurnTimeoutError } from "../types";
 import { EventDispatcher } from "../events";
 import {
@@ -112,6 +112,8 @@ export interface Options {
   watch: boolean;
   /** delete: permanently delete the thread server-side instead of archiving. */
   purge: boolean;
+  /** kill: clear (abandon) the thread's goal instead of pausing it. */
+  clear: boolean;
   /** output: print only the latest turn's agent output (implies contentOnly). */
   last: boolean;
   /** approve: override a Guardian denial instead of answering a pending
@@ -180,6 +182,11 @@ export const EXIT_CODES = {
   /** Broker stream owned by another invocation and the direct-connection
    *  fallback did not absorb it — transient, safe to retry. */
   brokerBusy: 6,
+  /** The run followed a goal that ended needing a human: `blocked` (Codex
+   *  stalled 3 consecutive turns) or a server brake (usage/token-budget
+   *  limit). The goal persists on the thread — steer with a resume turn, or
+   *  abandon it with `kill --clear`. */
+  goalBlocked: 7,
 } as const;
 
 /** Errors can carry an explicit exit code (set where the context to classify
@@ -262,6 +269,7 @@ export function defaultOptions(): Options {
     detach: false,
     watch: false,
     purge: false,
+    clear: false,
     guardian: false,
     dir: process.cwd(),
     last: false,
@@ -401,6 +409,8 @@ export function parseOptions(args: string[]): { positional: string[]; options: O
       options.watch = true;
     } else if (arg === "--purge") {
       options.purge = true;
+    } else if (arg === "--clear") {
+      options.clear = true;
     } else if (arg === "--last") {
       options.last = true;
       options.contentOnly = true;
@@ -1165,6 +1175,9 @@ export function recordTerminalRunState(
   result: TurnResult,
   label: "Turn" | "Review",
   contentOnly: boolean,
+  /** Final goal snapshot for the record; undefined leaves the field as the
+   *  live mirror last wrote it (non-goal runs never have one). */
+  goal?: RunGoalState | null,
 ): number {
   // Snapshot before the terminal write below clears it: a non-completed end
   // with an approval still pending is the "healthy turn killed while blocked
@@ -1191,6 +1204,7 @@ export function recordTerminalRunState(
       // record claiming an approval (or ask-channel question) is still pending.
       pendingApproval: null,
       pendingQuestion: null,
+      ...(goal !== undefined ? { goal } : {}),
     });
   } catch (e) {
     console.error(`[codex] CRITICAL: could not save run state for ${runId}: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -181,6 +181,16 @@ export async function handleThreads(args: string[]): Promise<void> {
   const displayLimit = applyDiscoverLimit(options);
   if (displayLimit !== Infinity) entries = entries.slice(0, displayLimit);
 
+  // Goal state from each thread's LATEST run record only — an older run's
+  // goal snapshot is history, not the thread's current situation.
+  const latestRunSeen = new Set<string>();
+  const goalByThread = new Map<string, NonNullable<RunRecord["goal"]>>();
+  for (const r of listRuns(ws.stateDir)) {
+    if (latestRunSeen.has(r.threadId)) continue;
+    latestRunSeen.add(r.threadId);
+    if (r.goal) goalByThread.set(r.threadId, r.goal);
+  }
+
   if (options.json) {
     const enriched = entries.map(e => ({
       shortId: e.shortId,
@@ -191,6 +201,7 @@ export async function handleThreads(args: string[]): Promise<void> {
       preview: e.preview ?? null,
       createdAt: e.createdAt,
       updatedAt: e.updatedAt ?? e.createdAt,
+      goal: goalByThread.get(e.threadId) ?? null,
     }));
     console.log(JSON.stringify(enriched, null, 2));
   } else {
@@ -204,11 +215,21 @@ export async function handleThreads(args: string[]): Promise<void> {
       const age = formatAge(ts);
       const model = e.model ? ` (${e.model})` : "";
       const preview = e.preview ? ` ${e.preview.slice(0, 50)}` : "";
+      const goal = goalByThread.get(e.threadId);
+      const goalNote = goal ? `  [goal ${goal.status}: ${formatGoalTokens(goal)}]` : "";
       console.log(
-        `  ${e.shortId}  ${status.padEnd(12)} ${age.padEnd(8)} ${e.cwd ?? ""}${model}${preview}`,
+        `  ${e.shortId}  ${status.padEnd(12)} ${age.padEnd(8)} ${e.cwd ?? ""}${model}${preview}${goalNote}`,
       );
     }
   }
+}
+
+/** "45k/100k tokens" (budgeted) or "45k tokens" for the threads listing. */
+function formatGoalTokens(goal: NonNullable<RunRecord["goal"]>): string {
+  const compact = (n: number): string => n >= 1000 ? `${Math.round(n / 1000)}k` : String(n);
+  return goal.tokenBudget !== null
+    ? `${compact(goal.tokensUsed)}/${compact(goal.tokenBudget)} tokens`
+    : `${compact(goal.tokensUsed)} tokens`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -199,6 +199,25 @@ describe("EventDispatcher", () => {
     expect(content).toContain("echo flush-test");
   });
 
+  test("flushOutput is incremental — repeated flushes never duplicate earlier output", () => {
+    // Goal-following runs flush once per followed turn; re-writing the whole
+    // accumulation would repeat turn 1's text in every later block.
+    const logPath = join(TEST_LOG_DIR, "test-incremental-flush.log");
+    const dispatcher = new EventDispatcher(logPath, () => {});
+
+    dispatcher.handleDelta("item/agentMessage/delta", { threadId: "t1", turnId: "u1", itemId: "i1", delta: "turn one." });
+    dispatcher.flushOutput();
+    dispatcher.flushOutput(); // nothing new — must be a no-op
+    dispatcher.handleDelta("item/agentMessage/delta", { threadId: "t1", turnId: "u2", itemId: "i2", delta: "turn two." });
+    dispatcher.flushOutput();
+    dispatcher.flush();
+
+    const content = readFileSync(logPath, "utf-8");
+    expect(content.split("turn one.").length - 1).toBe(1); // exactly once
+    expect(content.split("turn two.").length - 1).toBe(1);
+    expect(content.split("<<END_AGENT_OUTPUT>>").length - 1).toBe(2); // one block per flush with new content
+  });
+
   test("collects file changes and commands", () => {
     const dispatcher = new EventDispatcher(join(TEST_LOG_DIR, "test5.log"));
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -216,6 +216,12 @@ export class EventDispatcher {
     }
   }
 
+  /** Public entry for out-of-band progress lines from the turn owner (goal
+   *  following announcements) — same path as internal progress lines. */
+  progressLine(text: string): void {
+    this.progress(text);
+  }
+
   /** Log-only sink for out-of-band lines that already reached the console by
    *  another path (e.g. approval prompts, which must stay visible even under
    *  --content-only). Writes the `[codex]`-tagged entry to the thread log so
@@ -579,6 +585,7 @@ export class EventDispatcher {
 
   reset(): void {
     this.accumulatedOutput = "";
+    this.flushedOutputLength = 0;
     this.finalAnswerOutput = "";
     this.reviewOutput = "";
     this.filesChanged = [];
@@ -592,10 +599,19 @@ export class EventDispatcher {
     for (const id of [...this.resolutionWatchers.keys()]) this.stopResolutionWatcher(id);
   }
 
-  /** Write accumulated agent output to the log (called before final flush). */
+  /** How much of accumulatedOutput has already been written to the log —
+   *  goal-following runs flush once per followed turn, and re-writing the
+   *  whole accumulation each time would duplicate earlier turns' output. */
+  private flushedOutputLength = 0;
+
+  /** Write agent output accrued since the last call to the log, as one
+   *  block per call (matches extractAgentOutputBlocks' one-block-per-turn
+   *  reading). Idempotent when nothing new accrued. */
   flushOutput(): void {
-    if (this.accumulatedOutput) {
-      this.log(`agent output:\n${this.accumulatedOutput}\n<<END_AGENT_OUTPUT>>`);
+    const pending = this.accumulatedOutput.slice(this.flushedOutputLength);
+    if (pending) {
+      this.log(`agent output:\n${pending}\n<<END_AGENT_OUTPUT>>`);
+      this.flushedOutputLength = this.accumulatedOutput.length;
     }
   }
 

--- a/src/goals.test.ts
+++ b/src/goals.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearThreadGoal,
+  getThreadGoal,
+  goalNeedsAttention,
+  isGoalFeatureUnavailable,
+  isTerminalGoalStatus,
+  pauseThreadGoal,
+} from "./goals";
+import type { AppServerClient } from "./client";
+import type { ThreadGoal } from "./types";
+
+function clientWith(onRequest: (method: string, params?: unknown) => unknown): AppServerClient {
+  return {
+    async request<T>(method: string, params?: unknown): Promise<T> {
+      return onRequest(method, params) as T;
+    },
+    notify() {},
+    on: () => () => {},
+    onAny: () => () => {},
+    onRequest: () => () => {},
+    respond() {},
+    onClose: () => () => {},
+    async close() {},
+    userAgent: "mock/1.0",
+    brokerBusy: false,
+  };
+}
+
+const goal: ThreadGoal = {
+  threadId: "thr-1",
+  objective: "ship it",
+  status: "active",
+  tokenBudget: 100_000,
+  tokensUsed: 42_000,
+  timeUsedSeconds: 60,
+  createdAt: 1_700_000_000,
+  updatedAt: 1_700_000_100,
+};
+
+describe("goal status classification", () => {
+  test("only active is non-terminal", () => {
+    expect(isTerminalGoalStatus("active")).toBe(false);
+    for (const s of ["paused", "blocked", "usageLimited", "budgetLimited"] as const) {
+      expect(isTerminalGoalStatus(s)).toBe(true);
+    }
+  });
+
+  test("needs-attention covers blocked and the server brakes, not pause/completion", () => {
+    expect(goalNeedsAttention("blocked")).toBe(true);
+    expect(goalNeedsAttention("usageLimited")).toBe(true);
+    expect(goalNeedsAttention("budgetLimited")).toBe(true);
+    expect(goalNeedsAttention("active")).toBe(false);
+    expect(goalNeedsAttention("paused")).toBe(false);
+    expect(goalNeedsAttention("completed")).toBe(false);
+  });
+});
+
+describe("feature-unavailable classification", () => {
+  test("recognizes the disabled/missing shapes", () => {
+    expect(isGoalFeatureUnavailable(new Error("goals feature is disabled"))).toBe(true);
+    expect(isGoalFeatureUnavailable(new Error("Method not found"))).toBe(true);
+    expect(isGoalFeatureUnavailable(new Error("sqlite state db unavailable for thread goals"))).toBe(true);
+  });
+
+  test("real failures are not misclassified", () => {
+    expect(isGoalFeatureUnavailable(new Error("connection reset"))).toBe(false);
+    expect(isGoalFeatureUnavailable("goals feature is disabled")).toBe(false); // non-Error
+  });
+});
+
+describe("getThreadGoal", () => {
+  test("returns the goal from thread/goal/get", async () => {
+    const client = clientWith((method, params) => {
+      expect(method).toBe("thread/goal/get");
+      expect((params as { threadId: string }).threadId).toBe("thr-1");
+      return { goal };
+    });
+    expect(await getThreadGoal(client, "thr-1")).toEqual(goal);
+  });
+
+  test("returns null for no goal, feature-unavailable, and read failures", async () => {
+    expect(await getThreadGoal(clientWith(() => ({ goal: null })), "thr-1")).toBeNull();
+    expect(await getThreadGoal(clientWith(() => { throw new Error("goals feature is disabled"); }), "thr-1")).toBeNull();
+    // Real failure: warn (not asserted) but still null — reads must not break runs.
+    expect(await getThreadGoal(clientWith(() => { throw new Error("boom"); }), "thr-1")).toBeNull();
+  });
+});
+
+describe("pauseThreadGoal / clearThreadGoal", () => {
+  test("pause sends a status-only thread/goal/set", async () => {
+    let sent: unknown;
+    const client = clientWith((method, params) => {
+      expect(method).toBe("thread/goal/set");
+      sent = params;
+      return { goal: { ...goal, status: "paused" } };
+    });
+    expect(await pauseThreadGoal(client, "thr-1")).toBe(true);
+    expect(sent).toEqual({ threadId: "thr-1", status: "paused" });
+  });
+
+  test("pause reports failure — it is the headless-burn brake", async () => {
+    const client = clientWith(() => { throw new Error("write failed"); });
+    expect(await pauseThreadGoal(client, "thr-1")).toBe(false);
+  });
+
+  test("pause/clear on an unavailable feature succeed vacuously", async () => {
+    const client = clientWith(() => { throw new Error("goals feature is disabled"); });
+    expect(await pauseThreadGoal(client, "thr-1")).toBe(true);
+    expect(await clearThreadGoal(client, "thr-1")).toBe(true);
+  });
+
+  test("clear sends thread/goal/clear", async () => {
+    let cleared = false;
+    const client = clientWith((method) => {
+      expect(method).toBe("thread/goal/clear");
+      cleared = true;
+      return { cleared: true };
+    });
+    expect(await clearThreadGoal(client, "thr-1")).toBe(true);
+    expect(cleared).toBe(true);
+  });
+});

--- a/src/goals.test.ts
+++ b/src/goals.test.ts
@@ -41,7 +41,7 @@ const goal: ThreadGoal = {
 describe("goal status classification", () => {
   test("only active is non-terminal", () => {
     expect(isTerminalGoalStatus("active")).toBe(false);
-    for (const s of ["paused", "blocked", "usageLimited", "budgetLimited"] as const) {
+    for (const s of ["complete", "paused", "blocked", "usageLimited", "budgetLimited"] as const) {
       expect(isTerminalGoalStatus(s)).toBe(true);
     }
   });
@@ -52,7 +52,7 @@ describe("goal status classification", () => {
     expect(goalNeedsAttention("budgetLimited")).toBe(true);
     expect(goalNeedsAttention("active")).toBe(false);
     expect(goalNeedsAttention("paused")).toBe(false);
-    expect(goalNeedsAttention("completed")).toBe(false);
+    expect(goalNeedsAttention("complete")).toBe(false);
   });
 });
 

--- a/src/goals.ts
+++ b/src/goals.ts
@@ -27,8 +27,8 @@ export function isTerminalGoalStatus(status: ThreadGoalStatus): boolean {
  *  (`blocked`, stamped after 3 consecutive no-progress turns) or a server
  *  brake engaged (usage/token-budget). Mapped to their own exit code so
  *  callers can distinguish "goal needs attention" from success/failure.
- *  Accepts the run-record widening ("completed") for caller convenience. */
-export function goalNeedsAttention(status: ThreadGoalStatus | "completed"): boolean {
+ *  Accepts the run-record widening ("cleared") for caller convenience. */
+export function goalNeedsAttention(status: ThreadGoalStatus | "cleared"): boolean {
   return status === "blocked" || status === "usageLimited" || status === "budgetLimited";
 }
 

--- a/src/goals.ts
+++ b/src/goals.ts
@@ -44,22 +44,38 @@ export function isGoalFeatureUnavailable(e: unknown): boolean {
     || msg.includes("sqlite state db unavailable");
 }
 
-/** Read the thread's goal. Returns null when there is no goal, the feature
- *  is unavailable, or the read fails (with a warning for real failures) —
- *  goal awareness must never break a run that would otherwise work. */
+export interface GoalReadResult {
+  goal: ThreadGoal | null;
+  /** False iff the read FAILED (transient RPC error) — distinct from "no
+   *  goal". The follow loop must not take a failed read for a cleared
+   *  (= completed) goal, and the pause brake must not fail open on it. */
+  ok: boolean;
+}
+
+/** Read the thread's goal, reporting read failures distinctly. A missing
+ *  goals feature counts as a successful "no goal" — there is nothing to
+ *  follow or brake. */
+export async function readThreadGoal(
+  client: AppServerClient,
+  threadId: string,
+): Promise<GoalReadResult> {
+  try {
+    const res = await client.request<{ goal: ThreadGoal | null }>("thread/goal/get", { threadId });
+    return { goal: res.goal ?? null, ok: true };
+  } catch (e) {
+    if (isGoalFeatureUnavailable(e)) return { goal: null, ok: true };
+    console.error(`[codex] Warning: could not read thread goal: ${e instanceof Error ? e.message : String(e)}`);
+    return { goal: null, ok: false };
+  }
+}
+
+/** Convenience read for callers where "unknown" and "none" coincide (display,
+ *  best-effort checks). Never breaks a run that would otherwise work. */
 export async function getThreadGoal(
   client: AppServerClient,
   threadId: string,
 ): Promise<ThreadGoal | null> {
-  try {
-    const res = await client.request<{ goal: ThreadGoal | null }>("thread/goal/get", { threadId });
-    return res.goal ?? null;
-  } catch (e) {
-    if (!isGoalFeatureUnavailable(e)) {
-      console.error(`[codex] Warning: could not read thread goal: ${e instanceof Error ? e.message : String(e)}`);
-    }
-    return null;
-  }
+  return (await readThreadGoal(client, threadId)).goal;
 }
 
 /** Pause the thread's goal so the server stops auto-continuing. This is the

--- a/src/goals.ts
+++ b/src/goals.ts
@@ -1,0 +1,96 @@
+// src/goals.ts — Goal protocol helpers (thread/goal/get|set|clear)
+//
+// Codex's Goal mode is SERVER-driven multi-turn: with an active goal, the
+// goal runtime auto-starts a new turn the instant one completes. These
+// helpers are the CLI's levers on that machinery. Two design rules:
+//
+// 1. Reading goal state is an ENHANCEMENT — a failure must never take a
+//    run down with it (the goals feature may be disabled, the state db
+//    unavailable, or the server too old). Read helpers return null.
+// 2. PAUSING is a BRAKE — the timeout and kill paths rely on it to stop
+//    headless token burn, so its failure is loud (returned to the caller,
+//    who decides how loud).
+//
+// Pause-before-interrupt ordering matters everywhere: `turn/interrupt` does
+// not pause a goal, so interrupting first just makes the server start a
+// fresh continuation turn (verified against codex 0.142.3).
+
+import type { AppServerClient } from "./client";
+import type { ThreadGoal, ThreadGoalStatus } from "./types";
+
+/** Statuses the server will NOT continue from. Everything but `active`. */
+export function isTerminalGoalStatus(status: ThreadGoalStatus): boolean {
+  return status !== "active";
+}
+
+/** Goal statuses that mean "Codex needs you": the model stalled out
+ *  (`blocked`, stamped after 3 consecutive no-progress turns) or a server
+ *  brake engaged (usage/token-budget). Mapped to their own exit code so
+ *  callers can distinguish "goal needs attention" from success/failure.
+ *  Accepts the run-record widening ("completed") for caller convenience. */
+export function goalNeedsAttention(status: ThreadGoalStatus | "completed"): boolean {
+  return status === "blocked" || status === "usageLimited" || status === "budgetLimited";
+}
+
+/** True iff the error means the goals feature isn't available at all —
+ *  disabled by config, method unknown to an older server, or the goal state
+ *  db missing. Callers treat these as "no goal", silently. */
+export function isGoalFeatureUnavailable(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const msg = e.message.toLowerCase();
+  return msg.includes("goals feature is disabled")
+    || msg.includes("method not found")
+    || msg.includes("unknown method")
+    || msg.includes("sqlite state db unavailable");
+}
+
+/** Read the thread's goal. Returns null when there is no goal, the feature
+ *  is unavailable, or the read fails (with a warning for real failures) —
+ *  goal awareness must never break a run that would otherwise work. */
+export async function getThreadGoal(
+  client: AppServerClient,
+  threadId: string,
+): Promise<ThreadGoal | null> {
+  try {
+    const res = await client.request<{ goal: ThreadGoal | null }>("thread/goal/get", { threadId });
+    return res.goal ?? null;
+  } catch (e) {
+    if (!isGoalFeatureUnavailable(e)) {
+      console.error(`[codex] Warning: could not read thread goal: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return null;
+  }
+}
+
+/** Pause the thread's goal so the server stops auto-continuing. This is the
+ *  brake the timeout and kill paths depend on — returns false on failure so
+ *  the caller can warn that the goal may keep burning tokens headless.
+ *  Status-only set preserves the objective (verified 0.142.3). */
+export async function pauseThreadGoal(
+  client: AppServerClient,
+  threadId: string,
+): Promise<boolean> {
+  try {
+    await client.request("thread/goal/set", { threadId, status: "paused" });
+    return true;
+  } catch (e) {
+    if (isGoalFeatureUnavailable(e)) return true; // nothing to pause
+    console.error(`[codex] Warning: could not pause thread goal: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+}
+
+/** Clear (abandon) the thread's goal. Used by `kill --clear`. */
+export async function clearThreadGoal(
+  client: AppServerClient,
+  threadId: string,
+): Promise<boolean> {
+  try {
+    await client.request("thread/goal/clear", { threadId });
+    return true;
+  } catch (e) {
+    if (isGoalFeatureUnavailable(e)) return true; // nothing to clear
+    console.error(`[codex] Warning: could not clear thread goal: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+}

--- a/src/prompts/collab.md
+++ b/src/prompts/collab.md
@@ -19,4 +19,6 @@ Channel mechanics and costs:
 - An answer is their judgment, possibly informed by context you lack. Weigh it against what you know; if you disagree, say so — ask a follow-up or record the disagreement — rather than silently complying.
 - If a decision genuinely blocks you, ending your turn with `QUESTION FOR COLLABORATOR:` on its own line pauses the task until the collaborator resumes it.
 
+If you work under a goal (create_goal): your collaborator's session stays attached for the whole goal, and their `--timeout` pauses the goal when it expires. A `token_budget` on the goal is a second, independent brake — one you size to the work. The ask channel works the same mid-goal as mid-turn.
+
 Whether to consult, when, how often, and what to do with the answers is yours to decide.

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -367,7 +367,7 @@ export function loadRun(stateDir: string, runId: string): RunRecord | null {
 type RunPatch = Partial<Pick<RunRecord,
   "status" | "phase" | "sessionId" | "completedAt" | "elapsed" |
   "output" | "filesChanged" | "commandsRun" | "error" | "logOffset" |
-  "pendingApproval" | "pendingQuestion" | "questions"
+  "pendingApproval" | "pendingQuestion" | "questions" | "goal"
 >>;
 
 /**

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1196,6 +1196,71 @@ describe("runTurnWithGoalFollow", () => {
     expect(result.status).toBe("interrupted");
     expect(calls).toContain("thread/goal/set");
     expect(calls.indexOf("thread/goal/set")).toBeLessThan(calls.indexOf("turn/interrupt"));
+    // The follow-phase kill must clean up its own signal file — executeTurn's
+    // finally only covers the first turn.
+    expect(existsSync(join(TEST_KILL_DIR, "thr-1"))).toBe(false);
+  });
+
+  test("a transient goal-read failure mid-follow is not taken for goal completion", async () => {
+    // One failed thread/goal/get must not end the follow with a false
+    // success: the loop keeps acting on the last known (active) state, and
+    // the continuation that starts AFTER the failed read is still followed.
+    let goalGets = 0;
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("turn/completed", completedTurn("turn-1"));
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        goalGets++;
+        if (goalGets === 1) return { goal: null }; // pre-turn read
+        if (goalGets === 2) {
+          setTimeout(() => emit("turn/completed", completedTurn("turn-2")), 30);
+          return { goal: makeGoal("active") };
+        }
+        if (goalGets === 3) {
+          // Transient failure right after turn-2 — pre-fix this read as
+          // "cleared" and the run exited 0 while the goal kept working.
+          setTimeout(() => {
+            emit("turn/started", startedTurn("turn-3"));
+            emit("turn/completed", completedTurn("turn-3"));
+          }, 30);
+          throw new Error("socket hang up");
+        }
+        return { goal: null }; // genuinely cleared after turn-3
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-transient-read"));
+    expect(result.status).toBe("completed");
+    expect(result.continuationTurns).toBe(2); // turn-3 followed DESPITE the failed read
+  }, 10_000);
+
+  test("the pause brake fails CLOSED when the goal read fails at timeout", async () => {
+    // If thread/goal/get errors at brake time, the pause must still be
+    // attempted — skipping it on an unknown state is exactly the headless
+    // burn the brake exists to stop.
+    const calls: string[] = [];
+    const { client } = buildMockClient((method, params) => {
+      calls.push(method);
+      if (method === "turn/start") return inProgressTurn("turn-1"); // never completes
+      if (method === "thread/goal/get") throw new Error("socket hang up");
+      if (method === "thread/goal/set") {
+        expect((params as { status: string }).status).toBe("paused");
+        return { goal: makeGoal("paused") };
+      }
+      if (method === "turn/interrupt") return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    await expect(
+      runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-brake-closed", { timeoutMs: 300 })),
+    ).rejects.toThrow(/timed out/);
+    expect(calls).toContain("thread/goal/set");
   });
 
   test("connection loss mid-goal rejects and is never read as goal completion", async () => {

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1201,6 +1201,43 @@ describe("runTurnWithGoalFollow", () => {
     expect(existsSync(join(TEST_KILL_DIR, "thr-1"))).toBe(false);
   });
 
+  test("a continuation that streams BEFORE follow mode arms loses no output", async () => {
+    // The continuation can start and emit deltas while the wrapper is still
+    // awaiting the post-turn goal read. Those events must be buffered and
+    // replayed, not dropped — the run's output and log must contain every
+    // followed turn in full.
+    let goalGets = 0;
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("item/agentMessage/delta", { threadId: "thr-1", turnId: "turn-1", itemId: "m1", delta: "first." });
+          emit("turn/completed", completedTurn("turn-1"));
+          // Continuation starts, streams, AND completes before the post-turn
+          // goal read below resolves.
+          emit("turn/started", startedTurn("turn-2"));
+          emit("item/agentMessage/delta", { threadId: "thr-1", turnId: "turn-2", itemId: "m2", delta: "second." });
+          emit("turn/completed", completedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        goalGets++;
+        if (goalGets === 1) return { goal: null }; // pre-turn read
+        if (goalGets === 2) {
+          // Slow post-turn read — everything above lands pre-follow.
+          return new Promise((resolve) => setTimeout(() => resolve({ goal: makeGoal("active") }), 60));
+        }
+        return { goal: null }; // cleared after turn-2
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-prefollow-buffer"));
+    expect(result.status).toBe("completed");
+    expect(result.continuationTurns).toBe(1);
+    expect(result.output).toBe("first.second."); // pre-follow delta replayed, not dropped
+  });
+
   test("a transient goal-read failure mid-follow is not taken for goal completion", async () => {
     // One failed thread/goal/get must not end the follow with a false
     // success: the loop keeps acting on the last known (active) state, and

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1364,10 +1364,11 @@ describe("runTurnWithGoalFollow", () => {
     expect(result.continuationTurns).toBe(1);
   });
 
-  test("first-turn timeout with a PRE-EXISTING goal still pauses it", async () => {
+  test("first-turn timeout with a PRE-EXISTING goal pauses BEFORE the cleanup interrupt", async () => {
     // Resumed goal-mode thread whose first turn times out before any goal
-    // notification arrives: the brake must not depend on goalSeen — the
-    // timeout path re-reads the goal authoritatively and pauses it.
+    // notification arrives: the brake must not depend on goalSeen, and it
+    // must land before executeTurn's cleanup turn/interrupt — interrupting
+    // an active goal first spawns one more headless continuation.
     const calls: string[] = [];
     const { client } = buildMockClient((method, params) => {
       calls.push(method);
@@ -1384,7 +1385,39 @@ describe("runTurnWithGoalFollow", () => {
     await expect(
       runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "resume" }], baseOpts("goal-preexisting-timeout", { timeoutMs: 300 })),
     ).rejects.toThrow(/timed out/);
-    expect(calls).toContain("thread/goal/set");
+    const pauseIdx = calls.indexOf("thread/goal/set");
+    const interruptIdx = calls.indexOf("turn/interrupt");
+    expect(pauseIdx).toBeGreaterThan(-1);
+    expect(interruptIdx).toBeGreaterThan(-1);
+    expect(pauseIdx).toBeLessThan(interruptIdx);
+  });
+
+  test("first-turn kill with an active goal pauses BEFORE the cleanup interrupt", async () => {
+    // Same inversion as the timeout path: executeTurn's KillSignalError
+    // branch interrupts the first turn during cleanup — the pause hook must
+    // run before that interrupt.
+    const calls: string[] = [];
+    const { client } = buildMockClient((method, params) => {
+      calls.push(method);
+      if (method === "turn/start") {
+        setTimeout(() => {
+          writeFileSync(join(TEST_KILL_DIR, "thr-1"), "*", { mode: 0o600 });
+        }, 100);
+        return inProgressTurn("turn-1"); // never completes; kill ends it
+      }
+      if (method === "thread/goal/get") return { goal: makeGoal("active") };
+      if (method === "thread/goal/set") return { goal: makeGoal("paused") };
+      if (method === "turn/interrupt") return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-firstturn-kill"));
+    expect(result.status).toBe("interrupted");
+    const pauseIdx = calls.indexOf("thread/goal/set");
+    const interruptIdx = calls.indexOf("turn/interrupt");
+    expect(pauseIdx).toBeGreaterThan(-1);
+    expect(interruptIdx).toBeGreaterThan(-1);
+    expect(pauseIdx).toBeLessThan(interruptIdx);
   });
 });
 

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1077,7 +1077,8 @@ describe("runTurnWithGoalFollow", () => {
       }
       if (method === "thread/goal/get") {
         goalGets++;
-        if (goalGets === 1) {
+        if (goalGets === 1) return { goal: null }; // pre-turn read: goal not created yet
+        if (goalGets === 2) {
           // Goal active after turn 1; continuation streams shortly after.
           setTimeout(() => {
             emit("item/agentMessage/delta", { threadId: "thr-1", turnId: "turn-2", itemId: "m2", delta: "second." });
@@ -1118,7 +1119,8 @@ describe("runTurnWithGoalFollow", () => {
       }
       if (method === "thread/goal/get") {
         goalGets++;
-        if (goalGets === 1) {
+        if (goalGets === 1) return { goal: null }; // pre-turn read
+        if (goalGets === 2) {
           setTimeout(() => emit("turn/completed", completedTurn("turn-2")), 30);
           return { goal: makeGoal("active") };
         }
@@ -1241,7 +1243,8 @@ describe("runTurnWithGoalFollow", () => {
       }
       if (method === "thread/goal/get") {
         goalGets++;
-        if (goalGets === 1) {
+        if (goalGets === 1) return { goal: null }; // pre-turn read
+        if (goalGets === 2) {
           setTimeout(async () => {
             // Approval fired from the CONTINUATION turn.
             const cmdHandler = requestHandlers.get("item/commandExecution/requestApproval");
@@ -1269,7 +1272,7 @@ describe("runTurnWithGoalFollow", () => {
 
   test("goal created before the run (resume) is picked up via goal/get, not notifications", async () => {
     // Resuming a goal-mode thread: no goal/updated fires during our turn —
-    // the authoritative post-turn goal/get must find it anyway.
+    // the authoritative pre/post-turn goal/get must find it anyway.
     let goalGets = 0;
     const { client, emit } = buildMockClient((method) => {
       if (method === "turn/start") {
@@ -1278,7 +1281,8 @@ describe("runTurnWithGoalFollow", () => {
       }
       if (method === "thread/goal/get") {
         goalGets++;
-        if (goalGets === 1) {
+        if (goalGets === 1) return { goal: makeGoal("active") }; // pre-existing, seen pre-turn
+        if (goalGets === 2) {
           setTimeout(() => {
             emit("turn/started", startedTurn("turn-2"));
             emit("turn/completed", completedTurn("turn-2"));
@@ -1293,6 +1297,29 @@ describe("runTurnWithGoalFollow", () => {
     const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "resume" }], baseOpts("goal-preexisting"));
     expect(result.goalSeen).toBe(true);
     expect(result.continuationTurns).toBe(1);
+  });
+
+  test("first-turn timeout with a PRE-EXISTING goal still pauses it", async () => {
+    // Resumed goal-mode thread whose first turn times out before any goal
+    // notification arrives: the brake must not depend on goalSeen — the
+    // timeout path re-reads the goal authoritatively and pauses it.
+    const calls: string[] = [];
+    const { client } = buildMockClient((method, params) => {
+      calls.push(method);
+      if (method === "turn/start") return inProgressTurn("turn-1"); // never completes
+      if (method === "thread/goal/get") return { goal: makeGoal("active") };
+      if (method === "thread/goal/set") {
+        expect((params as { status: string }).status).toBe("paused");
+        return { goal: makeGoal("paused") };
+      }
+      if (method === "turn/interrupt") return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    await expect(
+      runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "resume" }], baseOpts("goal-preexisting-timeout", { timeoutMs: 300 })),
+    ).rejects.toThrow(/timed out/);
+    expect(calls).toContain("thread/goal/set");
   });
 });
 

--- a/src/turns.test.ts
+++ b/src/turns.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { runTurn, runReview, belongsToTurn } from "./turns";
+import { runTurn, runReview, runTurnWithGoalFollow, belongsToTurn } from "./turns";
 import { EventDispatcher } from "./events";
 import { autoApproveHandler } from "./approvals";
 import type { ApprovalHandler } from "./approvals";
 import type { AppServerClient } from "./client";
 import type {
   TurnCompletedParams, TurnStartResponse,
-  ReviewStartResponse,
+  ReviewStartResponse, ThreadGoal,
 } from "./types";
 import { mkdirSync, rmSync, existsSync, writeFileSync, utimesSync } from "fs";
 import { join } from "path";
@@ -992,6 +992,307 @@ describe("approval wiring", () => {
 
     expect(approvalCalls).toContain("cmd:sudo rm -rf");
     expect(approvalCalls).toContain("file:/etc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Goal-following runs
+// ---------------------------------------------------------------------------
+
+function makeGoal(status: ThreadGoal["status"], tokensUsed = 10_000): ThreadGoal {
+  return {
+    threadId: "thr-1",
+    objective: "refactor the module end to end",
+    status,
+    tokenBudget: 100_000,
+    tokensUsed,
+    timeUsedSeconds: 30,
+    createdAt: 1_700_000_000,
+    updatedAt: 1_700_000_030,
+  };
+}
+
+/** turn/started notification for a continuation turn. */
+function startedTurn(turnId: string) {
+  return { threadId: "thr-1", turn: { id: turnId, items: [], status: "inProgress", error: null } };
+}
+
+describe("runTurnWithGoalFollow", () => {
+  const baseOpts = (name: string, extra?: Record<string, unknown>) => ({
+    dispatcher: new EventDispatcher(join(TEST_LOG_DIR, `${name}.log`), () => {}),
+    approvalHandler: autoApproveHandler,
+    timeoutMs: 5000,
+    killSignalsDir: TEST_KILL_DIR,
+    ...extra,
+  });
+
+  test("no goal: behaves like a single turn", async () => {
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => emit("turn/completed", completedTurn("turn-1")), 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") return { goal: null };
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "hi" }], baseOpts("goal-none"));
+    expect(result.status).toBe("completed");
+    expect(result.goalSeen).toBe(false);
+    expect(result.goal).toBeNull();
+    expect(result.continuationTurns).toBe(0);
+  });
+
+  test("goals feature unavailable: behaves like a single turn", async () => {
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => emit("turn/completed", completedTurn("turn-1")), 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") throw new Error("goals feature is disabled");
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "hi" }], baseOpts("goal-disabled"));
+    expect(result.status).toBe("completed");
+    expect(result.goalSeen).toBe(false);
+    expect(result.continuationTurns).toBe(0);
+  });
+
+  test("active goal: follows continuation turns until the goal clears, accumulating output", async () => {
+    // Turn 1 completes with an active goal; the server starts turn-2
+    // IMMEDIATELY (before the goal/get round-trip finishes — the race the
+    // early buffering exists for), streams output, completes; the goal is
+    // then cleared (= completed).
+    let goalGets = 0;
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("item/agentMessage/delta", { threadId: "thr-1", turnId: "turn-1", itemId: "m1", delta: "first." });
+          emit("turn/completed", completedTurn("turn-1"));
+          // Continuation races ahead of the client's goal/get.
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        goalGets++;
+        if (goalGets === 1) {
+          // Goal active after turn 1; continuation streams shortly after.
+          setTimeout(() => {
+            emit("item/agentMessage/delta", { threadId: "thr-1", turnId: "turn-2", itemId: "m2", delta: "second." });
+            emit("turn/completed", completedTurn("turn-2"));
+          }, 30);
+          return { goal: makeGoal("active") };
+        }
+        // After turn-2: goal cleared server-side (completed).
+        setTimeout(() => emit("thread/goal/cleared", { threadId: "thr-1" }), 1);
+        return { goal: null };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const goalUpdates: Array<{ status: string; turns: number }> = [];
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-follow", {
+      onGoalUpdate: (g: ThreadGoal, turns: number) => goalUpdates.push({ status: g.status, turns }),
+    }));
+
+    expect(result.status).toBe("completed");
+    expect(result.goalSeen).toBe(true);
+    expect(result.goal).toBeNull(); // cleared = completed
+    expect(result.continuationTurns).toBe(1);
+    expect(result.output).toBe("first.second.");
+    expect(goalUpdates.length).toBeGreaterThanOrEqual(1);
+    expect(goalUpdates[0].status).toBe("active");
+  });
+
+  test("goal ending blocked is surfaced on the result", async () => {
+    let goalGets = 0;
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("turn/completed", completedTurn("turn-1"));
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        goalGets++;
+        if (goalGets === 1) {
+          setTimeout(() => emit("turn/completed", completedTurn("turn-2")), 30);
+          return { goal: makeGoal("active") };
+        }
+        return { goal: makeGoal("blocked", 55_000) };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-blocked"));
+    expect(result.status).toBe("completed");
+    expect(result.goal?.status).toBe("blocked");
+    expect(result.continuationTurns).toBe(1);
+  });
+
+  test("timeout mid-goal pauses the goal BEFORE interrupting, then throws", async () => {
+    const calls: string[] = [];
+    const { client, emit } = buildMockClient((method, params) => {
+      calls.push(method);
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("turn/completed", completedTurn("turn-1"));
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") return { goal: makeGoal("active") };
+      if (method === "thread/goal/set") {
+        expect((params as { status: string }).status).toBe("paused");
+        return { goal: makeGoal("paused") };
+      }
+      if (method === "turn/interrupt") return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    await expect(
+      runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-timeout", { timeoutMs: 700 })),
+    ).rejects.toThrow(/Goal did not complete.*paused/);
+
+    const pauseIdx = calls.indexOf("thread/goal/set");
+    const interruptIdx = calls.indexOf("turn/interrupt");
+    expect(pauseIdx).toBeGreaterThan(-1);
+    expect(interruptIdx).toBeGreaterThan(-1);
+    // Pause must precede interrupt — interrupt-first respawns a continuation.
+    expect(pauseIdx).toBeLessThan(interruptIdx);
+  });
+
+  test("kill mid-goal pauses the goal, interrupts, and returns interrupted", async () => {
+    const calls: string[] = [];
+    const { client, emit } = buildMockClient((method, params) => {
+      calls.push(method);
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("turn/completed", completedTurn("turn-1"));
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") return { goal: makeGoal("active") };
+      if (method === "thread/goal/set") {
+        expect((params as { status: string }).status).toBe("paused");
+        return { goal: makeGoal("paused") };
+      }
+      if (method === "turn/interrupt") return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    // Kill lands while the follow loop waits on turn-2's completion.
+    setTimeout(() => {
+      writeFileSync(join(TEST_KILL_DIR, "thr-1"), "*", { mode: 0o600 });
+    }, 150);
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-kill"));
+    expect(result.status).toBe("interrupted");
+    expect(calls).toContain("thread/goal/set");
+    expect(calls.indexOf("thread/goal/set")).toBeLessThan(calls.indexOf("turn/interrupt"));
+  });
+
+  test("connection loss mid-goal rejects and is never read as goal completion", async () => {
+    const { client, emit, triggerClose } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("turn/completed", completedTurn("turn-1"));
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        setTimeout(() => triggerClose(), 30);
+        return { goal: makeGoal("active") };
+      }
+      if (method === "turn/interrupt") return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    await expect(
+      runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-connloss")),
+    ).rejects.toThrow("Connection to Codex lost");
+  });
+
+  test("approval requests during continuation turns are still forwarded", async () => {
+    const approvals: string[] = [];
+    const handler: ApprovalHandler = {
+      async handleCommandApproval(req) {
+        approvals.push(req.command ?? "");
+        return "accept";
+      },
+      async handleFileChangeApproval() {
+        return "accept";
+      },
+    };
+
+    let goalGets = 0;
+    const { client, emit, requestHandlers } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => {
+          emit("turn/completed", completedTurn("turn-1"));
+          emit("turn/started", startedTurn("turn-2"));
+        }, 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        goalGets++;
+        if (goalGets === 1) {
+          setTimeout(async () => {
+            // Approval fired from the CONTINUATION turn.
+            const cmdHandler = requestHandlers.get("item/commandExecution/requestApproval");
+            if (cmdHandler) {
+              await cmdHandler({
+                threadId: "thr-1", turnId: "turn-2", itemId: "i1",
+                approvalId: "appr-goal-1", command: "make deploy", cwd: "/",
+              });
+            }
+            emit("turn/completed", completedTurn("turn-2"));
+          }, 30);
+          return { goal: makeGoal("active") };
+        }
+        return { goal: null };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "go" }], baseOpts("goal-approvals", {
+      approvalHandler: handler,
+    }));
+    expect(result.status).toBe("completed");
+    expect(approvals).toEqual(["make deploy"]);
+  });
+
+  test("goal created before the run (resume) is picked up via goal/get, not notifications", async () => {
+    // Resuming a goal-mode thread: no goal/updated fires during our turn —
+    // the authoritative post-turn goal/get must find it anyway.
+    let goalGets = 0;
+    const { client, emit } = buildMockClient((method) => {
+      if (method === "turn/start") {
+        setTimeout(() => emit("turn/completed", completedTurn("turn-1")), 20);
+        return inProgressTurn("turn-1");
+      }
+      if (method === "thread/goal/get") {
+        goalGets++;
+        if (goalGets === 1) {
+          setTimeout(() => {
+            emit("turn/started", startedTurn("turn-2"));
+            emit("turn/completed", completedTurn("turn-2"));
+          }, 30);
+          return { goal: makeGoal("active") };
+        }
+        return { goal: null };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const result = await runTurnWithGoalFollow(client, "thr-1", [{ type: "text", text: "resume" }], baseOpts("goal-preexisting"));
+    expect(result.goalSeen).toBe(true);
+    expect(result.continuationTurns).toBe(1);
   });
 });
 

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -261,12 +261,24 @@ export async function runTurnWithGoalFollow(
     followedTurnIds.add(p.turn.id);
     startedTurnIds.push(p.turn.id);
   }));
+  // A continuation can start AND stream while we are still doing the
+  // post-turn goal read — before `following` arms. Those events are
+  // buffered (not dropped) and replayed the moment follow mode starts.
+  // Only events carrying a followed turn's id land here, and own turns
+  // never enter followedTurnIds, so nothing double-dispatches with
+  // executeTurn's routing during the first turn.
+  const preFollowBuffer: Array<{ method: string; params: unknown }> = [];
   unsubs.push(...DISPATCHED_NOTIFICATION_METHODS.map((method) =>
     client.on(method, (params) => {
-      if (!following) return;
       const routing = params as { threadId?: unknown; turnId?: unknown };
       if (routing?.threadId !== threadId) return;
       if (typeof routing?.turnId === "string" && !followedTurnIds.has(routing.turnId)) return;
+      if (!following) {
+        // No-turnId events stay dropped pre-follow: ownership is ambiguous
+        // with the first turn's own routing.
+        if (typeof routing?.turnId === "string") preFollowBuffer.push({ method, params });
+        return;
+      }
       dispatchNotification(opts.dispatcher, method, params);
     }),
   ));
@@ -401,6 +413,12 @@ export async function runTurnWithGoalFollow(
     const followUnsubs: Array<() => void> = [];
     try {
       following = true;
+      // Replay events a fast continuation streamed before follow mode armed.
+      // Synchronous — no await between arming and replay, so live events
+      // cannot interleave out of order.
+      for (const buffered of preFollowBuffer.splice(0)) {
+        dispatchNotification(opts.dispatcher, buffered.method, buffered.params);
+      }
       followUnsubs.push(...registerApprovalHandlers(client, opts, followAbort.signal));
 
       let connectionLost: ((err: Error) => void) | null = null;

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -85,6 +85,21 @@ export interface TurnOptions {
    *  CLI signal handler target the right thread for `turn/interrupt`. Never
    *  fires for normal turns. */
   onReviewThreadId?: (reviewThreadId: string) => void;
+  /** Called BEFORE the cleanup turn/interrupt on abnormal exits (timeout,
+   *  kill, errors). Goal-following installs its pause brake here: with an
+   *  active goal, interrupting first lets the server spawn one more
+   *  headless continuation in the gap before the wrapper's own pause runs.
+   *  Failures are swallowed — the interrupt must still happen. */
+  onBeforeInterrupt?: () => Promise<void>;
+}
+
+/** Run the pre-interrupt hook, never letting its failure block the interrupt. */
+async function runBeforeInterruptHook(opts: TurnOptions): Promise<void> {
+  try {
+    await opts.onBeforeInterrupt?.();
+  } catch (e) {
+    console.error(`[codex] Warning: pre-interrupt hook failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
 }
 
 export interface ReviewOptions extends TurnOptions {
@@ -233,6 +248,12 @@ export async function runTurnWithGoalFollow(
       if (queued !== -1) startedTurnIds.splice(queued, 1);
       opts.onTurnId?.(id);
     },
+    // executeTurn's abnormal-exit cleanup interrupts the FIRST turn before
+    // our catch handlers run — with an active goal, that interrupt spawns
+    // one more headless continuation in the gap. The hook pauses first,
+    // preserving pause-before-interrupt on the first turn too. (defined
+    // below; only invoked during runTurn's cleanup, long after init)
+    onBeforeInterrupt: () => pauseIfActive("before interrupt"),
   };
   unsubs.push(client.on("turn/started", (params) => {
     const p = params as TurnStartedParams;
@@ -275,20 +296,14 @@ export async function runTurnWithGoalFollow(
     return goal;
   };
 
-  /** The brake for every abnormal exit while a goal is active: pause FIRST
-   *  (so no fresh continuation spawns), then interrupt the live turn. */
-  const pauseAndInterrupt = async (activeTurnId: string | null, context: string): Promise<void> => {
-    // Fresh read: `kill --clear` may have already cleared (or paused) the
-    // goal — pausing a goal that no longer exists is noise, not a brake.
-    // Skip ONLY on a positive answer: a failed read must not skip the pause
-    // (fail closed — this is the lever that stops headless token burn).
+  /** Pause the goal iff it is (or may be) active. Fresh read first:
+   *  `kill --clear` may have already cleared (or paused) the goal, and
+   *  pausing a goal that no longer exists is noise, not a brake. Skip ONLY
+   *  on a positive answer — a failed read must not skip the pause (fail
+   *  closed: this is the lever that stops headless token burn). */
+  const pauseIfActive = async (context: string): Promise<void> => {
     const { goal: current, ok } = await readThreadGoal(client, threadId);
-    if (ok && (current === null || current.status !== "active")) {
-      if (activeTurnId !== null) {
-        await tryInterruptTurn(client, threadId, activeTurnId, context);
-      }
-      return;
-    }
+    if (ok && (current === null || current.status !== "active")) return;
     const paused = await pauseThreadGoal(client, threadId);
     if (!paused) {
       opts.dispatcher.progressLine(
@@ -303,6 +318,12 @@ export async function runTurnWithGoalFollow(
       const stamped = current ?? (lastGoal as ThreadGoal | null);
       if (stamped) notifyGoal({ ...stamped, status: "paused" });
     }
+  };
+
+  /** The brake for every abnormal exit while a goal is active: pause FIRST
+   *  (so no fresh continuation spawns), then interrupt the live turn. */
+  const pauseAndInterrupt = async (activeTurnId: string | null, context: string): Promise<void> => {
+    await pauseIfActive(context);
     if (activeTurnId !== null) {
       await tryInterruptTurn(client, threadId, activeTurnId, context);
     }
@@ -859,6 +880,7 @@ async function executeTurn(
       opts.dispatcher.flushOutput();
       opts.dispatcher.flush();
       if (turnId !== null) {
+        await runBeforeInterruptHook(opts);
         await tryInterruptTurn(client, interruptThreadId, turnId, "on kill");
       }
       return {
@@ -871,6 +893,7 @@ async function executeTurn(
       };
     }
     if (turnId !== null) {
+      await runBeforeInterruptHook(opts);
       await tryInterruptTurn(client, interruptThreadId, turnId);
     }
     throw e;

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -281,6 +281,12 @@ export async function runTurnWithGoalFollow(
       );
     } else {
       opts.dispatcher.progressLine(`Goal paused ${context} — resume by running a new turn on this thread.`);
+      // Stamp the pause locally: the server's goal/updated notification races
+      // our exit, and losing that race would leave the terminal run record
+      // claiming an "active" goal that is in fact paused.
+      if (lastGoal !== null && (lastGoal as ThreadGoal).status === "active") {
+        notifyGoal({ ...(lastGoal as ThreadGoal), status: "paused" });
+      }
     }
     if (activeTurnId !== null) {
       await tryInterruptTurn(client, threadId, activeTurnId, context);
@@ -444,10 +450,13 @@ export async function runTurnWithGoalFollow(
         goal = await readGoal();
       }
 
-      // Goal reached a non-active state (or was cleared = completed).
+      // Goal reached a non-active state. Success is status "complete"
+      // (observed live) — a cleared goal after being seen reads the same.
       const endGoal = lastGoal as ThreadGoal | null;
-      if (endGoal === null) {
-        opts.dispatcher.progressLine(`Goal completed after ${continuationTurns + 1} turns.`);
+      if (endGoal === null || endGoal.status === "complete") {
+        opts.dispatcher.progressLine(
+          `Goal complete after ${continuationTurns + 1} turns${endGoal ? ` (${goalProgress(endGoal)})` : ""}.`,
+        );
       } else {
         opts.dispatcher.progressLine(`Goal ${endGoal.status} after ${continuationTurns + 1} turns (${goalProgress(endGoal)}).`);
       }

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -17,7 +17,7 @@ import {
 import type { EventDispatcher } from "./events";
 import type { ApprovalHandler } from "./approvals";
 import { config } from "./config";
-import { getThreadGoal, pauseThreadGoal } from "./goals";
+import { pauseThreadGoal, readThreadGoal } from "./goals";
 
 const STALE_KILL_SIGNAL_MS = 1000;
 
@@ -143,8 +143,8 @@ export interface GoalRunOptions extends TurnOptions {
 
 export interface GoalRunResult extends TurnResult {
   /** Final goal state: null when no goal ever appeared OR the goal was
-   *  cleared (Codex clears the goal on completion — there is no "completed"
-   *  status on the wire; disambiguate with goalSeen). */
+   *  cleared after being seen (disambiguate with goalSeen). Completion
+   *  normally arrives as status "complete" with the goal still present. */
   goal: ThreadGoal | null;
   /** A goal existed at some point during this run. */
   goalSeen: boolean;
@@ -259,9 +259,14 @@ export async function runTurnWithGoalFollow(
   // take for a cleared (= completed) goal.
   let connectionDown: Error | null = null;
 
-  /** Authoritative goal state; refreshes lastGoal/goalSeen. */
+  /** Authoritative goal state; refreshes lastGoal/goalSeen. A FAILED read
+   *  returns the last known state instead of null — one transient RPC error
+   *  must not read as "goal cleared" (= completed) and end the follow with
+   *  a false success while the server keeps working. The repoll cadence
+   *  retries; the deadline is the backstop if reads never recover. */
   const readGoal = async (): Promise<ThreadGoal | null> => {
-    const goal = await getThreadGoal(client, threadId);
+    const { goal, ok } = await readThreadGoal(client, threadId);
+    if (!ok) return lastGoal;
     if (goal) notifyGoal(goal);
     else if (goalSeen && connectionDown === null) {
       lastGoal = null;
@@ -275,8 +280,10 @@ export async function runTurnWithGoalFollow(
   const pauseAndInterrupt = async (activeTurnId: string | null, context: string): Promise<void> => {
     // Fresh read: `kill --clear` may have already cleared (or paused) the
     // goal — pausing a goal that no longer exists is noise, not a brake.
-    const current = await getThreadGoal(client, threadId);
-    if (current === null || current.status !== "active") {
+    // Skip ONLY on a positive answer: a failed read must not skip the pause
+    // (fail closed — this is the lever that stops headless token burn).
+    const { goal: current, ok } = await readThreadGoal(client, threadId);
+    if (ok && (current === null || current.status !== "active")) {
       if (activeTurnId !== null) {
         await tryInterruptTurn(client, threadId, activeTurnId, context);
       }
@@ -293,7 +300,8 @@ export async function runTurnWithGoalFollow(
       // Stamp the pause locally: the server's goal/updated notification races
       // our exit, and losing that race would leave the terminal run record
       // claiming an "active" goal that is in fact paused.
-      notifyGoal({ ...current, status: "paused" });
+      const stamped = current ?? (lastGoal as ThreadGoal | null);
+      if (stamped) notifyGoal({ ...stamped, status: "paused" });
     }
     if (activeTurnId !== null) {
       await tryInterruptTurn(client, threadId, activeTurnId, context);
@@ -307,6 +315,23 @@ export async function runTurnWithGoalFollow(
     goalSeen,
     continuationTurns,
   });
+
+  /** Follow-phase kill: brake, flush, clean up the signal file (executeTurn's
+   *  finally only covers the first turn), and shape the interrupted result. */
+  const finishKilled = async (activeTurnId: string | null): Promise<GoalRunResult> => {
+    await pauseAndInterrupt(activeTurnId, "on kill");
+    opts.dispatcher.flushOutput();
+    opts.dispatcher.flush();
+    removeOwnKillSignal(opts.killSignalsDir ?? config.killSignalsDir, threadId);
+    return finish({
+      status: "interrupted",
+      output: opts.dispatcher.getTurnOutput(),
+      filesChanged: opts.dispatcher.getFilesChanged(),
+      commandsRun: opts.dispatcher.getCommandsRun(),
+      error: "Thread killed by user",
+      durationMs: 0,
+    });
+  };
 
   try {
     // Read the goal BEFORE the turn: a goal that predates this run (resumed
@@ -404,19 +429,7 @@ export async function runTurnWithGoalFollow(
           }
           await new Promise((r) => setTimeout(r, GOAL_CONTINUATION_POLL_MS));
         }
-        if (killed) {
-          await pauseAndInterrupt(turnId, "on kill");
-          opts.dispatcher.flushOutput();
-          opts.dispatcher.flush();
-          return finish({
-            status: "interrupted",
-            output: opts.dispatcher.getTurnOutput(),
-            filesChanged: opts.dispatcher.getFilesChanged(),
-            commandsRun: opts.dispatcher.getCommandsRun(),
-            error: "Thread killed by user",
-            durationMs: 0,
-          });
-        }
+        if (killed) return await finishKilled(turnId);
         if (turnId === null) { goal = await readGoal(); continue; }
 
         continuationTurns++;
@@ -434,17 +447,7 @@ export async function runTurnWithGoalFollow(
           lastTurnError = completed.turn.error?.message;
         } catch (e) {
           if (e instanceof KillSignalError) {
-            await pauseAndInterrupt(turnId, "on kill");
-            opts.dispatcher.flushOutput();
-            opts.dispatcher.flush();
-            return finish({
-              status: "interrupted",
-              output: opts.dispatcher.getTurnOutput(),
-              filesChanged: opts.dispatcher.getFilesChanged(),
-              commandsRun: opts.dispatcher.getCommandsRun(),
-              error: "Thread killed by user",
-              durationMs: 0,
-            });
+            return await finishKilled(turnId);
           }
           if (e instanceof TurnTimeoutError) {
             await pauseAndInterrupt(turnId, "on timeout");
@@ -509,6 +512,23 @@ class KillSignalError extends Error {
   constructor(public readonly threadId: string) {
     super(`Thread ${threadId} killed by user`);
     this.name = "KillSignalError";
+  }
+}
+
+/** Remove a kill-signal file iff it targets this process (empty, wildcard,
+ *  or our PID) — a different LIVE pid's signal belongs to a concurrent run
+ *  on the thread, and deleting it would make that kill silently never land. */
+function removeOwnKillSignal(signalsDir: string, threadId: string): void {
+  const signalPath = join(signalsDir, threadId);
+  try {
+    const content = readFileSync(signalPath, "utf-8").trim();
+    if (content === "" || content === "*" || content === String(process.pid)) {
+      unlinkSync(signalPath);
+    }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error(`[codex] Warning: could not clean up kill signal: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 }
 

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -273,6 +273,15 @@ export async function runTurnWithGoalFollow(
   /** The brake for every abnormal exit while a goal is active: pause FIRST
    *  (so no fresh continuation spawns), then interrupt the live turn. */
   const pauseAndInterrupt = async (activeTurnId: string | null, context: string): Promise<void> => {
+    // Fresh read: `kill --clear` may have already cleared (or paused) the
+    // goal — pausing a goal that no longer exists is noise, not a brake.
+    const current = await getThreadGoal(client, threadId);
+    if (current === null || current.status !== "active") {
+      if (activeTurnId !== null) {
+        await tryInterruptTurn(client, threadId, activeTurnId, context);
+      }
+      return;
+    }
     const paused = await pauseThreadGoal(client, threadId);
     if (!paused) {
       opts.dispatcher.progressLine(
@@ -284,9 +293,7 @@ export async function runTurnWithGoalFollow(
       // Stamp the pause locally: the server's goal/updated notification races
       // our exit, and losing that race would leave the terminal run record
       // claiming an "active" goal that is in fact paused.
-      if (lastGoal !== null && (lastGoal as ThreadGoal).status === "active") {
-        notifyGoal({ ...(lastGoal as ThreadGoal), status: "paused" });
-      }
+      notifyGoal({ ...current, status: "paused" });
     }
     if (activeTurnId !== null) {
       await tryInterruptTurn(client, threadId, activeTurnId, context);
@@ -302,15 +309,23 @@ export async function runTurnWithGoalFollow(
   });
 
   try {
+    // Read the goal BEFORE the turn: a goal that predates this run (resumed
+    // goal-mode thread) fires no goal/updated during our turn, and every
+    // abnormal-exit brake below keys off knowing it exists. The get also
+    // travels through the broker, which learns the active goal from it and
+    // retains stream ownership across the coming continuation turns.
+    await readGoal();
+
     let first: TurnResult;
     try {
       first = await runTurn(client, threadId, input, wrappedOpts);
     } catch (e) {
       // A first-turn timeout with an active goal must not leave the goal
-      // burning headless after the CLI exits with code 3.
-      if (e instanceof TurnTimeoutError && goalSeen && lastGoal !== null) {
-        const g = lastGoal as ThreadGoal;
-        if (g.status === "active") await pauseAndInterrupt(null, "on timeout");
+      // burning headless after the CLI exits with code 3. pauseAndInterrupt
+      // does its own authoritative read — cached flags would miss a goal
+      // that appeared mid-turn without any notification reaching us.
+      if (e instanceof TurnTimeoutError) {
+        await pauseAndInterrupt(null, "on timeout");
       }
       throw e;
     }
@@ -319,9 +334,7 @@ export async function runTurnWithGoalFollow(
       // Killed during turn 1. The goal-aware `kill` pauses the goal itself,
       // but older kills, SIGINT paths, and server-side interrupts don't —
       // never exit "interrupted" while the server keeps continuing.
-      if (goalSeen && (await readGoal())?.status === "active") {
-        await pauseAndInterrupt(null, "on kill");
-      }
+      await pauseAndInterrupt(null, "on kill");
       return finish(first);
     }
 

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -7,6 +7,7 @@ import {
   isKnownItem,
   TurnTimeoutError,
   type UserInput, type TurnStartParams, type TurnStartResponse, type TurnCompletedParams,
+  type TurnStartedParams, type ThreadGoal, type ThreadGoalUpdatedParams, type ThreadGoalClearedParams,
   type ReviewTarget, type ReviewStartParams, type ReviewDelivery,
   type TurnResult, type ItemStartedParams, type ItemCompletedParams, type DeltaParams,
   type ErrorNotificationParams, type AutoApprovalReviewParams,
@@ -16,6 +17,7 @@ import {
 import type { EventDispatcher } from "./events";
 import type { ApprovalHandler } from "./approvals";
 import { config } from "./config";
+import { getThreadGoal, pauseThreadGoal } from "./goals";
 
 const STALE_KILL_SIGNAL_MS = 1000;
 
@@ -132,11 +134,399 @@ export async function runReview(
   return executeTurn(client, "review/start", params, opts);
 }
 
+export interface GoalRunOptions extends TurnOptions {
+  /** Fired on every goal mutation seen during the run (create_goal /
+   *  update_goal / server budget stamps) and once per followed continuation
+   *  turn — callers mirror this onto the run record for observers. */
+  onGoalUpdate?: (goal: ThreadGoal, continuationTurns: number) => void;
+}
+
+export interface GoalRunResult extends TurnResult {
+  /** Final goal state: null when no goal ever appeared OR the goal was
+   *  cleared (Codex clears the goal on completion — there is no "completed"
+   *  status on the wire; disambiguate with goalSeen). */
+  goal: ThreadGoal | null;
+  /** A goal existed at some point during this run. */
+  goalSeen: boolean;
+  /** Server-driven continuation turns this run followed (0 = single turn). */
+  continuationTurns: number;
+}
+
+/** How long past turn/completed we keep waiting for the server to start the
+ *  continuation turn before re-polling goal state. Continuations start
+ *  within milliseconds (verified 0.142.3); the re-poll loop is the backstop
+ *  for pause/clear landing from elsewhere while we wait. */
+const GOAL_CONTINUATION_POLL_MS = 500;
+/** Re-read thread/goal/get at this cadence while waiting for a continuation
+ *  turn, in case a goal/updated notification was lost. */
+const GOAL_REPOLL_INTERVAL_MS = 5_000;
+
+/**
+ * Run a turn, then — if the thread has an active goal — keep following the
+ * server's continuation turns in the same dispatcher/log until the goal is
+ * terminal. This makes a `run` correspond to the unit of work: Codex's goal
+ * runtime auto-starts a new turn the instant one completes while the goal
+ * is active, so returning after the first turn would leave the goal working
+ * headless and unobserved (issue #19).
+ *
+ * `opts.timeoutMs` is GOAL-SCOPED here: one deadline for the whole span. On
+ * expiry the goal is paused BEFORE the active turn is interrupted (interrupt
+ * alone just makes the server start a fresh continuation), then a
+ * TurnTimeoutError propagates as usual. A kill signal mid-goal takes the
+ * same pause-then-interrupt path and returns status "interrupted".
+ */
+export async function runTurnWithGoalFollow(
+  client: AppServerClient,
+  threadId: string,
+  input: UserInput[],
+  opts: GoalRunOptions,
+): Promise<GoalRunResult> {
+  const deadlineMs = Date.now() + opts.timeoutMs;
+  const startTime = Date.now();
+
+  // Goal tracking spans the whole run: a goal created mid-turn-1 (create_goal
+  // tool call) is seen live, and its updates mirror onto the run record.
+  let lastGoal: ThreadGoal | null = null;
+  let goalSeen = false;
+  let goalCleared = false;
+  let continuationTurns = 0;
+  const unsubs: Array<() => void> = [];
+  const notifyGoal = (goal: ThreadGoal): void => {
+    lastGoal = goal;
+    goalSeen = true;
+    goalCleared = false;
+    try {
+      opts.onGoalUpdate?.(goal, continuationTurns);
+    } catch (e) {
+      console.error(`[codex] Warning: goal-update observer failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+  unsubs.push(client.on("thread/goal/updated", (params) => {
+    const p = params as ThreadGoalUpdatedParams;
+    if (p?.threadId !== threadId || !p.goal) return;
+    notifyGoal(p.goal);
+  }));
+  unsubs.push(client.on("thread/goal/cleared", (params) => {
+    if ((params as ThreadGoalClearedParams)?.threadId !== threadId) return;
+    lastGoal = null;
+    goalCleared = true;
+  }));
+
+  // Continuation turns are buffered from the START of the run: the server
+  // begins a continuation within milliseconds of turn/completed, easily
+  // beating the goal/get round-trip that decides whether to follow. Our own
+  // turn is filtered out via onTurnId. Item ROUTING is gated on the follow
+  // phase — during the first turn executeTurn owns routing, and dispatching
+  // here too would duplicate output and progress lines.
+  const ownTurnIds = new Set<string>();
+  const followedTurnIds = new Set<string>();
+  const startedTurnIds: string[] = [];
+  let following = false;
+  const wrappedOpts: GoalRunOptions = {
+    ...opts,
+    onTurnId: (id) => {
+      // turn/started for our own turn can beat the turn/start response —
+      // un-queue it, or the follow loop would try to follow our own turn.
+      ownTurnIds.add(id);
+      followedTurnIds.delete(id);
+      const queued = startedTurnIds.indexOf(id);
+      if (queued !== -1) startedTurnIds.splice(queued, 1);
+      opts.onTurnId?.(id);
+    },
+  };
+  unsubs.push(client.on("turn/started", (params) => {
+    const p = params as TurnStartedParams;
+    if (p?.threadId !== threadId || !p.turn?.id || ownTurnIds.has(p.turn.id)) return;
+    followedTurnIds.add(p.turn.id);
+    startedTurnIds.push(p.turn.id);
+  }));
+  unsubs.push(...DISPATCHED_NOTIFICATION_METHODS.map((method) =>
+    client.on(method, (params) => {
+      if (!following) return;
+      const routing = params as { threadId?: unknown; turnId?: unknown };
+      if (routing?.threadId !== threadId) return;
+      if (typeof routing?.turnId === "string" && !followedTurnIds.has(routing.turnId)) return;
+      dispatchNotification(opts.dispatcher, method, params);
+    }),
+  ));
+  // Buffers turn/completed from the start too — a fast continuation can
+  // complete before the follow loop reaches waitFor.
+  const completion = createTurnCompletionAwaiter(client, opts.timeoutMs);
+  unsubs.push(completion.unsubscribe);
+
+  // Connection loss must never read as "goal completed": a dead connection
+  // makes getThreadGoal return null, which the follow loop would otherwise
+  // take for a cleared (= completed) goal.
+  let connectionDown: Error | null = null;
+
+  /** Authoritative goal state; refreshes lastGoal/goalSeen. */
+  const readGoal = async (): Promise<ThreadGoal | null> => {
+    const goal = await getThreadGoal(client, threadId);
+    if (goal) notifyGoal(goal);
+    else if (goalSeen && connectionDown === null) {
+      lastGoal = null;
+      goalCleared = true;
+    }
+    return goal;
+  };
+
+  /** The brake for every abnormal exit while a goal is active: pause FIRST
+   *  (so no fresh continuation spawns), then interrupt the live turn. */
+  const pauseAndInterrupt = async (activeTurnId: string | null, context: string): Promise<void> => {
+    const paused = await pauseThreadGoal(client, threadId);
+    if (!paused) {
+      opts.dispatcher.progressLine(
+        `WARNING: could not pause the goal ${context} — it may keep running headless. ` +
+        `Stop it with: codex-collab kill <id> (or --clear to abandon it).`,
+      );
+    } else {
+      opts.dispatcher.progressLine(`Goal paused ${context} — resume by running a new turn on this thread.`);
+    }
+    if (activeTurnId !== null) {
+      await tryInterruptTurn(client, threadId, activeTurnId, context);
+    }
+  };
+
+  const finish = (result: TurnResult): GoalRunResult => ({
+    ...result,
+    durationMs: Date.now() - startTime,
+    goal: lastGoal,
+    goalSeen,
+    continuationTurns,
+  });
+
+  try {
+    let first: TurnResult;
+    try {
+      first = await runTurn(client, threadId, input, wrappedOpts);
+    } catch (e) {
+      // A first-turn timeout with an active goal must not leave the goal
+      // burning headless after the CLI exits with code 3.
+      if (e instanceof TurnTimeoutError && goalSeen && lastGoal !== null) {
+        const g = lastGoal as ThreadGoal;
+        if (g.status === "active") await pauseAndInterrupt(null, "on timeout");
+      }
+      throw e;
+    }
+
+    if (first.status === "interrupted") {
+      // Killed during turn 1. The goal-aware `kill` pauses the goal itself,
+      // but older kills, SIGINT paths, and server-side interrupts don't —
+      // never exit "interrupted" while the server keeps continuing.
+      if (goalSeen && (await readGoal())?.status === "active") {
+        await pauseAndInterrupt(null, "on kill");
+      }
+      return finish(first);
+    }
+
+    // Goal check is authoritative (not just notifications): a goal created
+    // before this run — e.g. resuming a goal-mode thread — never fires
+    // goal/updated during our turn.
+    let goal = await readGoal();
+    if (!goal || goal.status !== "active") return finish(first);
+
+    opts.dispatcher.progressLine(
+      `Goal active — following continuation turns (${goalProgress(goal)}). Objective: ${clipLine(goal.objective)}`,
+    );
+
+    // --- Follow phase ---------------------------------------------------
+    // The server owns turn creation now; we attach to each continuation
+    // turn as it starts and stream it into the same dispatcher/log.
+    const followAbort = new AbortController();
+    const followUnsubs: Array<() => void> = [];
+    try {
+      following = true;
+      followUnsubs.push(...registerApprovalHandlers(client, opts, followAbort.signal));
+
+      let connectionLost: ((err: Error) => void) | null = null;
+      const connectionLossPromise = new Promise<never>((_resolve, reject) => {
+        connectionLost = reject;
+      });
+      connectionLossPromise.catch(() => {});
+      followUnsubs.push(client.onClose(() => {
+        connectionDown = new Error("Connection to Codex lost mid-goal (app-server or broker exited)");
+        connectionLost?.(connectionDown);
+      }));
+
+      const killSignal = createKillSignalAwaiter(
+        threadId, opts.killSignalsDir ?? config.killSignalsDir, 500, followAbort.signal,
+      );
+      let killed = false;
+      killSignal.catch((e) => {
+        if (e instanceof KillSignalError) killed = true;
+        else console.error(`[codex] Unexpected error in kill signal awaiter: ${e instanceof Error ? e.message : String(e)}`);
+      });
+
+      let lastTurnStatus: TurnResult["status"] = first.status;
+      let lastTurnError: string | undefined = first.error;
+      for (;;) {
+        if (connectionDown !== null) throw connectionDown;
+        if (goal === null || goal.status !== "active") break;
+
+        // Wait for the continuation turn to start; re-check the world as we
+        // wait (kill, deadline, goal changed under us, lost notifications).
+        let turnId: string | null = null;
+        let lastRepoll = Date.now();
+        while (turnId === null) {
+          const next = startedTurnIds.shift();
+          if (next !== undefined) { turnId = next; break; }
+          if (killed) break;
+          if (connectionDown !== null) throw connectionDown;
+          if (Date.now() >= deadlineMs) {
+            await pauseAndInterrupt(null, "on timeout");
+            throw new TurnTimeoutError(
+              `Goal did not complete within ${Math.round(opts.timeoutMs / 1000)}s — goal paused (resume with a new turn, or kill --clear to abandon)`,
+            );
+          }
+          if (goalCleared || (lastGoal !== null && (lastGoal as ThreadGoal).status !== "active")) break;
+          if (Date.now() - lastRepoll >= GOAL_REPOLL_INTERVAL_MS) {
+            lastRepoll = Date.now();
+            await readGoal();
+          }
+          await new Promise((r) => setTimeout(r, GOAL_CONTINUATION_POLL_MS));
+        }
+        if (killed) {
+          await pauseAndInterrupt(turnId, "on kill");
+          opts.dispatcher.flushOutput();
+          opts.dispatcher.flush();
+          return finish({
+            status: "interrupted",
+            output: opts.dispatcher.getTurnOutput(),
+            filesChanged: opts.dispatcher.getFilesChanged(),
+            commandsRun: opts.dispatcher.getCommandsRun(),
+            error: "Thread killed by user",
+            durationMs: 0,
+          });
+        }
+        if (turnId === null) { goal = await readGoal(); continue; }
+
+        continuationTurns++;
+        opts.onTurnId?.(turnId);
+        if (lastGoal) notifyGoal(lastGoal as ThreadGoal); // refresh continuationTurns on the record
+        opts.dispatcher.progressLine(`Goal continuation turn ${continuationTurns} started${lastGoal ? ` (${goalProgress(lastGoal as ThreadGoal)})` : ""}`);
+
+        try {
+          const completed = await Promise.race([
+            completion.waitFor(turnId, Math.max(1, deadlineMs - Date.now())),
+            killSignal,
+            connectionLossPromise,
+          ]);
+          lastTurnStatus = completed.turn.status as TurnResult["status"];
+          lastTurnError = completed.turn.error?.message;
+        } catch (e) {
+          if (e instanceof KillSignalError) {
+            await pauseAndInterrupt(turnId, "on kill");
+            opts.dispatcher.flushOutput();
+            opts.dispatcher.flush();
+            return finish({
+              status: "interrupted",
+              output: opts.dispatcher.getTurnOutput(),
+              filesChanged: opts.dispatcher.getFilesChanged(),
+              commandsRun: opts.dispatcher.getCommandsRun(),
+              error: "Thread killed by user",
+              durationMs: 0,
+            });
+          }
+          if (e instanceof TurnTimeoutError) {
+            await pauseAndInterrupt(turnId, "on timeout");
+            throw new TurnTimeoutError(
+              `Goal did not complete within ${Math.round(opts.timeoutMs / 1000)}s — goal paused (resume with a new turn, or kill --clear to abandon)`,
+            );
+          }
+          // Connection loss and everything else: the goal may genuinely keep
+          // running server-side (that can be desirable — broker path), but we
+          // can no longer observe or brake it. Surface loudly and rethrow.
+          throw e;
+        }
+
+        opts.dispatcher.flushOutput();
+        opts.dispatcher.flush();
+        goal = await readGoal();
+      }
+
+      // Goal reached a non-active state (or was cleared = completed).
+      const endGoal = lastGoal as ThreadGoal | null;
+      if (endGoal === null) {
+        opts.dispatcher.progressLine(`Goal completed after ${continuationTurns + 1} turns.`);
+      } else {
+        opts.dispatcher.progressLine(`Goal ${endGoal.status} after ${continuationTurns + 1} turns (${goalProgress(endGoal)}).`);
+      }
+      return finish({
+        status: lastTurnStatus,
+        output: opts.dispatcher.getTurnOutput(),
+        filesChanged: opts.dispatcher.getFilesChanged(),
+        commandsRun: opts.dispatcher.getCommandsRun(),
+        error: lastTurnError,
+        durationMs: 0,
+      });
+    } finally {
+      followAbort.abort();
+      for (const unsub of followUnsubs) unsub();
+    }
+  } finally {
+    for (const unsub of unsubs) unsub();
+  }
+}
+
+/** "12,345 tokens used" / "12,345 / 100,000 tokens" for progress lines. */
+function goalProgress(goal: ThreadGoal): string {
+  const used = goal.tokensUsed.toLocaleString("en-US");
+  return goal.tokenBudget !== null
+    ? `${used} / ${goal.tokenBudget.toLocaleString("en-US")} tokens`
+    : `${used} tokens used`;
+}
+
+/** First ~80 chars of a goal objective for a progress line. */
+function clipLine(text: string): string {
+  const firstLine = text.split("\n", 1)[0].trim();
+  return firstLine.length > 80 ? firstLine.slice(0, 79) + "…" : firstLine;
+}
+
 /** Error thrown when a kill signal file is detected during turn execution. */
 class KillSignalError extends Error {
   constructor(public readonly threadId: string) {
     super(`Thread ${threadId} killed by user`);
     this.name = "KillSignalError";
+  }
+}
+
+/** Notification methods routed into the EventDispatcher — shared by the
+ *  single-turn path (executeTurn) and the goal-following path. */
+const DISPATCHED_NOTIFICATION_METHODS = [
+  "item/started",
+  "item/completed",
+  "item/agentMessage/delta",
+  "item/commandExecution/outputDelta",
+  "item/autoApprovalReview/started",
+  "item/autoApprovalReview/completed",
+  "guardianWarning",
+  "error",
+] as const;
+
+/** Route one already-filtered notification into the dispatcher. Callers own
+ *  the turn/thread filtering — this is just the method→handler fan-out. */
+function dispatchNotification(dispatcher: EventDispatcher, method: string, params: unknown): void {
+  switch (method) {
+    case "item/started":
+      dispatcher.handleItemStarted(params as ItemStartedParams);
+      break;
+    case "item/completed":
+      dispatcher.handleItemCompleted(params as ItemCompletedParams);
+      break;
+    case "item/agentMessage/delta":
+    case "item/commandExecution/outputDelta":
+      dispatcher.handleDelta(method, params as DeltaParams);
+      break;
+    case "item/autoApprovalReview/started":
+    case "item/autoApprovalReview/completed":
+      dispatcher.handleAutoApprovalReview(method, params as AutoApprovalReviewParams);
+      break;
+    case "guardianWarning":
+      dispatcher.handleGuardianWarning(params as { message?: unknown });
+      break;
+    case "error":
+      dispatcher.handleError(params as ErrorNotificationParams);
+      break;
   }
 }
 
@@ -248,54 +638,23 @@ async function executeTurn(
         return;
       }
     }
-    switch (method) {
-      case "item/started": {
-        const p = params as ItemStartedParams;
-        opts.dispatcher.handleItemStarted(p);
-        // Completion inference: if new non-reasoning work starts after a
-        // final_answer, cancel the inference timer to avoid premature
-        // completion synthesis. Reasoning items are excluded: the model can
-        // begin a reasoning trace concurrent with or after the final answer
-        // without that implying further work.
-        if (inferenceResolver) {
-          const item = p.item as { type?: string } | undefined;
-          if (item?.type !== "reasoning") clearInferenceTimer();
-        }
-        break;
+    dispatchNotification(opts.dispatcher, method, params);
+    if (method === "item/started") {
+      // Completion inference: if new non-reasoning work starts after a
+      // final_answer, cancel the inference timer to avoid premature
+      // completion synthesis. Reasoning items are excluded: the model can
+      // begin a reasoning trace concurrent with or after the final answer
+      // without that implying further work.
+      if (inferenceResolver) {
+        const item = (params as ItemStartedParams).item as { type?: string } | undefined;
+        if (item?.type !== "reasoning") clearInferenceTimer();
       }
-      case "item/completed": {
-        const p = params as ItemCompletedParams;
-        opts.dispatcher.handleItemCompleted(p);
-        processItemCompleted(p);
-        break;
-      }
-      case "item/agentMessage/delta":
-      case "item/commandExecution/outputDelta":
-        opts.dispatcher.handleDelta(method, params as DeltaParams);
-        break;
-      case "item/autoApprovalReview/started":
-      case "item/autoApprovalReview/completed":
-        opts.dispatcher.handleAutoApprovalReview(method, params as AutoApprovalReviewParams);
-        break;
-      case "guardianWarning":
-        opts.dispatcher.handleGuardianWarning(params as { message?: unknown });
-        break;
-      case "error":
-        opts.dispatcher.handleError(params as ErrorNotificationParams);
-        break;
+    } else if (method === "item/completed") {
+      processItemCompleted(params as ItemCompletedParams);
     }
   }
 
-  for (const method of [
-    "item/started",
-    "item/completed",
-    "item/agentMessage/delta",
-    "item/commandExecution/outputDelta",
-    "item/autoApprovalReview/started",
-    "item/autoApprovalReview/completed",
-    "guardianWarning",
-    "error",
-  ]) {
+  for (const method of DISPATCHED_NOTIFICATION_METHODS) {
     unsubs.push(
       client.on(method, (params) => {
         if (turnId === null) {
@@ -641,7 +1000,7 @@ function createTurnCompletionAwaiter(
   client: AppServerClient,
   timeoutMs: number,
 ): {
-  waitFor: (turnId: string) => Promise<TurnCompletedParams>;
+  waitFor: (turnId: string, timeoutOverrideMs?: number) => Promise<TurnCompletedParams>;
   unsubscribe: () => void;
 } {
   const buffer: TurnCompletedParams[] = [];
@@ -661,17 +1020,20 @@ function createTurnCompletionAwaiter(
   });
 
   return {
-    waitFor(turnId: string): Promise<TurnCompletedParams> {
+    // timeoutOverrideMs: per-call budget (goal following hands each
+    // continuation turn whatever remains of the goal-scoped deadline).
+    waitFor(turnId: string, timeoutOverrideMs?: number): Promise<TurnCompletedParams> {
       const found = buffer.find((p) => p.turn.id === turnId);
       if (found) return Promise.resolve(found);
+      const effectiveTimeoutMs = timeoutOverrideMs ?? timeoutMs;
 
       return new Promise((resolve, reject) => {
         timer = setTimeout(() => {
           resolver = null;
           targetId = null;
           unsub();
-          reject(new TurnTimeoutError(`Turn timed out after ${Math.round(timeoutMs / 1000)}s`));
-        }, timeoutMs);
+          reject(new TurnTimeoutError(`Turn timed out after ${Math.round(effectiveTimeoutMs / 1000)}s`));
+        }, effectiveTimeoutMs);
         // Set resolver before targetId so the notification handler never
         // sees targetId set without a resolver to call.
         resolver = (p) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,6 +332,48 @@ export interface TurnCompletedParams {
   turn: Turn;
 }
 
+export interface TurnStartedParams {
+  threadId: string;
+  turn: Turn;
+}
+
+// --- Goals (server-driven multi-turn; `goals = true` in Codex config) ---
+
+/** Goal lifecycle. `active` is the only state the server continues from —
+ *  the goal runtime auto-starts a new turn the moment one completes while
+ *  the goal is active. Everything else is terminal for a run's purposes:
+ *  `paused` is deliberate (our timeout/kill path sets it), `blocked` means
+ *  Codex stalled 3 consecutive turns and needs a human, the *Limited pair
+ *  are the server's own brakes. */
+export type ThreadGoalStatus =
+  | "active" | "paused" | "blocked" | "usageLimited" | "budgetLimited";
+
+/** Wire shape verified against codex 0.142.3 (thread/goal/get|set responses
+ *  and thread/goal/updated notifications). Timestamps are unix SECONDS. */
+export interface ThreadGoal {
+  threadId: string;
+  objective: string;
+  status: ThreadGoalStatus;
+  tokenBudget: number | null;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** thread/goal/updated — fired on every goal mutation (create_goal /
+ *  update_goal tool calls, thread/goal/set, server-side budget stamps).
+ *  turnId is null for out-of-turn mutations (e.g. our own goal/set). */
+export interface ThreadGoalUpdatedParams {
+  threadId: string;
+  turnId: string | null;
+  goal: ThreadGoal;
+}
+
+export interface ThreadGoalClearedParams {
+  threadId: string;
+}
+
 export interface ErrorNotificationParams {
   error: {
     message: string;
@@ -573,6 +615,24 @@ export interface RunRecord {
   pendingQuestion?: PendingQuestion | null;
   /** Resolved ask-channel questions, in resolution order. */
   questions?: ResolvedQuestion[];
+  /** Goal-mode progress mirrored from thread/goal/updated. Present iff a
+   *  goal was seen during this run; survives completion so post-mortems can
+   *  say how the goal ended and what it cost. */
+  goal?: RunGoalState | null;
+}
+
+/** Observer-facing goal snapshot on the run record. `turns` counts the turns
+ *  THIS run followed (first turn + continuations), not the thread's total.
+ *  `status` extends the wire enum with "completed": the server CLEARS a goal
+ *  on completion rather than stamping a status, so the record keeps the last
+ *  known snapshot re-labeled. */
+export interface RunGoalState {
+  objective: string;
+  status: ThreadGoalStatus | "completed";
+  tokenBudget: number | null;
+  tokensUsed: number;
+  turns: number;
+  updatedAt: string;
 }
 
 // --- Broker state (per-workspace) ---

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,11 +342,12 @@ export interface TurnStartedParams {
 /** Goal lifecycle. `active` is the only state the server continues from —
  *  the goal runtime auto-starts a new turn the moment one completes while
  *  the goal is active. Everything else is terminal for a run's purposes:
- *  `paused` is deliberate (our timeout/kill path sets it), `blocked` means
- *  Codex stalled 3 consecutive turns and needs a human, the *Limited pair
- *  are the server's own brakes. */
+ *  `complete` is success (observed live: update_goal stamps it, the goal is
+ *  NOT cleared), `paused` is deliberate (our timeout/kill path sets it),
+ *  `blocked` means Codex stalled 3 consecutive turns and needs a human,
+ *  the *Limited pair are the server's own brakes. */
 export type ThreadGoalStatus =
-  | "active" | "paused" | "blocked" | "usageLimited" | "budgetLimited";
+  | "active" | "complete" | "paused" | "blocked" | "usageLimited" | "budgetLimited";
 
 /** Wire shape verified against codex 0.142.3 (thread/goal/get|set responses
  *  and thread/goal/updated notifications). Timestamps are unix SECONDS. */
@@ -623,12 +624,13 @@ export interface RunRecord {
 
 /** Observer-facing goal snapshot on the run record. `turns` counts the turns
  *  THIS run followed (first turn + continuations), not the thread's total.
- *  `status` extends the wire enum with "completed": the server CLEARS a goal
- *  on completion rather than stamping a status, so the record keeps the last
- *  known snapshot re-labeled. */
+ *  A goal that disappeared (cleared) after being seen DURING the run is
+ *  recorded with the wire's success status, "complete"; "cleared" is the
+ *  post-hoc state `kill --clear` stamps so `threads` stops advertising a
+ *  paused goal that no longer exists. */
 export interface RunGoalState {
   objective: string;
-  status: ThreadGoalStatus | "completed";
+  status: ThreadGoalStatus | "cleared";
   tokenBudget: number | null;
   tokensUsed: number;
   turns: number;


### PR DESCRIPTION
Closes #19.

Codex's Goal mode is server-driven multi-turn: with an active goal, the server auto-starts a continuation turn the instant one completes. Previously `run` returned after the first turn, leaving the goal working headless and unobserved. Now the run corresponds to the unit of work.

## What changed

- **Goal-following by default** — after the first turn, if the thread's goal is active, the run attaches to each server-started continuation turn and streams it into the same run record and log until the goal is terminal. `follow`/`output`/`threads` see everything.
- **Goal-scoped `--timeout`** — one deadline for the whole goal; expiry pauses the goal (resumable, no headless token burn) **before** interrupting, then exits 3. Interrupt-first would just respawn a continuation.
- **Goal-aware `kill`** — pause-then-interrupt; `kill --clear` abandons the goal (works on settled threads whose goal outlived their runs, and reconciles the ledger). Ctrl-C takes the same brake.
- **Exit code 7** — goal ended `blocked` / `usageLimited` / `budgetLimited`: Codex needs steering.
- **Observability** — run ledger mirrors goal progress (objective, status, tokens, turns); `threads` shows `[goal active: 45k/100k tokens]` per thread.
- **Broker** — stream ownership now spans continuation turns while the goal is active (previously every continuation notification was dropped at the first `turn/completed`), with release when the goal ends — including a goal paused in the between-turns gap, which otherwise wedged the broker until the orphan watchdog.
- **Template** — `collab` mentions `token_budget` as a second, independent brake (non-prescriptive).

## Verification

Wire shapes probed against codex 0.142.3 (`thread/goal/get|set|clear`, `thread/goal/updated|cleared`, the `complete` status). E2E through the CLI: a 3-turn goal followed live through the broker to completion (exit 0, all turns in the log and ledger); kill mid-goal paused-then-interrupted with zero headless continuation afterward (exit 4, `[goal paused]` in threads); `kill --clear` immediately after (broker not stuck) cleared the goal and the ledger mirror. 686 unit tests.