### PR TITLE
fix(review): reject -s and --approval instead of silently ignoring them

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ codex-collab follow --watch
 | `-d, --dir <path>` | Working directory |
 | `-m, --model <model>` | Model name (default: auto — latest available) |
 | `-r, --reasoning <level>` | none, minimal, low, medium, high, xhigh, max, ultra (default: auto — highest the model supports, up to `xhigh`) |
-| `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
+| `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access (default: workspace-write). `review` rejects this flag: reviews always run read-only |
 | `--resume <id>` | Resume existing thread |
-| `--approval <policy>` | Approval policy: never, on-request, on-failure, untrusted, auto (default: never). `auto`: Codex's Guardian reviewer approves or denies each request autonomously — never blocks on a human; decisions stream as Guardian lines |
+| `--approval <policy>` | Approval policy: never, on-request, on-failure, untrusted, auto (default: never). `auto`: Codex's Guardian reviewer approves or denies each request autonomously — never blocks on a human; decisions stream as Guardian lines. `review` rejects this flag: Codex locks review sub-agents to `never`, so it could never take effect |
 | `--memory` | Let Codex's memory feature learn from threads this run creates. Default: created threads get `thread/memoryMode/set mode=disabled`; resumed threads are never touched (the flag is persistent per-thread, and a thread you created yourself should keep feeding your memory). Governs Codex's *local* memory consolidation (`~/.codex/memories`) only — the `personality` feature is explicit user config (not learned) and unaffected. Persistent form: `config memory true` |
 | `--timeout <sec>` | Turn timeout (default: 1200, max 2147483). When a goal is active it scopes the whole goal, and expiry pauses the goal before exiting. For `ask`: answer deadline (default: 600); for `next`: wait deadline (default: wait indefinitely) |
 | `--` | End of options; remaining arguments are treated as prompt text |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -152,9 +152,9 @@ codex-collab follow --watch
 | `-d, --dir <path>` | 工作目录 |
 | `-m, --model <model>` | 模型名称（默认: 自动选择最新可用模型） |
 | `-r, --reasoning <level>` | none, minimal, low, medium, high, xhigh, max, ultra（默认: 自动选择模型支持的最高级别，上限为 `xhigh`） |
