### PR TITLE
Fix failures that reported the wrong thing; correct flag and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Collaborate with [Codex](https://github.com/openai/codex) from [Claude Code](htt
 
 ![demo](.github/assets/demo.png)
 
-codex-collab is a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) that drives Codex through its app server JSON-RPC protocol. It manages threads, streams structured events, handles tool-call approvals, and lets you resume conversations — all without leaving your Claude session.
+codex-collab is a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) that drives Codex through its app server JSON-RPC protocol. It manages threads, streams structured events, handles tool-call approvals, and lets you resume conversations.
 
 ## Why
 
@@ -45,11 +45,19 @@ cd codex-collab
 powershell -ExecutionPolicy Bypass -File install.ps1
 ```
 
-After installation, **reopen your terminal** so the updated PATH takes effect, then run `codex-collab health` to verify. If `~/.local/bin` is already on your PATH, no reopen is needed. Otherwise add the export line the installer prints, or verify by full path: `~/.local/bin/codex-collab health`.
+After installation, run `codex-collab health` to verify. If the command is not found, `~/.local/bin` is not on your PATH yet: reopen your terminal, add the export line the installer prints, or use the full path `~/.local/bin/codex-collab health`.
 
-You can also hand this to an agent — running it outside Claude Code (for example, from Codex) means the skill is ready the next time you start Claude. Expect a prompt to allow writes outside the repo.
+> [!TIP]
+> You can hand the install to an agent. Running it outside Claude Code, for example from Codex, means the skill is ready the next time you start Claude. It will ask permission to write outside the repository.
 
-The installer builds a self-contained bundle, deploys it to your home directory (`~/.claude/skills/codex-collab/` on Linux/macOS, `%USERPROFILE%\.claude\skills\codex-collab\` on Windows), and installs a binary shim (`install.ps1` adds it to your PATH; `install.sh` places it in `~/.local/bin` and prints instructions if that directory is not already on your PATH). Once installed, Claude discovers the skill automatically, including in an already-running session — unless `~/.claude/skills/` did not exist beforehand, in which case restart Claude Code once so the new directory is watched.
+<details>
+<summary>Where things get installed</summary>
+
+The installer builds a self-contained bundle plus a binary shim. On Linux and macOS these go to `~/.claude/skills/codex-collab/` and `~/.local/bin`. On Windows they go to `%USERPROFILE%\.claude\skills\codex-collab\`, and `install.ps1` adds the shim to your PATH.
+
+Claude discovers the skill automatically, including in a session that is already running. The exception is your first skill: if `~/.claude/skills/` did not exist before, restart Claude Code once so the new directory is watched.
+
+</details>
 
 ### Upgrading
 
@@ -60,11 +68,9 @@ codex-collab update            # show the latest release and changelog, confirm,
 codex-collab update --check    # report only, install nothing
 ```
 
-`update` downloads the pinned release tag from GitHub, rebuilds locally, reinstalls the skill bundle and binary shim, and prints the SKILL.md diff it applied. Nothing is installed without consent: an interactive `y/N` prompt, or an explicit `--yes` in non-interactive sessions. `run`, `review`, and `health` print a one-line notice when a newer release exists (checked at most once a day, never installing anything on their own); `update --skip` mutes notices for a given release, and `CODEX_COLLAB_NO_UPDATE_CHECK=1` disables the release check entirely (the local skill-drift notice is offline and stays on).
+`update` fetches the latest release, rebuilds it locally, and reinstalls. Nothing is installed without your confirmation: an interactive `y/N` prompt, or an explicit `--yes` when there is no terminal to ask. `run`, `review`, and `health` print a one-line notice when a newer release exists, but never install anything themselves.
 
-Relatedly, if the installed SKILL.md drifts from the binary or your template set (e.g., after adding a custom template), `codex-collab skill sync` shows the pending diff and applies it on confirmation.
-
-Upgrading manually still works: pull the latest version in your clone and rerun the installer (dev installs — `install.sh --dev` — always update this way):
+Upgrading manually still works, and is the only way to update a dev install (`install.sh --dev`):
 
 ```bash
 git pull
@@ -72,9 +78,16 @@ git pull
 codex-collab health
 ```
 
-Either path replaces the installed skill bundle and binary shim. Existing configuration, templates, thread history, and run logs under `~/.codex-collab/` are preserved. Treat `~/.claude/skills/codex-collab/` as installer-managed: manual edits there may be overwritten on upgrade (`skill sync` surfaces them as a diff before overwriting).
+<details>
+<summary>More on upgrading</summary>
 
-When upgrading from older versions, codex-collab automatically migrates thread state to the per-workspace layout on first use. No manual state migration is required. The old `jobs` command remains available as a deprecated alias for `threads`.
+`update --skip` mutes notices for one release, and `CODEX_COLLAB_NO_UPDATE_CHECK=1` turns the release check off entirely. The local skill-drift check is offline and stays on regardless.
+
+If the installed SKILL.md falls out of step with the binary or your template set, `codex-collab skill sync` shows the pending diff and applies it once you confirm.
+
+Both upgrade paths replace the skill bundle and the binary shim. Everything under `~/.codex-collab/` is preserved: configuration, templates, thread history, and run logs. Treat `~/.claude/skills/codex-collab/` as installer-managed, since manual edits there can be overwritten on upgrade.
+
+</details>
 
 <details>
 <summary>Development mode</summary>
@@ -112,35 +125,51 @@ codex-collab follow --watch
 
 | Command | Description |
 |---------|-------------|
