### PR TITLE
fix(reasoning): accept max/ultra, cap auto-select at xhigh, make review -r actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ codex-collab follow --watch
 |------|-------------|
 | `-d, --dir <path>` | Working directory |
 | `-m, --model <model>` | Model name (default: auto — latest available) |
-| `-r, --reasoning <level>` | none, minimal, low, medium, high, xhigh (default: auto — highest for model) |
+| `-r, --reasoning <level>` | none, minimal, low, medium, high, xhigh, max, ultra (default: auto — highest the model supports, up to `xhigh`) |
 | `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
 | `--mode <mode>` | Review mode: pr, uncommitted, commit, custom |
 | `--ref <hash>` | Commit ref for `--mode commit` |
@@ -177,7 +177,9 @@ codex-collab follow --watch
 
 ## Defaults & Configuration
 
-By default, codex-collab auto-selects the **latest model** (preferring `-codex` variants) and the **highest reasoning effort** supported by that model. No configuration needed — it stays current as new models are released.
+By default, codex-collab auto-selects the **latest model** (the server's default, followed up its upgrade chain, preferring a `-codex` variant where one exists) and the **highest reasoning effort that model supports, up to `xhigh`**. No configuration needed — it stays current as new models are released.
+
+The `max` and `ultra` tiers are opt-in rather than auto-selected: reach for them with `-r max` / `-r ultra` on a single run, or make one the standing default with `codex-collab config reasoning`.
 
 To override defaults persistently, use `codex-collab config`:
 
@@ -186,7 +188,7 @@ To override defaults persistently, use `codex-collab config`:
 codex-collab config
 
 # Set a preferred model
-codex-collab config model gpt-5.3-codex
+codex-collab config model gpt-5.6-sol
 
 # Set default reasoning effort
 codex-collab config reasoning high

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,7 +139,7 @@ codex-collab follow --watch
 |------|------|
 | `-d, --dir <path>` | 工作目录 |
 | `-m, --model <model>` | 模型名称（默认: 自动选择最新可用模型） |
-| `-r, --reasoning <level>` | none, minimal, low, medium, high, xhigh（默认: 自动选择模型支持的最高级别） |
+| `-r, --reasoning <level>` | none, minimal, low, medium, high, xhigh, max, ultra（默认: 自动选择模型支持的最高级别，上限为 `xhigh`） |
 | `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access（默认: workspace-write；review 始终使用 read-only） |
 | `--mode <mode>` | 审查模式: pr, uncommitted, commit, custom |
 | `--ref <hash>` | 指定 commit 哈希（配合 `--mode commit`） |
@@ -168,13 +168,15 @@ codex-collab follow --watch
 
 ## 默认值与配置
 
-默认情况下，codex-collab 自动选择**最新模型**（优先选择 `-codex` 变体）及该模型支持的**最高推理级别**。无需配置——新模型发布后自动更新。
+默认情况下，codex-collab 自动选择**最新模型**（以服务端默认模型为起点，沿升级链向上查找，并在存在 `-codex` 变体时优先选用）及该模型支持的**最高推理级别，上限为 `xhigh`**。无需配置——新模型发布后自动更新。
+
+`max` 与 `ultra` 两个级别不会被自动选中，需显式启用：单次运行使用 `-r max` / `-r ultra`，或通过 `codex-collab config reasoning` 设为默认值。
 
 使用 `codex-collab config` 持久化覆盖默认值：
 
 ```bash
 codex-collab config                     # 查看当前配置
-codex-collab config model gpt-5.3-codex # 设置默认模型
+codex-collab config model gpt-5.6-sol   # 设置默认模型
 codex-collab config reasoning high      # 设置默认推理级别
 codex-collab config model --unset       # 取消单个设置（恢复自动检测）
 codex-collab config --unset             # 取消所有设置

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,7 @@ cat prompt.md | codex-collab run - --content-only
 If the user asks about progress mid-task, use `TaskOutput(block=false)` to read the background output stream, or `codex-collab progress <id>` for just the log tail. `<id>` is the codex-collab thread short ID (8-char hex), not the Claude Code task ID — it appears in the first progress line (`[codex] Thread a1b2c3d4 started`); `codex-collab threads` lists them. Progress lines stream in real time:
 
 ```