-| `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access（默认: workspace-write；review 始终使用 read-only） |
+| `-s, --sandbox <mode>` | read-only, workspace-write, danger-full-access（默认: workspace-write）。`review` 不接受此参数：审查始终以 read-only 运行 |
 | `--resume <id>` | 恢复已有会话 |
-| `--approval <policy>` | 审批策略: never, on-request, on-failure, untrusted, auto（默认: never）。`auto`: Codex 的 Guardian 审查器自主批准或拒绝每个请求，绝不阻塞等待人工；决策以 Guardian 进度行的形式实时展示 |
+| `--approval <policy>` | 审批策略: never, on-request, on-failure, untrusted, auto（默认: never）。`auto`: Codex 的 Guardian 审查器自主批准或拒绝每个请求，绝不阻塞等待人工；决策以 Guardian 进度行的形式实时展示。`review` 不接受此参数：Codex 将审查子代理的审批策略锁定为 `never`，该参数不可能生效 |
 | `--memory` | 允许 Codex 的记忆功能学习本次运行创建的会话。默认: 创建的会话会执行 `thread/memoryMode/set mode=disabled`；恢复的会话永不改动（该标记按会话持久保存，你自己创建的会话应继续进入你的记忆）。只作用于 Codex 的*本地*记忆整合（`~/.codex/memories`）；`personality` 属于显式用户配置（非学习所得），不受影响。持久化设置: `config memory true` |
 | `--timeout <sec>` | 单轮超时时间，单位秒（默认: 1200，最大 2147483）。存在进行中的 goal 时，该时限约束整个 goal，超时会先暂停 goal 再退出。用于 `ask` 时为回答等待时限（默认 600）；用于 `next` 时为等待上限（默认无限期等待） |
 | `--` | 选项结束标记；其后的参数一律视为提示词文本 |

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -156,6 +156,16 @@ describe("CLI invalid inputs", () => {
     expect(stderr).toContain("--approval");
   });
 
+  it("review rejects --goal and --budget (only run reads them)", () => {
+    const goal = run("review", "--goal", "ship it");
+    expect(goal.exitCode).toBe(1);
+    expect(goal.stderr).toContain("apply to run only");
+
+    const budget = run("review", "--budget", "1000");
+    expect(budget.exitCode).toBe(1);
+    expect(budget.stderr).toContain("apply to run only");
+  });
+
   it("run without prompt exits with error message", () => {
     const { stderr, exitCode } = run("run");
     expect(exitCode).toBe(1);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -134,6 +134,28 @@ describe("CLI invalid inputs", () => {
     expect(stderr).toContain("Invalid sandbox mode");
   });
 
+  // review rejects flags that parse but cannot take effect (#22). The guard
+  // fires before any client connection, so these are hermetic. Even values
+  // matching the forced behavior are rejected: accepting `-s read-only`
+  // would teach that the flag does something.
+  it("review -s exits 1 explaining reviews are read-only", () => {
+    const { stderr, exitCode } = run("review", "-s", "read-only");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("review always runs read-only");
+  });
+
+  it("review --approval exits 1 explaining Codex forces never", () => {
+    const { stderr, exitCode } = run("review", "--approval", "auto");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('locks review sub-agents to approval policy "never"');
+  });
+
+  it("review --resume rejects the same flags", () => {
+    const { stderr, exitCode } = run("review", "--resume", "abc123", "--approval", "never");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--approval");
+  });
+
   it("run without prompt exits with error message", () => {
     const { stderr, exitCode } = run("run");
     expect(exitCode).toBe(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,8 @@ Options:
   -m, --model <model>     Model name (default: auto — latest available)
   -r, --reasoning <lvl>   Reasoning: ${config.reasoningEfforts.join(", ")} (default: auto — highest up to ${config.autoEffortCeiling})
   -s, --sandbox <mode>    Sandbox: ${config.sandboxModes.join(", ")}
-                          (default: ${config.defaultSandbox})
+                          (default: ${config.defaultSandbox}; rejected by review,
+                          which always runs read-only)
   -d, --dir <path>        Working directory (default: cwd)
   --resume <id>           Resume existing thread
   --timeout <sec>         Turn timeout in seconds (default: ${config.defaultTimeout}).
@@ -180,6 +181,8 @@ Options:
   --approval <policy>     Approval: ${config.approvalModes.join(", ")} (default: ${config.defaultApprovalPolicy})
                           "auto": Codex's Guardian reviewer approves or denies
                           each request autonomously (never blocks on a human)
+                          (rejected by review — Codex locks review sub-agents
+                          to "never", so the flag could never take effect)
   --memory                Let Codex's memory feature learn from threads this
                           run creates (default: created threads are excluded)
   --detach                (run) Return once the turn is running; watch it with

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -80,6 +80,10 @@ export async function handleReview(args: string[]): Promise<void> {
   if (options.explicit.has("approval")) {
     die('review cannot honor --approval: Codex locks review sub-agents to approval policy "never", so no approval request can ever fire during a review. Drop the flag.');
   }
+  // Same class: only `run` reads these, so on review they'd vanish silently.
+  if (options.goal !== null || options.budget !== null) {
+    die("review cannot run a goal: --goal/--budget apply to run only (a review is a single turn on an ephemeral thread).");
+  }
   applyUserConfig(options);
 
   const target = resolveReviewTarget(positional, options, options.dir);

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -31,6 +31,7 @@ import {
   setActiveTurnId,
   setActiveWsPaths,
   setActiveRunId,
+  sandboxModeLabel,
   VALID_REVIEW_MODES,
   type Options,
 } from "./shared";
@@ -66,6 +67,19 @@ function resolveReviewTarget(positional: string[], opts: Options, cwd: string): 
 
 export async function handleReview(args: string[]): Promise<void> {
   const { positional, options } = parseOptions(args);
+  // Both flags parse and validate but neither can take effect on a review:
+  // the review thread is forced read-only below (the documented safety
+  // property), and Codex hard-locks review sub-agents to approval policy
+  // "never", so no value sent from here survives. Fail loud instead of
+  // accepting a flag that looks like it worked (#22). Config-file defaults
+  // land in `configured`, not `explicit`, so they still pass — they are
+  // global defaults for `run`, not a per-invocation request.
+  if (options.explicit.has("sandbox")) {
+    die("review always runs read-only; -s/--sandbox cannot change that. Drop the flag.");
+  }
+  if (options.explicit.has("approval")) {
+    die('review cannot honor --approval: Codex locks review sub-agents to approval policy "never", so no approval request can ever fire during a review. Drop the flag.');
+  }
   applyUserConfig(options);
 
   const target = resolveReviewTarget(positional, options, options.dir);
@@ -88,11 +102,14 @@ export async function handleReview(args: string[]): Promise<void> {
     if (options.contentOnly) {
       console.error(`[codex] Reviewing (thread ${shortId})...`);
     } else {
+      // Sandbox comes from the server's echo, not a hardcoded literal, so if
+      // the forced mode ever drifts the progress line shows it (#22).
+      const sandbox = sandboxModeLabel(effective.sandbox);
       if (options.resumeId) {
-        progress(`Forked thread ${shortId} for read-only review`);
+        progress(`Forked thread ${shortId} for ${sandbox} review`);
       } else {
         const effort = effective.reasoningEffort ? `, ${effective.reasoningEffort}` : "";
-        progress(`Thread ${shortId} started for review (${effective.model}${effort}, read-only)`);
+        progress(`Thread ${shortId} started for review (${effective.model}${effort}, ${sandbox})`);
       }
     }
 

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -11,6 +11,7 @@ import {
   startOrResumeThread,
   turnOverrides,
   resolveApproval,
+  sandboxModeLabel,
   formatDuration,
   isThreadProcessAlive,
   defaultOptions,
@@ -744,6 +745,27 @@ describe("resolveApproval", () => {
   });
 });
 
+describe("sandboxModeLabel", () => {
+  test("maps wire-shape objects back to kebab-case modes", () => {
+    expect(sandboxModeLabel({ type: "readOnly" })).toBe("read-only");
+    expect(sandboxModeLabel({ type: "workspaceWrite" })).toBe("workspace-write");
+    expect(sandboxModeLabel({ type: "dangerFullAccess" })).toBe("danger-full-access");
+  });
+
+  test("passes kebab-case string echoes through", () => {
+    expect(sandboxModeLabel("read-only")).toBe("read-only");
+  });
+
+  test("renders unknown shapes verbatim instead of guessing", () => {
+    // Protocol drift must show up in the progress line, not hide behind a
+    // familiar label — that invisibility is how #22 survived.
+    expect(sandboxModeLabel({ type: "futureMode" })).toBe("futureMode");
+    expect(sandboxModeLabel({ mode: "?" })).toBe('{"mode":"?"}');
+    expect(sandboxModeLabel(undefined)).toBe("unknown");
+    expect(sandboxModeLabel(null)).toBe("null");
+  });
+});
+
 describe("pickBestModel", () => {
   const m = (id: string, opts: { upgrade?: string; isDefault?: boolean } = {}): Model => ({
     id,
@@ -1258,8 +1280,10 @@ describe("startOrResumeThread", () => {
         ephemeral: true,
         model: "gpt-5",
         cwd: "/tmp/review-project",
-        approvalPolicy: "on-request",
-        approvalsReviewer: "user",
+        // No approvalPolicy even though --approval was explicit: Codex locks
+        // review sub-agents to "never", so forwarding it would only fake
+        // effect. handleReview rejects the flag before reaching here (#22);
+        // this asserts the fork path doesn't resurrect it.
         sandbox: "read-only",
         // review_model pin: Codex would otherwise prefer its own config.toml
         // review_model over the model we requested for this review.

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -946,7 +946,9 @@ export async function startOrResumeThread(
       };
       if (opts.explicit.has("model")) forkParams.model = opts.model;
       if (opts.explicit.has("dir")) forkParams.cwd = opts.dir;
-      if (opts.explicit.has("approval")) Object.assign(forkParams, resolveApproval(opts.approval));
+      // No approval forwarding: Codex hard-locks review sub-agents to
+      // approval policy "never" (nothing sent here survives), which is why
+      // handleReview rejects an explicit --approval up front (#22).
       // Codex resolves the review sub-agent's model from its own
       // `review_model` config key before falling back to the thread's model,
       // so a review_model in ~/.codex/config.toml would silently override the
@@ -1140,6 +1142,23 @@ export function sandboxPolicyFor(mode: SandboxMode): { type: string } {
     case "workspace-write": return { type: "workspaceWrite" };
     case "danger-full-access": return { type: "dangerFullAccess" };
   }
+}
+
+/** Inverse of sandboxPolicyFor, for display: thread/start|fork echo the
+ *  sandbox as either the kebab-case string they were sent or the wire
+ *  object. Unrecognized shapes render verbatim rather than being guessed
+ *  at, so protocol drift shows up in the progress line instead of hiding
+ *  behind a familiar label. */
+export function sandboxModeLabel(sandbox: unknown): string {
+  if (typeof sandbox === "string") return sandbox;
+  const type = (sandbox as { type?: unknown } | null | undefined)?.type;
+  switch (type) {
+    case "readOnly": return "read-only";
+    case "workspaceWrite": return "workspace-write";
+    case "dangerFullAccess": return "danger-full-access";
+  }
+  if (typeof type === "string") return type;
+  return JSON.stringify(sandbox) ?? "unknown";
 }
 
 /** Per-turn parameter overrides: all values for new threads, explicit-only for resume. */


### PR DESCRIPTION
Closes #22.

`review` accepted `-s/--sandbox` and `--approval` — both parsed, both validated, neither had any effect, and nothing said so. Same defect family as `-r` before #21, except these two cannot be plumbed through:

- **`-s`** is clobbered by the forced `{ sandbox: "read-only" }` extra start param — the documented safety property of `review`.
- **`--approval`** is hard-overridden upstream: Codex clones the thread config for the review sub-agent and locks the approval policy to `Never` via `Constrained::allow_only`, so no value sent on `thread/start`/`thread/fork` survives, and no approval request (or Guardian decision) can ever fire during a review.

## Changes

- `review` now **errors on an explicit `-s` or `--approval`**, before any client connection, with a message saying why the flag cannot work. Values matching the forced behavior (`-s read-only`, `--approval never`) are rejected too — accepting them would teach that the flag does something.
- **Config-file defaults still pass silently** — they are global defaults for `run`, not a per-invocation request. The existing `explicit`/`configured` split already draws that line.
- The review fork path no longer forwards an explicit approval policy — unreachable behind the new guard, and it only faked effect.
- The review progress line **derives its sandbox from the server's echo** (`sandboxModeLabel`, the display inverse of `sandboxPolicyFor`) instead of hardcoding `read-only`. Unknown wire shapes render verbatim so protocol drift shows up in the line instead of hiding behind a familiar label — the invisibility that let both flags survive.
- `review` also rejects `--goal`/`--budget` -- same class: they parse on any command but only `run` reads them, and a goal makes no sense on a single-turn ephemeral review thread.
- Help text and both READMEs document the rejection.

## Out of scope

The issue's open question — whether `review` should accept a sandbox override at all so a review can run the test suite — is a deliberate posture change, left for a separate decision.

## Testing

- Full suite: 738 pass, 0 fail (new: CLI subprocess tests for both guards incl. the `--resume` path; `sandboxModeLabel` mapping/fallback tests; fork-params test now asserts approval is *not* forwarded).
- Verified live against a real app-server: both guards exit 1 before connecting; start-path and fork-path reviews still print `read-only`, now derived from the echo.