-| `run "prompt" [opts]` | Start thread, send prompt, wait, print output (`run -` reads the prompt from stdin — no shell-quoting hazards) |
-| `review [opts]` | Code review (PR, uncommitted, commit) |
-| `threads [--json] [--all]` | List threads (`--limit <n>` to cap, `--discover` to scan server, `--session` for only threads the current session has run) |
-| `kill <id> [--clear]` | Interrupt running thread. An active goal is paused first — interrupt alone would just respawn a continuation turn; `--clear` abandons the goal instead |
-| `follow [id]` | Live view of a running thread; exits with its status (replays the last run when already finished). Without an ID, attaches to the workspace's active run — or replays the most recent one. With `--watch`, stays open and follows each new run (every run shown once, in start order) |
-| `output <id> [--last]` | Full log for thread (`--last`: only the latest turn's output) |
-| `progress <id>` | Recent activity (tail of log) |
-| `peek <id>` | Show recent conversation slice from server |
-| `ask "question"` | (for Codex, mid-turn) Post a question to the collaborator and wait for the answer; `--timeout <sec>` sets the deadline (default 600). Fails open: on expiry it prints proceed-on-your-judgment guidance and exits 0 |
-| `answer <id> "text"` | Answer a pending question (`answer <id> -` reads the answer from stdin) |
-| `questions [id]` | List pending questions in this workspace; with an ID, show that question's full text |
-| `next` | Block until something needs attention (question or approval), print it in full with how to respond, exit |
-| `config [key] [value]` | Show or set persistent defaults |
-| `models` | List available models |
-| `templates` | List available prompt templates |
-| `skill sync [--yes]` | Regenerate the installed SKILL.md when it drifts from the binary or template set — prints the diff, applies only on confirmation |
-| `update` | Check GitHub for a newer release, show its changelog, and (with confirmation) download, build, and reinstall — see [Upgrading](#upgrading) |
-| `health` | Check dependencies |
-| `version` | Print version (also `-v`/`--version` before a command) |
+| `run "prompt" [opts]` | Start a thread, send a prompt, wait, print the output (`run -` reads the prompt from stdin) |
+| `review [opts]` | Code review (PR, uncommitted, or a specific commit) |
+| `threads [--json] [--all]` | List threads (`--discover` scans the server, `--session` limits to this session) |
+| `follow [id]` | Live view of a running thread in your own terminal pane. Without an ID it attaches to the active run; `--watch` keeps following each new run |
+| `output <id> [--last]` | Full log for a thread (`--last`: only the latest turn's output) |
+| `kill <id> [--clear]` | Stop a running thread. An active goal is paused first; `--clear` abandons it |
 
 <details>
-<summary>Thread management</summary>
+<summary>Questions and approvals</summary>
 
 | Command | Description |
 |---------|-------------|
-| `delete <id> [--purge]` | Archive thread (recoverable via `codex unarchive`) and delete local files; `--purge` permanently deletes it server-side instead |
-| `clean` | Delete old logs and stale mappings |
+| `ask "question"` | Invoked by Codex mid-turn to ask a question and wait for the answer. `--timeout <sec>` sets the deadline (default 600). Fails open: on expiry it tells Codex to proceed on its own judgment and exits 0 |
+| `answer <id> "text"` | Answer a pending question (`answer <id> -` reads from stdin) |
+| `questions [id]` | List pending questions in this workspace; with an ID, show the full text |
+| `next` | Block until something needs attention, print it in full with how to respond, then exit |
 | `approve <id>` | Approve a pending request |
 | `decline <id>` | Decline a pending request |
+
+</details>
+
+<details>
+<summary>Inspection and configuration</summary>
+
+| Command | Description |
+|---------|-------------|
+| `progress <id>` | Recent activity (tail of the log) |
+| `peek <id>` | Recent conversation slice from the server |
+| `config [key] [value]` | Show or set persistent defaults |
+| `models` | List available models |
+| `templates` | List available prompt templates |
+
+</details>
+
+<details>
+<summary>Maintenance</summary>
+
+| Command | Description |
+|---------|-------------|
+| `delete <id> [--purge]` | Archive a thread (recoverable via `codex unarchive`) and delete local files; `--purge` deletes it server-side instead |
+| `clean` | Delete old logs and stale mappings |
+| `skill sync [--yes]` | Regenerate the installed SKILL.md when it drifts from the binary or template set. Prints the diff, applies only on confirmation |
+| `update` | Check for a newer release and install it with confirmation. See [Upgrading](#upgrading) |
+| `health` | Check dependencies and authentication |
+| `version` | Print version (also `-v`/`--version` before a command) |
 
 </details>
 
@@ -275,8 +304,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines. Thi
 
 ## See also
 
-For simpler interactions, you can also check out the official [Codex MCP server](https://developers.openai.com/codex/guides/agents-sdk). codex-collab is designed as a Claude Code skill, with built-in support for code review, thread management, and real-time progress streaming.
-
-codex-collab's shared app-server broker was inspired by OpenAI's [codex-plugin-cc](https://github.com/openai/codex-plugin-cc), the official Codex plugin for Claude Code.
+For simpler interactions, you can also check out the official [Codex MCP server](https://developers.openai.com/codex/guides/agents-sdk). OpenAI also ships an official [Codex plugin for Claude Code](https://github.com/openai/codex-plugin-cc), built around slash commands you invoke yourself. codex-collab asks less of you. Tell Claude what you want in your own words and it handles the rest, running Codex in the background and coming back with what it found.
 
 Thanks to the [LINUX DO](https://linux.do/) community for the feedback and support.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ cd codex-collab
 powershell -ExecutionPolicy Bypass -File install.ps1
 ```
 
-After installation, **reopen your terminal** so the updated PATH takes effect, then run `codex-collab health` to verify.
+After installation, **reopen your terminal** so the updated PATH takes effect, then run `codex-collab health` to verify. If `~/.local/bin` is already on your PATH, no reopen is needed. Otherwise add the export line the installer prints, or verify by full path: `~/.local/bin/codex-collab health`.
 
-The installer builds a self-contained bundle, deploys it to your home directory (`~/.claude/skills/codex-collab/` on Linux/macOS, `%USERPROFILE%\.claude\skills\codex-collab\` on Windows), and installs a binary shim (`install.ps1` adds it to your PATH; `install.sh` places it in `~/.local/bin` and prints instructions if that directory is not already on your PATH). Once installed, Claude discovers the skill automatically.
+You can also hand this to an agent — running it outside Claude Code (for example, from Codex) means the skill is ready the next time you start Claude. Expect a prompt to allow writes outside the repo.
+
+The installer builds a self-contained bundle, deploys it to your home directory (`~/.claude/skills/codex-collab/` on Linux/macOS, `%USERPROFILE%\.claude\skills\codex-collab\` on Windows), and installs a binary shim (`install.ps1` adds it to your PATH; `install.sh` places it in `~/.local/bin` and prints instructions if that directory is not already on your PATH). Once installed, Claude discovers the skill automatically, including in an already-running session — unless `~/.claude/skills/` did not exist beforehand, in which case restart Claude Code once so the new directory is watched.
 
 ### Upgrading
 
@@ -165,8 +167,8 @@ codex-collab follow --watch
 |------|-------------|
 | `--detach` | Return once the turn is running; watch with `follow <id>`. Turn lifetime is decoupled from the invoking shell |
 | `--template <name>` | Prompt template (user `~/.codex-collab/templates/` or built-in) |
-| `--goal <objective>` | Create the thread's goal before the first turn (replaces the objective on `--resume`); requires `goals = true` in `~/.codex/config.toml`. With `--template collab` the objective also gets a one-line ask-channel note — re-injected into every continuation turn, so channel awareness survives long goals |
-| `--budget <tokens>` | Token budget for `--goal`. Size generously — usage counts each turn's full context, so a single small turn can consume ~60k |
+| `--goal <objective>` | Create the thread's goal before the first turn (replaces the objective on `--resume`); requires `goals = true` in `~/.codex/config.toml`. A prompt is still required — it is turn one, while the goal is the standing objective. With `--template collab` the objective also gets a one-line ask-channel note — re-injected into every continuation turn, so channel awareness survives long goals. `review` rejects this flag: a review is a single turn on an ephemeral thread |
+| `--budget <tokens>` | Token budget for `--goal`. Size generously — usage counts each turn's full context, so a single small turn can consume ~60k. `review` rejects this flag |
 | `-` | Read the prompt from stdin |
 
 **review**
@@ -228,7 +230,7 @@ codex-collab follow --watch
 <details>
 <summary>Goal mode</summary>
 
-With `goals = true` in `~/.codex/config.toml`, a goal — created by Codex mid-turn, or explicitly with `run --goal "objective" [--budget <tokens>]` — makes the server keep starting continuation turns until the objective is done, and a `run` follows the whole goal in one run record and log; its exit code reflects the goal's end. The objective is re-injected into every continuation turn; one too big to state in a sentence can point at a spec or plan file in the repo. `threads` shows each thread's latest goal state (`[goal active: 45k/100k tokens]`).
+With `goals = true` in `~/.codex/config.toml`, a goal — created by Codex mid-turn, or explicitly with `run "first-turn prompt" --goal "objective" [--budget <tokens>]` — makes the server keep starting continuation turns until the objective is done, and a `run` follows the whole goal in one run record and log; its exit code reflects the goal's end. The objective is re-injected into every continuation turn; one too big to state in a sentence can point at a spec or plan file in the repo. `threads` shows each thread's latest goal state (`[goal active: 45k/100k tokens]`).
 
 </details>
 
@@ -274,3 +276,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines. Thi
 ## See also
 
 For simpler interactions, you can also check out the official [Codex MCP server](https://developers.openai.com/codex/guides/agents-sdk). codex-collab is designed as a Claude Code skill, with built-in support for code review, thread management, and real-time progress streaming.
+
+codex-collab's shared app-server broker was inspired by OpenAI's [codex-plugin-cc](https://github.com/openai/codex-plugin-cc), the official Codex plugin for Claude Code.
+
+Thanks to the [LINUX DO](https://linux.do/) community for the feedback and support.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,9 +45,11 @@ cd codex-collab
 powershell -ExecutionPolicy Bypass -File install.ps1
 ```
 
-安装完成后，**重新打开终端**以使 PATH 生效，然后运行 `codex-collab health` 验证安装。
+安装完成后，**重新打开终端**以使 PATH 生效，然后运行 `codex-collab health` 验证安装。若 `~/.local/bin` 已在 PATH 中，则无需重开终端；否则请添加安装脚本打印的 export 语句，或直接以完整路径验证：`~/.local/bin/codex-collab health`。
 
-安装脚本会自动构建独立 bundle，部署到主目录下（Linux/macOS 为 `~/.claude/skills/codex-collab/`，Windows 为 `%USERPROFILE%\.claude\skills\codex-collab\`），并安装可执行文件（`install.ps1` 会将其加入 PATH；`install.sh` 会放置在 `~/.local/bin`，若该目录不在 PATH 中会打印提示）。完成后 Claude 即可自动发现该技能。
+也可以把安装交给智能体完成——在 Claude Code 之外运行（例如交给 Codex），下次启动 Claude 时技能即已就绪。过程中会请求写入仓库以外目录的权限。
+
+安装脚本会自动构建独立 bundle，部署到主目录下（Linux/macOS 为 `~/.claude/skills/codex-collab/`，Windows 为 `%USERPROFILE%\.claude\skills\codex-collab\`），并安装可执行文件（`install.ps1` 会将其加入 PATH；`install.sh` 会放置在 `~/.local/bin`，若该目录不在 PATH 中会打印提示）。完成后 Claude 即可自动发现该技能，正在运行中的会话同样生效；唯一的例外是 `~/.claude/skills/` 此前并不存在——这种情况下需重启一次 Claude Code，新目录才会被监听。
 
 ### 升级
 
@@ -165,8 +167,8 @@ codex-collab follow --watch
 |------|------|
 | `--detach` | 在轮次真正开始运行后立即返回；用 `follow <id>` 观看。任务的生命周期与发起它的 shell 解耦 |
 | `--template <name>` | 提示词模板（优先使用 `~/.codex-collab/templates/`，然后使用内置模板） |
-| `--goal <objective>` | 在第一轮开始前为会话创建 goal（配合 `--resume` 时替换已有目标）；需要在 `~/.codex/config.toml` 中设置 `goals = true`。配合 `--template collab` 时，目标末尾会附加一行 ask 通道说明；由于目标文本会在每个后续轮次重新注入，这条说明在整个 goal 期间始终有效 |
-| `--budget <tokens>` | `--goal` 的 token 预算。请预留充足余量：用量按每轮的完整上下文计算，即使很小的一轮也可能消耗约 6 万 token |
+| `--goal <objective>` | 在第一轮开始前为会话创建 goal（配合 `--resume` 时替换已有目标）；需要在 `~/.codex/config.toml` 中设置 `goals = true`。仍须提供 prompt：prompt 是第一轮的指令，goal 则是贯穿全程的目标。配合 `--template collab` 时，目标末尾会附加一行 ask 通道说明；由于目标文本会在每个后续轮次重新注入，这条说明在整个 goal 期间始终有效。`review` 不接受此参数：审查是临时会话上的单轮任务 |
+| `--budget <tokens>` | `--goal` 的 token 预算。请预留充足余量：用量按每轮的完整上下文计算，即使很小的一轮也可能消耗约 6 万 token。`review` 不接受此参数 |
 | `-` | 从标准输入读取提示词 |
 
 **review**
@@ -228,7 +230,7 @@ codex-collab follow --watch
 <details>
 <summary>Goal 模式</summary>
 
-在 `~/.codex/config.toml` 中设置 `goals = true` 后，goal（由 Codex 在任务中途自行创建，或用 `run --goal "objective" [--budget <tokens>]` 显式设置）会让 app server 不断启动后续轮次，直到目标完成；`run` 会在同一份运行记录和日志中跟踪整个 goal，退出码反映 goal 的最终状态。目标文本会在每个后续轮次重新注入；内容较复杂的目标，可以改为指向仓库中的规格或计划文档。`threads` 会显示每个会话最新的 goal 状态（`[goal active: 45k/100k tokens]`）。
+在 `~/.codex/config.toml` 中设置 `goals = true` 后，goal（由 Codex 在任务中途自行创建，或用 `run "首轮指令" --goal "objective" [--budget <tokens>]` 显式设置）会让 app server 不断启动后续轮次，直到目标完成；`run` 会在同一份运行记录和日志中跟踪整个 goal，退出码反映 goal 的最终状态。目标文本会在每个后续轮次重新注入；内容较复杂的目标，可以改为指向仓库中的规格或计划文档。`threads` 会显示每个会话最新的 goal 状态（`[goal active: 45k/100k tokens]`）。
 
 </details>
 
@@ -258,6 +260,10 @@ codex-collab config --unset             # 取消所有设置
 
 欢迎贡献！开发环境搭建及贡献流程详见 [CONTRIBUTING.md](CONTRIBUTING.md)。本项目遵循 [Contributor Covenant](CODE_OF_CONDUCT.md) 行为准则。
 
-## 相关项目
+## 相关链接
 
 如果只需更轻量的交互，不妨试试官方的 [Codex MCP server](https://developers.openai.com/codex/guides/agents-sdk)。codex-collab 则专为 Claude Code skill 场景打造，内置代码审查、会话管理与实时进度推送。
+
+本项目 broker 的常驻 app-server 思路，受 OpenAI 官方 Claude Code 插件 [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 启发。
+
+感谢 [LINUX DO](https://linux.do/) 社区的反馈与支持。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,11 +45,19 @@ cd codex-collab
 powershell -ExecutionPolicy Bypass -File install.ps1
 ```
 
-安装完成后，**重新打开终端**以使 PATH 生效，然后运行 `codex-collab health` 验证安装。若 `~/.local/bin` 已在 PATH 中，则无需重开终端；否则请添加安装脚本打印的 export 语句，或直接以完整路径验证：`~/.local/bin/codex-collab health`。
+安装完成后运行 `codex-collab health` 验证。若提示找不到该命令，说明 `~/.local/bin` 尚未加入 PATH：可以重开终端、添加安装脚本打印的 export 语句，或直接使用完整路径 `~/.local/bin/codex-collab health`。
 
-也可以把安装交给智能体完成——在 Claude Code 之外运行（例如交给 Codex），下次启动 Claude 时技能即已就绪。过程中会请求写入仓库以外目录的权限。
+> [!TIP]
+> 安装也可以交给智能体完成。在 Claude Code 之外运行（例如交给 Codex），下次启动 Claude 时技能即已就绪。过程中它会请求写入仓库以外目录的权限。
 
-安装脚本会自动构建独立 bundle，部署到主目录下（Linux/macOS 为 `~/.claude/skills/codex-collab/`，Windows 为 `%USERPROFILE%\.claude\skills\codex-collab\`），并安装可执行文件（`install.ps1` 会将其加入 PATH；`install.sh` 会放置在 `~/.local/bin`，若该目录不在 PATH 中会打印提示）。完成后 Claude 即可自动发现该技能，正在运行中的会话同样生效；唯一的例外是 `~/.claude/skills/` 此前并不存在——这种情况下需重启一次 Claude Code，新目录才会被监听。
+<details>
+<summary>安装位置</summary>
+
+安装脚本会构建一份独立 bundle 和一个可执行文件 shim。Linux 与 macOS 上分别放置于 `~/.claude/skills/codex-collab/` 和 `~/.local/bin`；Windows 上放置于 `%USERPROFILE%\.claude\skills\codex-collab\`，并由 `install.ps1` 将 shim 加入 PATH。
+
+完成后 Claude 会自动发现该技能，正在运行中的会话同样生效。唯一的例外是首次安装技能：若 `~/.claude/skills/` 此前并不存在，需重启一次 Claude Code，新目录才会被监听。
+
+</details>
 
 ### 升级
 
@@ -60,11 +68,9 @@ codex-collab update            # 显示最新版本及更新日志，确认后�
 codex-collab update --check    # 仅查看，不安装
 ```
 
-`update` 会从 GitHub 下载锁定到发布标签的源码包，在本地重新构建并重装 skill bundle 与可执行文件 shim，随后打印本次更新对 SKILL.md 的改动 diff。任何安装动作都必须先获得同意：交互式终端中为 `y/N` 确认，非交互式会话则需显式传入 `--yes`。存在新版本时，`run`、`review`、`health` 会在 stderr 打印一行提示（每天至多检查一次，绝不自行安装）；`update --skip` 可屏蔽针对某个版本的提示，设置 `CODEX_COLLAB_NO_UPDATE_CHECK=1` 则完全关闭该联网检查（本地的 SKILL.md 漂移提示无需联网，不受影响）。
+`update` 会拉取最新版本，在本地重新构建并重装。任何安装动作都必须先获得同意：交互式终端中为 `y/N` 确认，无终端可询问时则需显式传入 `--yes`。存在新版本时，`run`、`review`、`health` 只会打印一行提示，绝不自行安装。
 
-此外，当已安装的 SKILL.md 与当前可执行文件或模板集不一致时（例如新增自定义模板之后），`codex-collab skill sync` 会先展示待应用的 diff，确认后写入。
-
-手动升级依然可行：在克隆目录中拉取最新代码并重新运行安装脚本（开发模式安装 —— `install.sh --dev` —— 只能通过这种方式升级）：
+手动升级依然可行，也是开发模式安装（`install.sh --dev`）唯一的升级方式：
 
 ```bash
 git pull
@@ -72,9 +78,16 @@ git pull
 codex-collab health
 ```
 
-两种方式都会替换已安装的 skill bundle 和可执行文件 shim。`~/.codex-collab/` 下已有的配置、模板、会话历史和运行日志都会保留。请将 `~/.claude/skills/codex-collab/` 视为安装脚本管理的目录：升级时其中的手动修改可能会被覆盖（`skill sync` 会在覆盖前以 diff 形式展示这些改动）。
+<details>
+<summary>升级的更多细节</summary>
 
-从旧版本升级时，codex-collab 会在首次使用时自动把会话状态迁移到按工作区划分的新布局，无需手动迁移状态。旧的 `jobs` 命令仍可作为 `threads` 的已弃用别名使用。
+`update --skip` 可屏蔽某个版本的提示，设置 `CODEX_COLLAB_NO_UPDATE_CHECK=1` 则完全关闭联网检查。本地的 SKILL.md 漂移检查无需联网，始终生效。
+
+当已安装的 SKILL.md 与当前可执行文件或模板集不一致时，`codex-collab skill sync` 会先展示待应用的 diff，确认后写入。
+
+两种升级方式都会替换 skill bundle 和可执行文件 shim。`~/.codex-collab/` 下的配置、模板、会话历史与运行日志均会保留。请将 `~/.claude/skills/codex-collab/` 视为安装脚本管理的目录，其中的手动修改可能在升级时被覆盖。
+
+</details>
 
 <details>
 <summary>开发模式</summary>
@@ -112,35 +125,51 @@ codex-collab follow --watch
 
 | 命令 | 说明 |
 |------|------|
-| `run "prompt" [opts]` | 新建会话、发送提示、等待完成并输出结果（`run -` 从标准输入读取提示词，不受 shell 引号转义困扰） |
-| `review [opts]` | 代码审查（PR、未提交更改、指定 commit） |
-| `threads [--json] [--all]` | 列出会话（`--limit <n>` 限制数量，`--discover` 扫描 app server，`--session` 只列当前会话期运行过的会话） |
-| `kill <id> [--clear]` | 中断运行中的会话。若会话存在进行中的 goal，会先暂停再中断，否则 app server 会立即启动新一轮继续执行；`--clear` 表示直接放弃该 goal |
-| `follow [id]` | 实时查看运行中的会话，结束时随其状态退出（已结束的会话则回放最近一次运行）。不带 ID 时自动附着到当前工作区的活跃运行；若无活跃运行，则回放最近一次。配合 `--watch` 保持打开并按启动顺序跟踪每一次新运行（每次运行只显示一次） |
+| `run "prompt" [opts]` | 新建会话、发送提示、等待完成并输出结果（`run -` 从标准输入读取提示词） |
+| `review [opts]` | 代码审查（PR、未提交更改或指定 commit） |
+| `threads [--json] [--all]` | 列出会话（`--discover` 扫描 app server，`--session` 只列当前会话期运行过的） |
+| `follow [id]` | 在你自己的终端分屏中实时查看运行中的会话。不带 ID 时自动附着到活跃运行；`--watch` 会持续跟踪每一次新运行 |
 | `output <id> [--last]` | 查看会话完整日志（`--last`: 只输出最近一轮的结果） |
-| `progress <id>` | 查看近期活动（日志尾部） |
-| `peek <id>` | 从 app server 查看最近的会话片段 |
-| `ask "question"` | （供 Codex 在任务中途调用）向协作者提问并等待回答；`--timeout <sec>` 设置等待时限（默认 600 秒）。超时不视为失败：提示 Codex 自行判断并继续，随后以 0 退出 |
-| `answer <id> "text"` | 回答待处理的问题（`answer <id> -` 从标准输入读取回答） |
-| `questions [id]` | 列出当前工作区待处理的问题；带 ID 时显示该问题的完整内容 |
-| `next` | 持续等待，直到出现需要处理的事件（问题或审批）；完整打印事件内容及响应方式后退出 |
-| `config [key] [value]` | 查看或设置持久化默认值 |
-| `models` | 列出可用模型 |
-| `templates` | 列出可用提示词模板 |
-| `skill sync [--yes]` | 当已安装的 SKILL.md 与可执行文件或模板集不一致时重新生成——先打印 diff，确认后才写入 |
-| `update` | 检查 GitHub 上是否有新版本并显示更新日志，经确认后下载、构建并重装——见[升级](#升级) |
-| `health` | 检查依赖项 |
-| `version` | 打印版本号（也可在命令前使用 `-v`/`--version`） |
+| `kill <id> [--clear]` | 中断运行中的会话。若存在进行中的 goal 会先暂停；`--clear` 表示直接放弃 |
 
 <details>
-<summary>会话管理</summary>
+<summary>提问与审批</summary>
 
 | 命令 | 说明 |
 |------|------|
-| `delete <id> [--purge]` | 归档会话（可用 `codex unarchive` 恢复）并删除本地文件；`--purge` 则在服务端永久删除，不可恢复 |
-| `clean` | 清理过期日志和失效映射 |
+| `ask "question"` | 由 Codex 在任务中途调用，向协作者提问并等待回答。`--timeout <sec>` 设置等待时限（默认 600 秒）。超时不视为失败：会提示 Codex 自行判断并继续，随后以 0 退出 |
+| `answer <id> "text"` | 回答待处理的问题（`answer <id> -` 从标准输入读取） |
+| `questions [id]` | 列出当前工作区待处理的问题；带 ID 时显示完整内容 |
+| `next` | 持续等待，直到出现需要处理的事件；完整打印内容及响应方式后退出 |
 | `approve <id>` | 批准待处理的请求 |
 | `decline <id>` | 拒绝待处理的请求 |
+
+</details>
+
+<details>
+<summary>查看与配置</summary>
+
+| 命令 | 说明 |
+|------|------|
+| `progress <id>` | 查看近期活动（日志尾部） |
+| `peek <id>` | 从 app server 查看最近的会话片段 |
+| `config [key] [value]` | 查看或设置持久化默认值 |
+| `models` | 列出可用模型 |
+| `templates` | 列出可用提示词模板 |
+
+</details>
+
+<details>
+<summary>维护</summary>
+
+| 命令 | 说明 |
+|------|------|
+| `delete <id> [--purge]` | 归档会话（可用 `codex unarchive` 恢复）并删除本地文件；`--purge` 则在服务端永久删除 |
+| `clean` | 清理过期日志和失效映射 |
+| `skill sync [--yes]` | 当已安装的 SKILL.md 与可执行文件或模板集不一致时重新生成。先打印 diff，确认后才写入 |
+| `update` | 检查是否有新版本，确认后下载安装。详见[升级](#升级) |
+| `health` | 检查依赖项与登录状态 |
+| `version` | 打印版本号（也可在命令前使用 `-v`/`--version`） |
 
 </details>
 
@@ -262,8 +291,6 @@ codex-collab config --unset             # 取消所有设置
 
 ## 相关链接
 
-如果只需更轻量的交互，不妨试试官方的 [Codex MCP server](https://developers.openai.com/codex/guides/agents-sdk)。codex-collab 则专为 Claude Code skill 场景打造，内置代码审查、会话管理与实时进度推送。
-
-本项目 broker 的常驻 app-server 思路，受 OpenAI 官方 Claude Code 插件 [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 启发。
+如果只需更轻量的交互，不妨试试官方的 [Codex MCP server](https://developers.openai.com/codex/guides/agents-sdk)。OpenAI 也提供了官方的 [Claude Code Codex 插件](https://github.com/openai/codex-plugin-cc)，以斜杠命令为主，需要你自行调用。codex-collab 要你做的更少：把需求用自己的话说给 Claude，它会在后台调用 Codex，再把结论带回给你。
 
 感谢 [LINUX DO](https://linux.do/) 社区的反馈与支持。

--- a/SKILL.md
+++ b/SKILL.md
@@ -248,11 +248,11 @@ Note: `jobs` still works as a deprecated alias for `threads`.
 |------|-------------|
 | `-m, --model <model>` | Model name (default: auto — latest available) |
 | `-r, --reasoning <level>` | Reasoning effort: none, minimal, low, medium, high, xhigh, max, ultra (default: auto — highest the model supports, up to `xhigh`) |
-| `-s, --sandbox <mode>` | Sandbox: read-only, workspace-write, danger-full-access (default: workspace-write; review always uses read-only) |
+| `-s, --sandbox <mode>` | Sandbox: read-only, workspace-write, danger-full-access (default: workspace-write). **`review` rejects this flag** (exit 1) — reviews always run read-only, so don't pass it even to restate the default |
 | `-d, --dir <path>` | Working directory (default: cwd) |
 | `--resume <id>` | Resume existing thread (run and review) |
 | `--timeout <sec>` | (run, review) Turn timeout in seconds (default: 1200). Do not lower this — Codex tasks routinely take 5-15 minutes; increase for large reviews or complex tasks. When a goal is active the timeout scopes the WHOLE goal and expiry pauses it (see Goal Mode). (ask) Answer deadline, default 600. (next) Wait bound, default none — it waits until an event or workspace idle. |
-| `--approval <policy>` | never, on-request, on-failure, untrusted, auto (default: never) — see Approvals |
+| `--approval <policy>` | never, on-request, on-failure, untrusted, auto (default: never) — see Approvals. **`review` rejects this flag** (exit 1): Codex locks review sub-agents to `never`, so it could never take effect |
 | `--memory` | Let Codex's memory feature learn from threads this run creates (default: created threads are excluded so agent-driven sessions don't shape Codex's picture of the user) |
 | `--detach` | (run) Return once the turn is running — see Detached Runs |
 | `-w, --watch` | (follow) Keep following each new run instead of exiting — see Detached Runs |
@@ -264,8 +264,8 @@ Note: `jobs` still works as a deprecated alias for `threads`.
 | `--json` | JSON output (threads, peek commands) |
 | `--full` | Include all item types in peek output (default shows messages only) |
 | `--template <name>` | Prompt template for run command (checks `~/.codex-collab/templates/` first, then built-in) |
-| `--goal <objective>` | (run) Create the thread's goal before the first turn (replaces the objective on `--resume`) — see Goal Mode |
-| `--budget <tokens>` | (run) Token budget for `--goal`. Size generously — usage counts each turn's full context, so a single small turn can consume ~60k |
+| `--goal <objective>` | (run) Create the thread's goal before the first turn (replaces the objective on `--resume`) — see Goal Mode. Still needs a prompt: the prompt is turn one, the goal is the standing objective. **`review` rejects this flag** (exit 1) — a review is a single turn on an ephemeral thread |
+| `--budget <tokens>` | (run) Token budget for `--goal`. Size generously — usage counts each turn's full context, so a single small turn can consume ~60k. **`review` rejects this flag** (exit 1) |
 | `--content-only` | Print only result text (no progress lines) |
 | `--last` | (output) Only the latest turn's output, not the whole thread history (implies `--content-only`) |
 | `--session` | (threads) Only threads the current session has run |

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -310,6 +310,13 @@ process.stdin.on("data", (chunk) => {
         respond({ id: msg.id, result: { data: [], nextCursor: null } });
         break;
 
+      case "model/list":
+        respond({ id: msg.id, result: {
+          data: [{ id: "mock-model", description: "mock", supportedReasoningEfforts: [] }],
+          nextCursor: null,
+        }});
+        break;
+
       default:
         respond({ id: msg.id, error: { code: -32601, message: "Method not found: " + msg.method } });
     }
@@ -1069,6 +1076,42 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
           includeTurns: false,
         }) as { thread: { id: string } };
         expect(readResult.thread.id).toBe("thread-001");
+
+        await client1.close();
+        await client2.close();
+      } finally {
+        proc.kill();
+      }
+    }, 15_000);
+
+    test("model/list allowed from different socket during active stream", async () => {
+      // `models` makes exactly one server call, and withClient's busy→direct
+      // fallback is streaming-only, so if model/list is not on the read-only
+      // allowlist it is the one read that hard-fails on a busy broker.
+      const sockPath = join(tempDir, "broker.sock");
+      const endpoint = `unix:${sockPath}`;
+      const mockDir = createMockCodex(tempDir, {
+        sendTurnCompleted: false,
+      });
+
+      const proc = spawnBroker(endpoint, mockDir);
+      await waitForSocket(sockPath);
+
+      try {
+        const client1 = await TestClient.connectAndInit(sockPath);
+        const client2 = await TestClient.connectAndInit(sockPath);
+
+        await client1.request("turn/start", {
+          threadId: "thread-001",
+          input: [{ type: "text", text: "hello" }],
+        });
+
+        await new Promise((r) => setTimeout(r, 100));
+
+        const result = await client2.request("model/list", {
+          includeHidden: true,
+        }) as { data: unknown[] };
+        expect(result.data.length).toBe(1);
 
         await client1.close();
         await client2.close();

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -602,7 +602,10 @@ async function main() {
       message.method === "turn/interrupt";
     const isReadOnly =
       typeof message.method === "string" &&
-      (message.method === "thread/read" || message.method === "thread/list");
+      (message.method === "thread/read" ||
+        message.method === "thread/list" ||
+        message.method === "model/list" ||
+        message.method === "account/read");
     const isGoalOp =
       typeof message.method === "string" &&
       (message.method === "thread/goal/get" ||
@@ -612,9 +615,12 @@ async function main() {
     // Allow interrupt, read-only, and goal requests through even when
     // another client owns the stream — but only when there's no pending
     // request. Read-only methods are needed by `kill` (reads thread to get
-    // turn ID) and `threads` (lists threads while a turn is running); goal
-    // ops are needed by `kill`/`kill --clear` to brake a goal whose
-    // following run owns the stream for the goal's whole lifetime.
+    // turn ID), `threads`/`peek` (read while a turn is running), and `models`
+    // (`model/list` is the only server call it makes, and withClient's
+    // busy→direct fallback is streaming-only, so without this it is the one
+    // read that hard-fails on a busy broker); goal ops are needed by
+    // `kill`/`kill --clear` to brake a goal whose following run owns the
+    // stream for the goal's whole lifetime.
     const allowDuringActiveStream =
       (isInterrupt || isReadOnly || isGoalOp) &&
       activeStreamSocket !== null &&

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,7 +1,7 @@
 // src/commands/config.ts — config, models, health command handlers
 
 import { config, listTemplates } from "../config";
-import type { Model } from "../types";
+import type { Model, AccountRead } from "../types";
 import {
   die,
   parseOptions,
@@ -115,6 +115,40 @@ export async function handleModels(args: string[]): Promise<void> {
 // health
 // ---------------------------------------------------------------------------
 
+/** Classify `account/read` into a health verdict.
+ *
+ *  Fails OPEN on anything inconclusive. A false "not authenticated" is the
+ *  worse error here: it tells a working user their setup is broken. Only the
+ *  case where Codex reports no account AND says it needs OpenAI credentials
+ *  is treated as a real failure. */
+export function describeAuth(read: AccountRead | "unknown"): { ready: boolean; detail: string } {
+  if (read === "unknown") {
+    return { ready: true, detail: "not reported (this codex build may predate account/read)" };
+  }
+  const account = read.account ?? null;
+  if (account?.type === "chatgpt") {
+    const who = [account.planType, account.email].filter(Boolean).join(" — ");
+    return { ready: true, detail: who ? `ChatGPT login active (${who})` : "ChatGPT login active" };
+  }
+  if (account?.type === "apiKey") {
+    // Presence is not validity — the key is only proven by a real request.
+    return { ready: true, detail: "API key configured (not verified here)" };
+  }
+  if (read.requiresOpenaiAuth === false) {
+    return { ready: true, detail: "provider configured; OpenAI authentication not required" };
+  }
+  if (account?.type) {
+    return { ready: true, detail: `${account.type} (unrecognized account type — assuming usable)` };
+  }
+  // No account. Only an explicit "OpenAI auth IS required" makes that a real
+  // failure: `requiresOpenaiAuth` is optional and nullable, so an absent or
+  // null flag is inconclusive and must not be reported as logged out.
+  if (read.requiresOpenaiAuth === true) {
+    return { ready: false, detail: "NOT AUTHENTICATED" };
+  }
+  return { ready: true, detail: "not reported (no account and no auth requirement given)" };
+}
+
 export async function handleHealth(args: string[]): Promise<void> {
   const { options } = parseOptions(args);
   const findCmd = process.platform === "win32" ? "where" : "which";
@@ -128,12 +162,34 @@ export async function handleHealth(args: string[]): Promise<void> {
   // `where` on Windows returns multiple matches; show only the first
   console.log(`  codex: ${which.stdout.toString().trim().split("\n")[0].trim()}`);
 
+  let account: AccountRead | "unknown" = "unknown";
   try {
-    const userAgent = await withClient(async (client) => client.userAgent, options.dir);
-    console.log(`  app-server: OK (${userAgent})`);
+    account = await withClient(async (client) => {
+      console.log(`  app-server: OK (${client.userAgent})`);
+      // A failure here must not fail the whole check: older codex builds may
+      // not know account/read, and a busy broker or transient RPC error is
+      // not evidence that the user is logged out.
+      try {
+        return await client.request<AccountRead>("account/read", { refreshToken: false });
+      } catch {
+        return "unknown" as const;
+      }
+    }, options.dir);
   } catch (e) {
     console.log(`  app-server: FAILED (${e instanceof Error ? e.message : e})`);
     process.exit(1);
+  }
+
+  const auth = describeAuth(account);
+  console.log(`  account: ${auth.detail}`);
+
+  // Missing auth is reported, never fatal. This command's exit code answers
+  // "is the installation sound?" — install.sh runs it as its own final check,
+  // so failing here would tell anyone who installs before `codex login` that
+  // their installation is broken. Logging in is a separate, later step.
+  if (!auth.ready) {
+    console.log("\nHealth check passed, but Codex is not authenticated — run 'codex login' before your first task.");
+    return;
   }
 
   console.log("\nHealth check passed.");

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,13 +2,14 @@
 
 import { spawn as childSpawn, spawnSync } from "node:child_process";
 import { openSync, closeSync, readFileSync } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
 import { updateThreadStatus, generateRunId, loadRun, updateRun, runLogRelPath } from "../threads";
 import { runTurnWithGoalFollow } from "../turns";
 import { goalNeedsAttention, setThreadGoal, readThreadGoal, pauseThreadGoal, isGoalFeatureUnavailable, GOAL_COLLAB_ASK_NOTE } from "../goals";
 import type { RunGoalState, ThreadGoal } from "../types";
 import { config, loadTemplateWithMeta, interpolateTemplate, type SandboxMode } from "../config";
 import { wrapBrokerBusy, isBrokerBusyError } from "../broker";
+import { shellQuote } from "../approvals";
 import {
   die,
   parseOptions,
@@ -135,16 +136,21 @@ async function detachRun(
       // Record exists = thread/start succeeded. Now wait for the turn:
       // the child bumps phase past "starting" when turn/start responds.
       if (rec.status === "running" && rec.phase !== "starting") {
+        // Carry -d into every hint. These commands exist to be pasted into a
+        // SECOND terminal, and thread IDs resolve only within their own
+        // workspace — without it the pane that follows a detached run has to
+        // already be in the project directory. `next` does the same.
+        const d = ` -d ${shellQuote(resolve(options.dir))}`;
         progress(`Detached: thread ${rec.shortId} running${rec.model ? ` (${rec.model})` : ""}`);
-        progress(`  Follow:   codex-collab follow ${rec.shortId}`);
-        progress(`  Output:   codex-collab output ${rec.shortId}`);
-        progress(`  Kill:     codex-collab kill ${rec.shortId}`);
+        progress(`  Follow:   codex-collab follow ${rec.shortId}${d}`);
+        progress(`  Output:   codex-collab output ${rec.shortId}${d}`);
+        progress(`  Kill:     codex-collab kill ${rec.shortId}${d}`);
         process.exit(0);
       }
       if (rec.status === "completed") {
         // Turn finished before we even noticed it start — report done.
         progress(`Detached run already completed: thread ${rec.shortId}`);
-        progress(`  Output:   codex-collab output ${rec.shortId}`);
+        progress(`  Output:   codex-collab output ${rec.shortId} -d ${shellQuote(resolve(options.dir))}`);
         process.exit(0);
       }
       if (rec.status === "interrupted") {

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -18,6 +18,7 @@ import {
   recordTerminalRunState,
   recordRunFailure,
   resolveThreadIdAllowRaw,
+  explainErrorInfo,
   VALID_REVIEW_MODES,
   type WorkspacePaths,
   type Options,
@@ -2046,6 +2047,32 @@ describe("stdin prompt marker", () => {
   test("bare '-' is a positional, not an unknown option", () => {
     const { positional } = parseOptions(["-", "--content-only"]);
     expect(positional).toEqual(["-"]);
+  });
+});
+
+describe("explainErrorInfo", () => {
+  test("a capacity blip and a spent quota give opposite advice", () => {
+    // The whole point of reading the typed variant: these two read almost
+    // identically in prose but want opposite responses from the caller.
+    expect(explainErrorInfo("serverOverloaded")).toMatch(/retry/i);
+    expect(explainErrorInfo("usageLimitExceeded")).toMatch(/same limit/i);
+  });
+
+  test("context and auth failures name their own remedy", () => {
+    expect(explainErrorInfo("contextWindowExceeded")).toMatch(/fresh thread/i);
+    expect(explainErrorInfo("unauthorized")).toMatch(/codex login/i);
+  });
+
+  test("object variants and absent info explain nothing", () => {
+    // These already carry an HTTP status in the message; adding prose would
+    // just talk over it.
+    expect(explainErrorInfo({ httpConnectionFailed: { httpStatusCode: 503 } })).toBeNull();
+    expect(explainErrorInfo(null)).toBeNull();
+    expect(explainErrorInfo(undefined)).toBeNull();
+  });
+
+  test("an unknown string variant explains nothing rather than guessing", () => {
+    expect(explainErrorInfo("other")).toBeNull();
   });
 });
 

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -17,6 +17,7 @@ import {
   defaultOptions,
   recordTerminalRunState,
   recordRunFailure,
+  resolveThreadIdAllowRaw,
   VALID_REVIEW_MODES,
   type WorkspacePaths,
   type Options,
@@ -2045,5 +2046,50 @@ describe("stdin prompt marker", () => {
   test("bare '-' is a positional, not an unknown option", () => {
     const { positional } = parseOptions(["-", "--content-only"]);
     expect(positional).toEqual(["-"]);
+  });
+});
+
+describe("resolveThreadIdAllowRaw", () => {
+  test("passes an unindexed server thread UUID through as a raw ID", () => {
+    const uuid = "019f983b-07c3-7b91-aeba-e5edca9d20ab";
+    const { threadId, shortId } = resolveThreadIdAllowRaw(tmpRoot, uuid);
+    expect(threadId).toBe(uuid);
+    expect(shortId).toBeNull();
+  });
+
+  test("accepts the urn:uuid: prefixed form", () => {
+    const id = "urn:uuid:019f983b-07c3-7b91-aeba-e5edca9d20ab";
+    const { threadId, shortId } = resolveThreadIdAllowRaw(tmpRoot, id);
+    expect(threadId).toBe(id);
+    expect(shortId).toBeNull();
+  });
+
+  test("an unindexed non-UUID is 'Thread not found', not a raw server ID", () => {
+    // Without the shape check the string is forwarded verbatim as a thread ID:
+    // every RPC then fails with the server's "invalid thread id" parse error
+    // while `kill` still prints "Stopped thread <id>" and exits 0.
+    const result = Bun.spawnSync({
+      cmd: ["bun", "-e", `
+        import { resolveThreadIdAllowRaw } from "./src/commands/shared";
+        resolveThreadIdAllowRaw(${JSON.stringify(tmpRoot)}, "nonexistent1");
+      `],
+      cwd: process.cwd(),
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain('Thread not found: "nonexistent1"');
+  });
+
+  test("a truncated UUID is rejected too", () => {
+    const result = Bun.spawnSync({
+      cmd: ["bun", "-e", `
+        import { resolveThreadIdAllowRaw } from "./src/commands/shared";
+        resolveThreadIdAllowRaw(${JSON.stringify(tmpRoot)}, "019f983b-07c3-7b91-aeba");
+      `],
+      cwd: process.cwd(),
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("Thread not found");
   });
 });

--- a/src/commands/shared.test.ts
+++ b/src/commands/shared.test.ts
@@ -18,6 +18,7 @@ import {
   recordTerminalRunState,
   recordRunFailure,
   resolveThreadIdAllowRaw,
+  resolveThreadIdOrDie,
   explainErrorInfo,
   VALID_REVIEW_MODES,
   type WorkspacePaths,
@@ -2105,6 +2106,23 @@ describe("resolveThreadIdAllowRaw", () => {
     });
     expect(result.exitCode).toBe(1);
     expect(result.stderr.toString()).toContain('Thread not found: "nonexistent1"');
+  });
+
+  test("the not-found error names workspace scoping as the likely cause", () => {
+    // A thread ID copied from a run started in another project resolves
+    // nowhere here. A bare "not found" reads as if the thread were gone,
+    // sending people to look for a bug instead of passing -d.
+    const result = Bun.spawnSync({
+      cmd: ["bun", "-e", `
+        import { resolveThreadIdOrDie } from "./src/commands/shared";
+        resolveThreadIdOrDie(${JSON.stringify(tmpRoot)}, "a1b2c3d4");
+      `],
+      cwd: process.cwd(),
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("per-workspace");
+    expect(result.stderr.toString()).toContain("-d <path>");
   });
 
   test("a truncated UUID is rejected too", () => {

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -242,7 +242,10 @@ export function validateIdOrDie(id: string): string {
 export function resolveThreadIdOrDie(stateDir: string, id: string): string {
   try {
     const resolved = resolveThreadId(stateDir, id);
-    if (!resolved) die(`Thread not found: "${id}"`);
+    // Name the most likely cause: threads are indexed per workspace, so an ID
+    // copied from a run started elsewhere resolves nowhere here, and the bare
+    // "not found" reads as if the thread were gone rather than out of scope.
+    if (!resolved) die(`Thread not found: "${id}" in this workspace — threads are per-workspace, so run this from the project directory or pass -d <path>.`);
     return resolved.threadId;
   } catch (e) {
     die(e instanceof Error ? e.message : String(e));

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -254,6 +254,11 @@ export function resolveThreadIdOrDie(stateDir: string, id: string): string {
  *  Codex TUI or another workspace that were never discovered locally.
  *  Ambiguous prefixes and index corruption still die. Callers must
  *  validateIdOrDie(id) first. */
+/** Shape of a server thread ID: a hyphenated UUID, optionally `urn:uuid:`-
+ *  prefixed (the form the server's own parse error names). */
+const RAW_THREAD_ID_RE =
+  /^(?:urn:uuid:)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 export function resolveThreadIdAllowRaw(
   stateDir: string,
   id: string,
@@ -264,6 +269,12 @@ export function resolveThreadIdAllowRaw(
   } catch (e) {
     die(e instanceof Error ? e.message : String(e));
   }
+  // Not in the local index. `validateId` only guarantees path-safety, so
+  // without a shape check a mistyped short ID is forwarded verbatim as a raw
+  // server thread ID: every RPC then fails with the server's "invalid thread
+  // id" parse error while the caller still reports success on a thread that
+  // never existed. Fail like the indexed lookup does instead.
+  if (!RAW_THREAD_ID_RE.test(id)) die(`Thread not found: "${id}"`);
   return { threadId: id, shortId: null };
 }
 

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -53,6 +53,7 @@ import type {
   TurnResult,
   RunRecord,
   ApprovalsReviewer,
+  CodexErrorInfo,
 } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -1216,6 +1217,26 @@ export function pluralize(n: number, word: string): string {
  *  blobs — e.g. the 400 for `-r minimal` on accounts whose built-in tools
  *  (image_gen, web_search) require a higher effort. Extract the human
  *  message; fall back to the raw string for anything unrecognized. */
+/** What the server's typed error classification means for the caller, and
+ *  whether trying again can help. The message text alone can't carry this:
+ *  a capacity blip and a spent quota read almost identically in prose but
+ *  want opposite responses. */
+export function explainErrorInfo(info: CodexErrorInfo | null | undefined): string | null {
+  if (typeof info !== "string") return null; // object variants carry HTTP detail already
+  switch (info) {
+    case "serverOverloaded":
+      return "The model is at capacity — this is transient. Retry, or pin a different model with -m (see `codex-collab models`).";
+    case "usageLimitExceeded":
+      return "Usage limit reached for this account — retrying will hit the same limit.";
+    case "contextWindowExceeded":
+      return "The thread outgrew the model's context window — start a fresh thread, or narrow the task.";
+    case "unauthorized":
+      return "Codex rejected the credentials — check `codex login` (or your API key) and retry.";
+    default:
+      return null;
+  }
+}
+
 export function humanizeTurnError(raw: string): string {
   const jsonStart = raw.indexOf("{");
   if (jsonStart === -1) return raw;
@@ -1248,6 +1269,8 @@ export function printResult(
   if (result.error) {
     const msg = humanizeTurnError(result.error);
     console.error(`\nError: ${msg}`);
+    const explained = explainErrorInfo(result.errorInfo);
+    if (explained) console.error(explained);
     if (/reasoning\.effort/i.test(msg)) {
       console.error("Tip: this account's built-in tools need a higher reasoning effort — retry with -r low or higher.");
     }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, realpathSync } from "fs";
 import { join, basename, resolve, sep } from "path";
 import { createHash } from "crypto";
+import { describeAuth } from "./commands/config";
 import {
   config,
   validateId,
@@ -292,5 +293,57 @@ describe("interpolateTemplate", () => {
   test("replaces multiple occurrences of the same variable", () => {
     const result = interpolateTemplate("{{X}} and {{X}}", { X: "y" });
     expect(result).toBe("y and y");
+  });
+});
+
+describe("describeAuth (health account check)", () => {
+  test("ChatGPT login is ready and names the plan and email", () => {
+    const r = describeAuth({
+      account: { type: "chatgpt", email: "a@b.com", planType: "pro" },
+      requiresOpenaiAuth: true,
+    });
+    expect(r.ready).toBe(true);
+    expect(r.detail).toContain("pro");
+    expect(r.detail).toContain("a@b.com");
+  });
+
+  test("an API key counts as ready, but is reported as unverified", () => {
+    // Presence of a key is not proof it works — don't claim more than we know.
+    const r = describeAuth({ account: { type: "apiKey" }, requiresOpenaiAuth: true });
+    expect(r.ready).toBe(true);
+    expect(r.detail).toMatch(/not verified/i);
+  });
+
+  test("a provider needing no OpenAI auth is ready even with no account", () => {
+    // Third-party base URL / proxy setups: no OpenAI credentials exist by design.
+    const r = describeAuth({ account: null, requiresOpenaiAuth: false });
+    expect(r.ready).toBe(true);
+  });
+
+  test("an unrecognized account type fails open", () => {
+    const r = describeAuth({ account: { type: "somethingNew" }, requiresOpenaiAuth: true });
+    expect(r.ready).toBe(true);
+  });
+
+  test("an unavailable account/read fails open", () => {
+    // Older codex builds, a busy broker, a transient RPC error — none of these
+    // are evidence the user is logged out.
+    expect(describeAuth("unknown").ready).toBe(true);
+  });
+
+  test("no account plus requiresOpenaiAuth is the only failure", () => {
+    const r = describeAuth({ account: null, requiresOpenaiAuth: true });
+    expect(r.ready).toBe(false);
+    expect(r.detail).toMatch(/NOT AUTHENTICATED/);
+  });
+
+  test("no account and no stated auth requirement is inconclusive, not logged out", () => {
+    // requiresOpenaiAuth is optional and nullable. Absent or null says nothing
+    // about whether credentials exist, so reporting it as logged out would tell
+    // a working user to run `codex login`.
+    expect(describeAuth({ account: null }).ready).toBe(true);
+    expect(describeAuth({ account: null, requiresOpenaiAuth: null }).ready).toBe(true);
+    expect(describeAuth({}).ready).toBe(true);
+    expect(describeAuth({ account: null }).detail).not.toMatch(/NOT AUTHENTICATED/);
   });
 });

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -442,6 +442,7 @@ export async function runTurnWithGoalFollow(
 
       let lastTurnStatus: TurnResult["status"] = first.status;
       let lastTurnError: string | undefined = first.error;
+      let lastTurnErrorInfo: TurnResult["errorInfo"] = first.errorInfo ?? null;
       for (;;) {
         if (connectionDown !== null) throw connectionDown;
         if (goal === null || goal.status !== "active") break;
@@ -484,6 +485,7 @@ export async function runTurnWithGoalFollow(
           ]);
           lastTurnStatus = completed.turn.status as TurnResult["status"];
           lastTurnError = completed.turn.error?.message;
+          lastTurnErrorInfo = completed.turn.error?.codexErrorInfo ?? null;
         } catch (e) {
           if (e instanceof KillSignalError) {
             return await finishKilled(turnId);
@@ -521,6 +523,7 @@ export async function runTurnWithGoalFollow(
         filesChanged: opts.dispatcher.getFilesChanged(),
         commandsRun: opts.dispatcher.getCommandsRun(),
         error: lastTurnError,
+        errorInfo: lastTurnErrorInfo,
         durationMs: 0,
       });
     } finally {
@@ -885,6 +888,7 @@ async function executeTurn(
       filesChanged: opts.dispatcher.getFilesChanged(),
       commandsRun: opts.dispatcher.getCommandsRun(),
       error: completedTurn.turn.error?.message,
+      errorInfo: completedTurn.turn.error?.codexErrorInfo ?? null,
       durationMs: Date.now() - startTime,
     };
   } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -518,6 +518,10 @@ export interface TurnResult {
   filesChanged: FileChange[];
   commandsRun: CommandExec[];
   error?: string;
+  /** The server's typed classification of `error`, when it sent one. The
+   *  message alone is prose and varies; this says which failure it IS, so
+   *  the CLI can tell a transient overload from a spent quota. */
+  errorInfo?: CodexErrorInfo | null;
   durationMs: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,21 @@ export interface TurnStartResponse {
   turn: Turn;
 }
 
+/** `account/read`. `type` is open-ended ("chatgpt", "apiKey", …) — treat an
+ *  unrecognized value as inconclusive rather than as logged out. */
+export interface CodexAccount {
+  type?: string | null;
+  email?: string | null;
+  planType?: string | null;
+}
+
+export interface AccountRead {
+  account?: CodexAccount | null;
+  /** False when the configured provider needs no OpenAI credentials at all
+   *  (third-party base URL) — such a setup is authenticated by definition. */
+  requiresOpenaiAuth?: boolean | null;
+}
+
 // --- Items ---
 
 /** Known item types with proper discriminants. */


### PR DESCRIPTION
Small fixes for failures that reported the wrong thing, plus documentation corrections.

## Fixes

**`models` died on a busy broker.** `model/list` was on neither the broker's during-active-stream allowlist nor eligible for `withClient`'s busy retry (which is streaming-only), so it was the one read that hard-failed with a raw `-32001` while a turn was in flight. `thread/read`, `thread/list` and the goal ops were already allowed; `model/list` and `account/read` now join them, so reads continue to be served off the running app-server rather than costing a second one.

**`kill <bogus-id>` reported success.** `validateId` only guarantees path-safety, so an ID that wasn't in the local index was forwarded verbatim as a raw server thread ID. Every RPC then failed with the server's "invalid thread id" parse error, and `kill` still printed `Stopped thread <id>` and exited 0. `resolveThreadIdAllowRaw` now requires a UUID shape before treating an unindexed ID as a server ID, which also fixes the same false-success in `delete` and the leaked parse error in `peek`.

**`health` passed while logged out.** It checked the `codex` binary, bun, and the app-server handshake — none of which require authentication — so a user who had installed correctly but never run `codex login` got a clean pass, then an opaque failure on their first run. It now reports account state via `account/read`.

The check fails **open** on anything inconclusive: API-key accounts and providers that need no OpenAI credentials at all (`requiresOpenaiAuth === false`) both count as ready, as does an unrecognized account type or an unavailable `account/read`. Only "no account, and OpenAI auth is required" is treated as a failure. A false "not authenticated" would be the worse error, since it tells a working user their setup is broken.

**Typed error info was discarded.** `error.codexErrorInfo` was declared in `types.ts` and read by nothing; `turns.ts` used only `error.message`. It is now carried on `TurnResult` and explained where it helps: `serverOverloaded` says to retry, `usageLimitExceeded` says retrying will hit the same limit, `contextWindowExceeded` and `unauthorized` name their own remedy. Unrecognized variants explain nothing rather than guessing.

## Docs

`review` rejects `-s`, `--approval`, `--goal` and `--budget` as of v0.3.1, but SKILL.md still implied `-s` was merely redundant, and the `--goal`/`--budget` rejection was documented nowhere. `--goal` also still requires a prompt, which the READMEs' goal-mode line omitted. Install notes now cover the PATH and skill-discovery cases that apply when the installer runs inside an existing session. Both READMEs kept in sync.

## Testing

`bun test`: 754 pass, 0 fail. `tsc --noEmit` clean. New regression tests were each confirmed to fail with the corresponding source change reverted.

Verified against a live app-server: `models` under a held stream, `kill`/`peek`/`delete` on a bogus ID, `health` reporting an account, and a raw probe confirming the server populates `codexErrorInfo` on both the `error` notification and `turn/completed`.

## Not included

Automatic retry on `serverOverloaded`. `ErrorNotificationParams` carries `willRetry`, so the app-server already retries some transient failures itself, and a client-side retry stacked on that would multiply attempts. Whether "Selected model is at capacity" maps to `serverOverloaded` is also still unconfirmed. Worth revisiting once a real capacity event can be observed.