-[codex] Thread a1b2c3d4 started (gpt-5.4, workspace-write)
+[codex] Thread a1b2c3d4 started (gpt-5.6-sol, workspace-write)
 [codex] Running: npm test
 [codex] Edited: src/auth.ts (update)
 [codex] Turn completed (2m 14s, 1 file changed)
@@ -113,7 +113,7 @@ If you've lost track of the thread ID, use `codex-collab threads` to find active
 
 ```bash
 codex-collab run "large refactor task" --detach --approval auto
-# [codex] Detached: thread a1b2c3d4 running (gpt-5.4)
+# [codex] Detached: thread a1b2c3d4 running (gpt-5.6-sol)
 # [codex]   Follow:   codex-collab follow a1b2c3d4
 ```
 
@@ -241,7 +241,7 @@ Note: `jobs` still works as a deprecated alias for `threads`.
 | Flag | Description |
 |------|-------------|
 | `-m, --model <model>` | Model name (default: auto — latest available) |
-| `-r, --reasoning <level>` | Reasoning effort: none, minimal, low, medium, high, xhigh (default: auto — highest for model) |
+| `-r, --reasoning <level>` | Reasoning effort: none, minimal, low, medium, high, xhigh, max, ultra (default: auto — highest the model supports, up to `xhigh`) |
 | `-s, --sandbox <mode>` | Sandbox: read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
 | `-d, --dir <path>` | Working directory (default: cwd) |
 | `--resume <id>` | Resume existing thread (run and review) |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,7 +161,7 @@ Commands:
 
 Options:
   -m, --model <model>     Model name (default: auto — latest available)
-  -r, --reasoning <lvl>   Reasoning: ${config.reasoningEfforts.join(", ")} (default: auto — highest available)
+  -r, --reasoning <lvl>   Reasoning: ${config.reasoningEfforts.join(", ")} (default: auto — highest up to ${config.autoEffortCeiling})
   -s, --sandbox <mode>    Sandbox: ${config.sandboxModes.join(", ")}
                           (default: ${config.defaultSandbox})
   -d, --dir <path>        Working directory (default: cwd)

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -20,7 +20,7 @@ export async function handleConfig(args: string[]): Promise<void> {
   const { positional, options } = parseOptions(args);
 
   const VALID_KEYS: Record<string, { validate: (v: string) => boolean; hint: string }> = {
-    model:     { validate: v => v.length > 0 && !/[^a-zA-Z0-9._\-\/:]/.test(v), hint: "model name (e.g. gpt-5.4, gpt-5.3-codex)" },
+    model:     { validate: v => v.length > 0 && !/[^a-zA-Z0-9._\-\/:]/.test(v), hint: "model name (e.g. gpt-5.6-sol, gpt-5.5)" },
     reasoning: { validate: v => (config.reasoningEfforts as readonly string[]).includes(v), hint: config.reasoningEfforts.join(", ") },
     sandbox:   { validate: v => (config.sandboxModes as readonly string[]).includes(v), hint: config.sandboxModes.join(", ") },
     approval:  { validate: v => (config.approvalModes as readonly string[]).includes(v), hint: config.approvalModes.join(", ") },

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -91,7 +91,8 @@ export async function handleReview(args: string[]): Promise<void> {
       if (options.resumeId) {
         progress(`Forked thread ${shortId} for read-only review`);
       } else {
-        progress(`Thread ${shortId} started for review (${effective.model}, read-only)`);
+        const effort = effective.reasoningEffort ? `, ${effective.reasoningEffort}` : "";
+        progress(`Thread ${shortId} started for review (${effective.model}${effort}, read-only)`);
       }
     }
 

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -1381,6 +1381,81 @@ describe("startOrResumeThread", () => {
     expect((runStart?.params as Record<string, unknown>).config).toBeUndefined();
   });
 
+  test("fresh review thread pins model_reasoning_effort: review/start carries no effort field", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = recordingClient(calls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+    opts.model = "gpt-5.6-sol";
+    opts.reasoning = "xhigh";
+
+    await startOrResumeThread(
+      client, opts, freshWorkspace("review-start-effort-pin"), { sandbox: "read-only" }, "Review PR", true,
+    );
+    const start = calls.find(c => c.method === "thread/start");
+    expect(start?.params).toMatchObject({
+      config: { review_model: "gpt-5.6-sol", model_reasoning_effort: "xhigh" },
+    });
+  });
+
+  test("plain run sends no effort pin — effort rides turn/start instead", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = recordingClient(calls, {
+      "thread/start": () => threadStartResponse(newThreadId, "/tmp/proj"),
+    });
+    const opts = defaultOptions();
+    opts.dir = "/tmp/proj";
+    opts.model = "gpt-5.6-sol";
+    opts.reasoning = "xhigh";
+
+    await startOrResumeThread(client, opts, freshWorkspace("run-start-no-effort-pin"), undefined, "task", false);
+    const start = calls.find(c => c.method === "thread/start");
+    expect((start?.params as Record<string, unknown>).config).toBeUndefined();
+  });
+
+  test("review --resume pins effort only when -r was explicit (else inherits the forked thread's)", async () => {
+    const sourceThreadId = "01900000000070008000000000000011";
+    const forkedThreadId = "01900000000070008000000000000012";
+
+    // Explicit -r: pinned.
+    const explicitCalls: Array<{ method: string; params: unknown }> = [];
+    const explicitClient = recordingClient(explicitCalls, {
+      "thread/fork": () => threadStartResponse(forkedThreadId, "/tmp/proj"),
+    });
+    const wsA = freshWorkspace("review-resume-effort-explicit");
+    const shortIdA = registerThread(wsA.stateDir, sourceThreadId, { model: "gpt-5.6-sol" });
+    const explicitOpts = defaultOptions();
+    explicitOpts.dir = "/tmp/proj";
+    explicitOpts.resumeId = shortIdA;
+    explicitOpts.reasoning = "low";
+    explicitOpts.explicit.add("reasoning");
+
+    await startOrResumeThread(explicitClient, explicitOpts, wsA, { sandbox: "read-only" }, "Review", true);
+    const explicitFork = explicitCalls.find(c => c.method === "thread/fork");
+    expect(explicitFork?.params).toMatchObject({
+      config: { review_model: "gpt-5.6-sol", model_reasoning_effort: "low" },
+    });
+
+    // Auto-resolved (not explicit): no effort pin, so the fork inherits.
+    const autoCalls: Array<{ method: string; params: unknown }> = [];
+    const autoClient = recordingClient(autoCalls, {
+      "thread/fork": () => threadStartResponse(forkedThreadId, "/tmp/proj"),
+    });
+    const wsB = freshWorkspace("review-resume-effort-auto");
+    const shortIdB = registerThread(wsB.stateDir, sourceThreadId, { model: "gpt-5.6-sol" });
+    const autoOpts = defaultOptions();
+    autoOpts.dir = "/tmp/proj";
+    autoOpts.resumeId = shortIdB;
+    autoOpts.reasoning = "xhigh"; // present on Options, but never flagged explicit
+
+    await startOrResumeThread(autoClient, autoOpts, wsB, { sandbox: "read-only" }, "Review", true);
+    const autoFork = autoCalls.find(c => c.method === "thread/fork");
+    const autoConfig = (autoFork?.params as Record<string, unknown>).config as Record<string, unknown>;
+    expect(autoConfig).toEqual({ review_model: "gpt-5.6-sol" });
+  });
+
   test("new thread with --memory: no memoryMode call", async () => {
     const calls: Array<{ method: string; params: unknown }> = [];
     const client = recordingClient(calls, {

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -913,7 +913,15 @@ export async function startOrResumeThread(
         : resolved
           ? loadThreadIndex(ws.stateDir)[resolved.shortId]?.model
           : undefined;
-      if (reviewModel) forkParams.config = { review_model: reviewModel };
+      // Effort is pinned only when explicitly asked for: resolveDefaults bails
+      // on resume, so an unpinned fork inherits the source thread's effort
+      // rather than re-resolving it — matching how -m behaves here.
+      const forkConfig: Record<string, unknown> = {};
+      if (reviewModel) forkConfig.review_model = reviewModel;
+      if (opts.explicit.has("reasoning") && opts.reasoning) {
+        forkConfig.model_reasoning_effort = opts.reasoning;
+      }
+      if (Object.keys(forkConfig).length > 0) forkParams.config = forkConfig;
       // Reviews must run in read-only mode. `thread/resume.sandbox` is not
       // reliable for already-loaded broker threads, and `review/start` has no
       // per-turn sandbox override, so fork the resumed context into a fresh
@@ -971,8 +979,16 @@ export async function startOrResumeThread(
     if (opts.model) startParams.model = opts.model;
     // Same review_model pin as the fork path above: without it, a
     // review_model in ~/.codex/config.toml would win over the model shown in
-    // our own "started for review" progress line.
-    if (isReview && opts.model) startParams.config = { review_model: opts.model };
+    // our own "started for review" progress line. model_reasoning_effort is
+    // pinned for the same reason and by necessity: review/start carries no
+    // effort field, so this config key is the only way an effort reaches the
+    // review sub-agent at all.
+    if (isReview) {
+      const reviewConfig: Record<string, unknown> = {};
+      if (opts.model) reviewConfig.review_model = opts.model;
+      if (opts.reasoning) reviewConfig.model_reasoning_effort = opts.reasoning;
+      if (Object.keys(reviewConfig).length > 0) startParams.config = reviewConfig;
+    }
     effective = await client.request<ThreadStartResponse>(
       "thread/start",
       startParams,

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -794,10 +794,12 @@ export function pickBestModel(models: Model[]): string | undefined {
   return current.id;
 }
 
-/** Pick the highest reasoning effort a model supports. */
-function pickHighestEffort(supported: Array<{ reasoningEffort: string }>): ReasoningEffort | undefined {
+/** Pick the highest reasoning effort a model supports, capped at the
+ *  auto-select ceiling. */
+function pickAutoEffort(supported: Array<{ reasoningEffort: string }>): ReasoningEffort | undefined {
   const available = new Set(supported.map(s => s.reasoningEffort));
-  for (let i = config.reasoningEfforts.length - 1; i >= 0; i--) {
+  const ceiling = config.reasoningEfforts.indexOf(config.autoEffortCeiling);
+  for (let i = ceiling; i >= 0; i--) {
     if (available.has(config.reasoningEfforts[i])) return config.reasoningEfforts[i];
   }
   return undefined;
@@ -833,7 +835,7 @@ export async function resolveDefaults(client: AppServerClient, opts: Options): P
   if (needReasoning) {
     const modelData = models.find(m => m.id === opts.model);
     if (modelData?.supportedReasoningEfforts?.length) {
-      opts.reasoning = pickHighestEffort(modelData.supportedReasoningEfforts);
+      opts.reasoning = pickAutoEffort(modelData.supportedReasoningEfforts);
     }
   }
 }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -47,7 +47,13 @@ describe("config object", () => {
   });
 
   test("has accepted reasoning efforts", () => {
-    expect(config.reasoningEfforts).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"]);
+    expect(config.reasoningEfforts).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
+  });
+
+  test("auto-select ceiling is a known effort below the top of the enum", () => {
+    const efforts = config.reasoningEfforts as readonly string[];
+    expect(efforts).toContain(config.autoEffortCeiling);
+    expect(efforts.indexOf(config.autoEffortCeiling)).toBeLessThan(efforts.length - 1);
   });
 
   test("is frozen", () => {
@@ -132,13 +138,12 @@ describe("resolveModel", () => {
 
 describe("validateEffort", () => {
   test("accepts all valid effort levels", () => {
-    for (const level of ["none", "minimal", "low", "medium", "high", "xhigh"] as const) {
+    for (const level of ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const) {
       expect(validateEffort(level)).toBe(level);
     }
   });
 
   test("throws on invalid effort", () => {
-    expect(() => validateEffort("max")).toThrow();
     expect(() => validateEffort("turbo")).toThrow();
     expect(() => validateEffort("")).toThrow();
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,9 @@ const MODEL_ALIASES: Record<string, string> = {
 
 // ─── Effort levels ──────────────────────────────────────────────────────────
 
-const VALID_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+// The full effort enum the app server accepts, ascending. Not every model
+// advertises every level in its `supportedReasoningEfforts`.
+const VALID_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
 
 // ─── Workspace state schema version ─────────────────────────────────────────
 // Bumped whenever the on-disk shape of a workspace state dir
@@ -47,6 +49,9 @@ export function isPathInside(candidate: string, root: string): boolean {
 export const config = {
   // Reasoning effort levels
   reasoningEfforts: VALID_EFFORTS,
+  // Highest level auto-selection will settle on. Levels above it stay reachable
+  // through an explicit -r flag or user config, but are never chosen for you.
+  autoEffortCeiling: "xhigh" as const,
 
   // Sandbox modes
   sandboxModes: ["read-only", "workspace-write", "danger-full-access"] as const,


### PR DESCRIPTION
Three defects, one subject: how reasoning effort is chosen and delivered.

## 1. `max` / `ultra` were unreachable

The new lineup ships two tiers above `xhigh`. `VALID_EFFORTS` stopped at `xhigh`, so they were rejected outright — and auto-select silently settled for `xhigh` while believing it had picked the model's highest supported effort.

| id | isDefault | upgrade | efforts |
|---|---|---|---|
| `gpt-5.6-sol` | **true** | `null` | low…xhigh, **max, ultra** |
| `gpt-5.6-terra` | false | `null` | low…xhigh, **max, ultra** |
| `gpt-5.6-luna` | false | `null` | low…xhigh, **max** |
| `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.3-codex-spark` | false | `null` | low…xhigh |

Two lists were doing one job. **`VALID_EFFORTS`** is the *protocol* enum (everything the app server accepts); **`supportedReasoningEfforts`** is what a model *advertises*. `pickHighestEffort` intersected them and took the top — correct while `xhigh` capped both, wrong once the enum fell behind.

Auto-select needs a third concept: a **policy ceiling**, the highest effort we'll pick on the user's behalf. Not the same as the highest that exists.

- Add `max`, `ultra` to `VALID_EFFORTS`. `ReasoningEffort` derives from the tuple, so the CLI validator and config hint widen for free.
- Add `config.autoEffortCeiling` (`"xhigh"`); auto-select scans down from it.
- `pickHighestEffort` → `pickAutoEffort`. It no longer picks the highest.
- `--help` derived its level list from `config.reasoningEfforts` but promised *"highest available"*, which the ceiling falsifies. It now derives from the ceiling too, so the two can't drift.

`none`/`minimal` stay. No model advertises them, so auto-select never lands there, but the server accepts them explicitly — the `reasoning.effort 'minimal'` tip in `shared.ts` exists because that path is live.

## 2. `review -r <level>` silently did nothing

`review/start` carries no effort field, and neither `thread/start` nor `thread/fork` ever sent one. `resolveDefaults` computed an effort for reviews and **threw it away**. Every review ran at whatever `model_reasoning_effort` sat in `~/.codex/config.toml`. `review -r ultra` parsed, validated, and evaporated — the worst of the three possible behaviors, because it looks like it worked.

Fix: pin `model_reasoning_effort` beside the existing `review_model` pin. That config key is the only road into the review sub-agent.

`thread/fork` pins effort **only when `-r` is explicit**: `resolveDefaults` bails on resume, so an unpinned fork inherits the source thread's effort rather than re-resolving it. Matches how `-m` already behaves there, and how `turnOverrides` treats a resumed `run`.

Plain runs still send no thread-level `config` — their effort rides `turn/start`. A test guards that asymmetry.

## 3. The effort was invisible

The review progress line printed model and sandbox but not effort, which is why #2 went unnoticed. It now reads `(gpt-5.6-sol, xhigh, read-only)`. `run`'s line is unchanged — its effort was always correct.

## Behavior change

Auto-select for `run` is **unchanged**: `gpt-5.6-sol` at `xhigh`.

**Reviews change.** They previously inherited `model_reasoning_effort` from `~/.codex/config.toml`; now codex-collab decides, using the same precedence as `run`:

1. explicit `-r <level>`
2. `codex-collab config reasoning <level>`
3. auto-select — highest the model supports, capped at `autoEffortCeiling` (`xhigh`)
4. `~/.codex/config.toml` — fallback only

For most users reviews get *deeper* (e.g. `high` → `xhigh`). But anyone who deliberately set `model_reasoning_effort = "ultra"` in `config.toml` will find reviews **capped at `xhigh`** by auto-select — shallower than before. That is intentional under this precedence (config.toml is a fallback, never a silent override, exactly as `run` has always behaved), and `-r ultra` or `codex-collab config reasoning ultra` still reach the top tier. `--resume` on either command ignores the config file and inherits the thread's effort.

## Verification

Against a live app server, not inferred:

- `resolveDefaults`, no flags, no user config → `gpt-5.6-sol` / `xhigh`. Unchanged.
- `run -r xhigh`, `-r max`, `-r ultra` → all exit 0. The tiers are genuinely accepted.
- `review` with `ultra` pinned → completes. The sub-agent accepts the top tier.
- Same review target (`--mode commit --ref 9fd46ad`): `-r low` → 17s, `-r medium` → 1m11s. The effort is *used*, not merely accepted.
- `codex-collab config reasoning medium` with no `-r` → review line reads `(gpt-5.6-sol, medium, read-only)`. Neither auto-select (`xhigh`) nor `config.toml` (`high`) produces `medium`, so the config file reaches reviews.
- `config reasoning ultra` / `max` accepted; `turbo` rejected.
- `bun test`: 698 pass, 0 fail. `tsc --noEmit` clean. CI green on ubuntu / windows / macos.

**Why the pin works, confirmed against Codex source.** `codex-rs/core/src/tasks/review.rs`:

```rust
let mut sub_agent_config = config.as_ref().clone();          // inherits thread config
sub_agent_config.permissions.approval_policy = Constrained::allow_only(Never);
let model = config.review_model.clone().unwrap_or_else(|| ctx.model_info.slug.clone());
```

The review sub-agent **clones the thread config**, which is precisely why pinning `model_reasoning_effort` there reaches it, and why `review_model` has always worked. (Checkout is v146.4.0 against a v0.144.1 binary, so treat as corroboration — but it predicts every observation below.)

**How the pin was proven empirically, since this is easy to get wrong:** `thread/start` validates nothing in `config` — hand it `model_reasoning_effort: "bogus"` and it echoes `effort=bogus` straight back. Its response is a mirror, so it cannot establish that a pin is honored. What establishes it is a control/treatment pair against a real review:

- control — `review_model: "bogus-model-xyz"` → 400, *"The 'bogus-model-xyz' model is not supported"*
- treatment — `model_reasoning_effort: "bogus"` → 400, *"[reasoning.effort] [invalid_enum_value] Invalid value: 'bogus'"*

Both keys reach the sub-agent's model call.

⚠️ That API error enumerates its supported values as `none … xhigh`, with **no `max`/`ultra`** — which looks like it contradicts `model/list`. It doesn't: `run -r ultra` and a review pinned to `ultra` both succeed. The message carries a stale enum. Don't trust it.

## Notes for review

- `config.test.ts` asserted `validateEffort("max")` **throws**. That inverts. `"turbo"` was already there as an invalid sentinel, so the test keeps its teeth.
- `pickBestModel`'s upgrade-chain walk and `-codex` preference are inert against today's flat lineup (every `upgrade` is `null`; nothing ends in `-codex`). Left alone deliberately — forward-compat, and removing them buys nothing.
- Docs: both READMEs and `SKILL.md` documented the pre-ceiling behavior; config examples cited the retired `gpt-5.3-codex`. `skill/codex-collab/` is untracked build output regenerated by `install.sh`, so it's left alone.
- Out of scope, found while verifying: `review` silently ignores `-s` and `--approval` (Codex hardcodes the review sub-agent to `AskForApproval::Never`, and codex-collab forces `read-only`), and `pickBestModel` has no fallback when the frontier model returns "at capacity". Both tracked separately.