### PR TITLE
fix: serialize app-server startup, and stop the broker orphaning one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ docs/
 # Bare git repo artifacts
 HEAD
 config
+config.lock
+config.worktree
 hooks
 objects
 refs

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -24,14 +24,40 @@ beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "broker-server-test-"));
 });
 
+/**
+ * rm -rf, tolerating Windows' asynchronous handle release.
+ *
+ * Windows refuses to remove a directory while any process still holds a
+ * handle inside it, and releases those handles some time after exit. Unix
+ * does not care, which is why this only surfaced once the suite ran on
+ * Windows: every test in the file failed in teardown, whatever the test
+ * itself did.
+ */
+async function removeDirWithRetry(dir: string, attempts = 40): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code !== "EBUSY" && code !== "ENOTEMPTY" && code !== "EPERM") throw e;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+  // Give up quietly. A leftover temp directory the OS will reap is not worth
+  // failing an otherwise-passing suite over.
+}
+
 afterEach(async () => {
   // Kill any broker processes we spawned
   for (const proc of spawnedProcesses) {
     try { proc.kill(); } catch {}
   }
+  // Wait for them to actually be gone before touching the directory they
+  // live in — see removeDirWithRetry. Killing only sends the signal.
+  await Promise.all(spawnedProcesses.map((p) => p.exited.catch(() => undefined)));
   spawnedProcesses.length = 0;
-  // Clean up temp dir
-  rmSync(tempDir, { recursive: true, force: true });
+  await removeDirWithRetry(tempDir);
 });
 
 const spawnedProcesses: Subprocess[] = [];

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import net from "node:net";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Subprocess } from "bun";
 
@@ -44,6 +44,67 @@ const spawnedProcesses: Subprocess[] = [];
  * It also supports sending notifications (item/started, turn/completed) after
  * turn/start, and server-sent approval requests when MOCK_SEND_APPROVAL=1.
  */
+/**
+ * A connectable address for a broker under test.
+ *
+ * Unix gets a socket file inside the per-test temp dir. Windows gets a named
+ * pipe — the transport the broker already uses there (`createEndpoint`) — but
+ * the pipe namespace is GLOBAL and outlives any directory, so the name is
+ * derived from the per-test dir (mkdtempSync guarantees uniqueness) plus the
+ * pid, or a stale pipe from another test would be connected to instead.
+ */
+function testSocketPath(dir: string): string {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\codex-collab-test-${process.pid}-${basename(dir)}`;
+  }
+  return join(dir, "broker.sock");
+}
+
+/** The `--endpoint` argument for a path from {@link testSocketPath}. */
+function endpointFor(socketPath: string): string {
+  return process.platform === "win32" ? `pipe:${socketPath}` : `unix:${socketPath}`;
+}
+
+/**
+ * Materialize a mock `codex` that the broker will find on PATH.
+ *
+ * Unix takes a shebang script named `codex`. Windows can run neither form — a
+ * shebang is not executable, and an extensionless file is not resolvable on
+ * PATH at all — so the body ships as a `.ts` beside a `codex.cmd` shim. That
+ * is the same shape npm installs, and the one `connectDirect` already expects
+ * (it wraps commands in `cmd.exe /c` on Windows for exactly this reason).
+ *
+ * `@echo off` is load-bearing: the mock's stdout IS the JSON-RPC channel, and
+ * an echoed command line would corrupt the stream before the handshake.
+ */
+function writeMockCodexScript(dir: string, script: string): void {
+  if (process.platform === "win32") {
+    writeFileSync(join(dir, "codex-mock.ts"), script);
+    writeFileSync(join(dir, "codex.cmd"), `@echo off\r\nbun run "%~dp0codex-mock.ts" %*\r\n`);
+    return;
+  }
+  writeFileSync(join(dir, "codex"), script, { mode: 0o755 });
+}
+
+/**
+ * `process.env` with `dir` prepended to PATH, using the platform separator.
+ *
+ * Windows env names are case-insensitive, but a spread of `process.env` is a
+ * plain object: an inherited `Path` would sit beside our `PATH` and either
+ * could win. Drop every casing before setting ours.
+ */
+function envWithPathPrefix(dir: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  let inherited = "";
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v === undefined) continue;
+    if (k.toLowerCase() === "path") { inherited = v; continue; }
+    env[k] = v;
+  }
+  env.PATH = `${dir}${delimiter}${inherited}`;
+  return env;
+}
+
 function createMockCodex(dir: string, opts?: {
   /** Delay in ms before responding to turn/start */
   turnDelay?: number;
@@ -91,7 +152,6 @@ function createMockCodex(dir: string, opts?: {
   const goalFastFirstTurn = opts?.goalFastFirstTurn ?? false;
 
   const interruptLog = join(dir, "interrupts.log");
-  const scriptPath = join(dir, "codex");
   const script = `#!/usr/bin/env bun
 import { appendFileSync } from "node:fs";
 // Mock codex app-server for broker-server tests
@@ -327,7 +387,7 @@ process.stdin.on("end", () => process.exit(0));
 process.stdin.on("error", () => process.exit(1));
 `;
 
-  writeFileSync(scriptPath, script, { mode: 0o755 });
+  writeMockCodexScript(dir, script);
   return dir; // The dir to prepend to PATH
 }
 
@@ -351,10 +411,7 @@ function spawnBroker(
   }
 
   const proc = Bun.spawn(["bun", ...args], {
-    env: {
-      ...process.env,
-      PATH: `${mockCodexDir}:${process.env.PATH}`,
-    },
+    env: envWithPathPrefix(mockCodexDir),
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
@@ -557,13 +614,14 @@ async function exitsWithin(proc: Subprocess, timeoutMs: number): Promise<boolean
 // ─── Socket support detection ────────────────────────────────────────────────
 
 // These integration tests spawn a real broker-server subprocess with a mock
-// codex script (bash shebang) and connect via Unix socket. They require:
-// 1. Unix platform (the mock script uses #!/usr/bin/env bun)
-// 2. Unix socket support (not restricted by sandbox)
+// codex on PATH and connect over the broker's own transport — a Unix socket,
+// or a named pipe on Windows, which broker-server already supports (every
+// Unix-only branch there is guarded by `listenTarget.kind === "unix"`). The
+// only requirement left is being able to bind one, which a sandbox can deny.
 const IS_UNIX = process.platform !== "win32";
-const SOCKETS_AVAILABLE = IS_UNIX && await (async () => {
+const SOCKETS_AVAILABLE = await (async () => {
   const checkDir = mkdtempSync(join(tmpdir(), "broker-sock-check-"));
-  const testSock = join(checkDir, "test.sock");
+  const testSock = testSocketPath(checkDir);
   try {
     const srv = net.createServer();
     await new Promise<void>((resolve, reject) => {
@@ -578,6 +636,17 @@ const SOCKETS_AVAILABLE = IS_UNIX && await (async () => {
   }
 })();
 
+// Say so out loud. This gate degrades on the ENVIRONMENT, not on a choice, so
+// a run under a sandbox that blocks socket bind reports "0 fail" and exit 0
+// while covering none of broker-server.ts. A skip count is not a signal
+// anyone reads; a warning is.
+if (!SOCKETS_AVAILABLE) {
+  console.warn(
+    `\n⚠️  broker-server suite SKIPPED — cannot bind ${IS_UNIX ? "a Unix socket" : "a named pipe"} here (sandbox or filesystem restriction).` +
+    `\n   This run does NOT cover src/broker-server.ts. Re-run outside the sandbox before trusting it.\n`,
+  );
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
@@ -587,8 +656,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
   describe("initialize handshake", () => {
     test("responds with userAgent locally, does not forward to app-server", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -609,8 +678,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
     }, 15_000);
 
     test("initialize returns busy=false when no stream is active", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -631,8 +700,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
     }, 15_000);
 
     test("initialize returns busy=true when a stream is active", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, { sendTurnCompleted: false });
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -664,8 +733,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
     }, 15_000);
 
     test("initialize returns busy=true while a streaming request is pending", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         turnDelay: 1000,
         sendTurnCompleted: false,
@@ -702,8 +771,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
     }, 15_000);
 
     test("non-streaming error from stream owner preserves stream ownership", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       // Long-running turn that won't auto-complete during the test.
       const mockDir = createMockCodex(tempDir, { sendTurnCompleted: false });
 
@@ -752,8 +821,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
       // activeRequestIsStreaming), the broker would report busy=true forever
       // and every subsequent streaming invocation would fall back to a direct
       // app-server until the broker restarted.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       // Force the race: the mock writes turn/completed *before* turn/start's
       // response, and `turnDelay > 0` makes the broker still be awaiting
       // appClient.request's resolution when it sees turn/completed.
@@ -788,8 +857,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("swallows initialized notification without error", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -814,8 +883,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
   describe("request forwarding", () => {
     test("forwards thread/start to app-server and returns result", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -838,8 +907,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("forwards thread/read and thread/list as read-only methods", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -865,8 +934,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("returns JSON parse error for invalid JSON input", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -897,8 +966,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("ignores client notifications (no id)", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -930,8 +999,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
   describe("concurrency control", () => {
     test("second client gets -32001 busy error during active stream", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       // Use a long turn delay so the stream stays active
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
@@ -975,8 +1044,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("second client can proceed after first client's turn completes", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: true,
         turnCompletedDelay: 50,
@@ -1011,8 +1080,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("turn/interrupt allowed from different socket during active stream", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1049,8 +1118,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
 
     test("thread/read allowed from different socket during active stream", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1088,8 +1157,8 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
       // `models` makes exactly one server call, and withClient's busy→direct
       // fallback is streaming-only, so if model/list is not on the read-only
       // allowlist it is the one read that hard-fails on a busy broker.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1120,27 +1189,31 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
       }
     }, 15_000);
 
-    test("a SIGTERM during startup reaps the app-server instead of orphaning it", async () => {
+    // Unix-only by nature, not by convenience. The orphan needs a detached
+    // app-server (connectDirect detaches on Unix only) AND a signal that runs
+    // a handler — Windows has neither: the app-server is a plain child, and
+    // `taskkill /T` takes the tree down together. The Windows guarantee is
+    // covered directly by process.test.ts's "terminating a parent takes its
+    // child with it".
+    test.skipIf(!IS_UNIX)("a SIGTERM during startup reaps the app-server instead of orphaning it", async () => {
       // The window between spawning the app-server and installing the main
       // signal handlers. A parent that gives up on a slow broker SIGTERMs it
       // here; the app-server is spawned detached, in its own process group, so
       // the parent's group signal never reaches it. Without a guard the broker
       // dies on default disposition and leaves it running — holding codex's
       // sqlite state lock, which is exactly what the parent then retries into.
-      if (process.platform === "win32") return; // no process groups / signals
-
       const pidFile = join(tempDir, "app-server.pid");
       const mockDir = join(tempDir, "hang-mock");
       mkdirSync(mockDir, { recursive: true });
       // Never answers `initialize` — a wedged app-server is the usual reason
       // the parent gave up, and it means the broker never gets a client.
-      writeFileSync(join(mockDir, "codex"), `#!/usr/bin/env bun
+      writeMockCodexScript(mockDir, `#!/usr/bin/env bun
 require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
 process.stdin.resume();
 setInterval(() => {}, 1000);
-`, { mode: 0o755 });
+`);
 
-      const endpoint = `unix:${join(tempDir, "broker.sock")}`;
+      const endpoint = endpointFor(testSocketPath(tempDir));
       const proc = spawnBroker(endpoint, mockDir);
 
       // Wait for the app-server to exist so there is something to orphan.
@@ -1172,8 +1245,8 @@ setInterval(() => {}, 1000);
 
     test("thread/list allowed from different socket during active stream", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1206,8 +1279,8 @@ setInterval(() => {}, 1000);
 
     test("non-streaming request from same socket is allowed", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1245,8 +1318,8 @@ setInterval(() => {}, 1000);
   describe("notification routing", () => {
     test("turn/completed notification is forwarded to the stream-owning socket", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: true,
         turnCompletedDelay: 50,
@@ -1282,8 +1355,8 @@ setInterval(() => {}, 1000);
 
     test("notifications are not sent to non-owning sockets", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: true,
         turnCompletedDelay: 50,
@@ -1322,8 +1395,8 @@ setInterval(() => {}, 1000);
 
   describe("goal-mode stream retention", () => {
     test("continuation-turn notifications keep flowing to the owner while the goal is active, and ownership releases when it completes", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, { goalContinuation: true });
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1373,8 +1446,8 @@ setInterval(() => {}, 1000);
       // thread/goal/updated ever fires. The goal-following CLI's pre-turn
       // thread/goal/get is the broker's only signal — pre-fix, ownership
       // released at turn 1's completion and the continuation was invisible.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, { goalPreexisting: true });
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1408,8 +1481,8 @@ setInterval(() => {}, 1000);
       // turn/start response, so the normal claim is skipped — but the goal
       // is active and continuations are coming. Pre-fix, they had no owner
       // and the goal-following client waited blind until its timeout.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, { sendTurnCompleted: false, goalFastFirstTurn: true });
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1436,8 +1509,8 @@ setInterval(() => {}, 1000);
     test("goal ops are allowed through from another socket while a stream is owned", async () => {
       // kill/kill --clear must be able to read and brake a goal whose
       // following run owns the broker stream for the goal's whole lifetime.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, { sendTurnCompleted: false });
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1466,8 +1539,8 @@ setInterval(() => {}, 1000);
       // active. If the goal is paused BEFORE the continuation starts (the
       // kill/timeout brake), no turn/completed will ever arrive — pre-fix
       // the broker stayed busy until the 30-minute orphan watchdog.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, { goalPausedInGap: true });
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1506,8 +1579,8 @@ setInterval(() => {}, 1000);
   describe("approval forwarding", () => {
     test("client receives forwarded approval request and responds — round-trip", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
         sendApproval: true,
@@ -1563,8 +1636,8 @@ setInterval(() => {}, 1000);
 
     test("malformed response (missing result and error) is rejected", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
         sendApproval: true,
@@ -1621,8 +1694,8 @@ setInterval(() => {}, 1000);
 
     test("socket disconnect during pending approval rejects only that socket's approvals", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
         sendApproval: true,
@@ -1673,10 +1746,11 @@ setInterval(() => {}, 1000);
   // ── Socket permissions ────────────────────────────────────────────────────
 
   describe("socket permissions", () => {
-    test("socket file has restrictive permissions (0o700)", async () => {
+    // A named pipe is not a filesystem object and carries no mode.
+    test.skipIf(!IS_UNIX)("socket file has restrictive permissions (0o700)", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1700,8 +1774,8 @@ setInterval(() => {}, 1000);
   describe("broker/shutdown", () => {
     test("broker exits cleanly after broker/shutdown request", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1729,8 +1803,8 @@ setInterval(() => {}, 1000);
   describe("idle timeout", () => {
     test("broker shuts down after idle timeout with no activity", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       // Use a very short idle timeout (1 second)
@@ -1749,8 +1823,8 @@ setInterval(() => {}, 1000);
 
     test("activity resets the idle timer", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       // Use a 2s idle timeout
@@ -1781,8 +1855,8 @@ setInterval(() => {}, 1000);
     }, 15_000);
 
     test("active stream prevents idle shutdown", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1805,8 +1879,8 @@ setInterval(() => {}, 1000);
     }, 10_000);
 
     test("pending approval prevents idle shutdown", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendApproval: true,
         sendTurnCompleted: false,
@@ -1835,8 +1909,8 @@ setInterval(() => {}, 1000);
 
   describe("buffer overflow protection", () => {
     test("broker destroys socket when client sends >10MB without newlines", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir, { idleTimeout: 30000 });
@@ -1905,8 +1979,8 @@ setInterval(() => {}, 1000);
   describe("multiple clients", () => {
     test("multiple clients can connect and make sequential requests", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -1937,8 +2011,8 @@ setInterval(() => {}, 1000);
 
     test("client disconnect during stream preserves concurrency lock until turn completes", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -1985,8 +2059,8 @@ setInterval(() => {}, 1000);
     }, 15_000);
 
     test("client disconnect before turn/start response preserves request lock", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         turnDelay: 1000,
         sendTurnCompleted: false,
@@ -2034,8 +2108,8 @@ setInterval(() => {}, 1000);
       // while the previous one was mid-cancel. Reserve before the
       // interrupt and let the natural turn/completed (or the watchdog)
       // release.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       // Delay the turn/start response so the broker is awaiting
       // appClient.request when client1 disconnects — that is the only
       // condition that triggers the orphan branch on the post-response
@@ -2093,8 +2167,8 @@ setInterval(() => {}, 1000);
       // turn is already done, so there is nothing to unwind. Reserving would
       // pin the broker busy until the watchdog fires (ORPHAN_WATCHDOG_MS = idle
       // timeout), forcing every other client onto direct connections meanwhile.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       // completeBeforeResponse: the single turn/completed (turn-001) is written
       // before the turn/start response; turnDelay holds the response so the
       // client can disconnect after the completion but before the response
@@ -2150,8 +2224,8 @@ setInterval(() => {}, 1000);
       // turn/interrupt there, while the actual review turn runs on the
       // response's reviewThreadId. The interrupt missed, so the review kept
       // running and held the broker's stream slot until natural completion.
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
         reviewDelay: 200, // window for the client to disconnect mid-flight
@@ -2196,8 +2270,8 @@ setInterval(() => {}, 1000);
     }, 10_000);
 
     test("orphan watchdog interrupts with threadId and turnId", async () => {
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: false,
       });
@@ -2236,8 +2310,8 @@ setInterval(() => {}, 1000);
   describe("streaming methods", () => {
     test("review/start establishes stream ownership with reviewThreadId", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       // Use a long turn-completed delay so stream stays active during the test
       const mockDir = createMockCodex(tempDir, {
         sendTurnCompleted: true,
@@ -2284,8 +2358,8 @@ setInterval(() => {}, 1000);
   describe("error forwarding", () => {
     test("app-server error responses are forwarded to the client", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -2319,8 +2393,8 @@ setInterval(() => {}, 1000);
     // warning to stderr, but we don't capture subprocess stderr in assertions.
     test("response for unknown forwarded request is ignored", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       const proc = spawnBroker(endpoint, mockDir);
@@ -2347,10 +2421,11 @@ setInterval(() => {}, 1000);
   // ── Stale socket cleanup ──────────────────────────────────────────────────
 
   describe("stale socket cleanup", () => {
-    test("removes stale socket file before listening", async () => {
+    // Windows named pipes vanish with their owner; there is no stale file.
+    test.skipIf(!IS_UNIX)("removes stale socket file before listening", async () => {
 
-      const sockPath = join(tempDir, "broker.sock");
-      const endpoint = `unix:${sockPath}`;
+      const sockPath = testSocketPath(tempDir);
+      const endpoint = endpointFor(sockPath);
       const mockDir = createMockCodex(tempDir);
 
       // Create a stale socket file

--- a/src/broker-server.test.ts
+++ b/src/broker-server.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import net from "node:net";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Subprocess } from "bun";
@@ -1119,6 +1119,56 @@ describe.skipIf(!SOCKETS_AVAILABLE)("broker-server", () => {
         proc.kill();
       }
     }, 15_000);
+
+    test("a SIGTERM during startup reaps the app-server instead of orphaning it", async () => {
+      // The window between spawning the app-server and installing the main
+      // signal handlers. A parent that gives up on a slow broker SIGTERMs it
+      // here; the app-server is spawned detached, in its own process group, so
+      // the parent's group signal never reaches it. Without a guard the broker
+      // dies on default disposition and leaves it running — holding codex's
+      // sqlite state lock, which is exactly what the parent then retries into.
+      if (process.platform === "win32") return; // no process groups / signals
+
+      const pidFile = join(tempDir, "app-server.pid");
+      const mockDir = join(tempDir, "hang-mock");
+      mkdirSync(mockDir, { recursive: true });
+      // Never answers `initialize` — a wedged app-server is the usual reason
+      // the parent gave up, and it means the broker never gets a client.
+      writeFileSync(join(mockDir, "codex"), `#!/usr/bin/env bun
+require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+process.stdin.resume();
+setInterval(() => {}, 1000);
+`, { mode: 0o755 });
+
+      const endpoint = `unix:${join(tempDir, "broker.sock")}`;
+      const proc = spawnBroker(endpoint, mockDir);
+
+      // Wait for the app-server to exist so there is something to orphan.
+      let appPid = 0;
+      for (let i = 0; i < 100 && !appPid; i++) {
+        if (existsSync(pidFile)) appPid = Number(readFileSync(pidFile, "utf-8").trim());
+        if (!appPid) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(appPid).toBeGreaterThan(0);
+
+      const alive = (pid: number) => {
+        try { process.kill(pid, 0); return true; } catch { return false; }
+      };
+      expect(alive(appPid)).toBe(true);
+
+      try {
+        proc.kill("SIGTERM");
+        let stillAlive = true;
+        for (let i = 0; i < 60 && stillAlive; i++) {
+          stillAlive = alive(appPid);
+          if (stillAlive) await new Promise((r) => setTimeout(r, 100));
+        }
+        expect(stillAlive).toBe(false);
+      } finally {
+        try { process.kill(appPid, "SIGKILL"); } catch {}
+        try { proc.kill("SIGKILL"); } catch {}
+      }
+    }, 20000);
 
     test("thread/list allowed from different socket during active stream", async () => {
 

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -25,16 +25,16 @@ import {
   type AppServerClient,
 } from "./client";
 import { terminateProcessTree, waitForProcessTreeExit } from "./process";
-
-/** Awaiting this parks the caller forever. Used where an async handler is
- *  already on its way to process.exit(): the point is to stop the main flow
- *  advancing in the meantime, not to ever resume. */
-const untilProcessExits = (): Promise<never> => new Promise<never>(() => {});
 import { parseEndpoint, BROKER_BUSY_RPC_CODE } from "./broker";
 import { RpcError } from "./types";
 import { config } from "./config";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Awaiting this parks the caller forever. Used where an async handler is
+ *  already on its way to process.exit(): the point is to stop the main flow
+ *  advancing in the meantime, not to ever resume. */
+const untilProcessExits = (): Promise<never> => new Promise<never>(() => {});
 
 const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 
@@ -138,9 +138,17 @@ async function main() {
     startupSignalled = true;
     void (async () => {
       process.stderr.write(`[broker-server] ${signal} while starting — stopping the app server before exit\n`);
-      if (appServerPid !== null) {
-        terminateProcessTree(appServerPid);
-        await waitForProcessTreeExit(appServerPid, config.appServerReapTimeout);
+      // Loop rather than read `appServerPid` once: connectDirectWithRetry runs
+      // independently of this guard and can spawn a REPLACEMENT while we are
+      // waiting on the one we just terminated. Exiting then would orphan it —
+      // the very failure this guard exists to prevent. `reaped` bounds the
+      // loop to the attempts that actually happened.
+      const reaped = new Set<number>();
+      while (appServerPid !== null && !reaped.has(appServerPid)) {
+        const pid = appServerPid;
+        reaped.add(pid);
+        terminateProcessTree(pid);
+        await waitForProcessTreeExit(pid, config.appServerReapTimeout);
       }
       process.exit(0);
     })();
@@ -155,7 +163,14 @@ async function main() {
   // the client sees only "broker did not become ready in time".
   const appClient = await connectDirectWithRetry({
     cwd,
-    onSpawn: (pid) => { appServerPid = pid; },
+    onSpawn: (pid) => {
+      appServerPid = pid;
+      // Spawned behind a guard that is already unwinding — signal it now
+      // rather than leave it initializing (and holding codex's sqlite state)
+      // for however long the guard still spends reaping its predecessor.
+      // The guard's loop picks this pid up and waits for it to go.
+      if (startupSignalled) terminateProcessTree(pid);
+    },
   });
 
   // Signalled while the handshake was completing: the guard is already

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -115,6 +115,8 @@ async function main() {
 
   const { endpoint, cwd, idleTimeout } = parseArgs(argv);
   const listenTarget = parseEndpoint(endpoint);
+  /** Inode of the socket this process bound, for ownership checks at cleanup. */
+  let listenInode: number | null = null;
 
   // Guard the startup window BEFORE spawning anything. The full signal
   // handlers below need `server`, which does not exist yet — but this is
@@ -154,9 +156,6 @@ async function main() {
   const appClient = await connectDirectWithRetry({
     cwd,
     onSpawn: (pid) => { appServerPid = pid; },
-  }).finally(() => {
-    process.off("SIGTERM", startupGuard);
-    process.off("SIGINT", startupGuard);
   });
 
   // Signalled while the handshake was completing: the guard is already
@@ -509,6 +508,13 @@ async function main() {
 
   // ─── Shutdown ───────────────────────────────────────────────────────────
 
+  /** True iff the socket at our path is the one we bound. Anything else — a
+   *  replacement's socket, or nothing — is not ours to remove. */
+  function socketIsStillOurs(): boolean {
+    if (listenInode === null) return false;
+    try { return fs.statSync(listenTarget.path).ino === listenInode; } catch { return false; }
+  }
+
   async function shutdown(server: net.Server): Promise<void> {
     shutdownInitiated = true;
     if (idleTimer) clearTimeout(idleTimer);
@@ -556,7 +562,7 @@ async function main() {
         }, 2000);
       }),
     ]);
-    if (listenTarget.kind === "unix") {
+    if (listenTarget.kind === "unix" && socketIsStillOurs()) {
       try {
         fs.unlinkSync(listenTarget.path);
       } catch (e) {
@@ -970,6 +976,14 @@ async function main() {
 
   // ─── Signal handlers ──────────────────────────────────────────────────
 
+  // Only now is it safe to drop the startup guard: until this point a signal
+  // would hit the default disposition and orphan the detached app-server,
+  // which is the whole race the guard exists to close. Everything between the
+  // handshake and here is synchronous today, but that is an accident of
+  // layout, not a guarantee.
+  process.off("SIGTERM", startupGuard);
+  process.off("SIGINT", startupGuard);
+
   process.on("SIGTERM", async () => {
     await shutdown(server);
     process.exit(0);
@@ -999,6 +1013,14 @@ async function main() {
   // slow macOS CI runner).
   const prevUmask = listenTarget.kind === "unix" ? process.umask(0o077) : null;
   server.listen(listenTarget.path, () => {
+    // Remember which socket is ours. The path is fixed per workspace, so a
+    // replacement can bind it while we are still shutting down — the listener
+    // closes first, so our liveness probe fails and the next invocation
+    // spawns — and a blind unlink at the end of shutdown would then strand a
+    // live broker behind a path with no socket.
+    if (listenTarget.kind === "unix") {
+      try { listenInode = fs.statSync(listenTarget.path).ino; } catch { listenInode = null; }
+    }
     if (prevUmask !== null) process.umask(prevUmask);
     process.stderr.write(
       `[broker-server] Listening on ${endpoint} (idle timeout: ${idleTimeout}ms)\n`,

--- a/src/broker-server.ts
+++ b/src/broker-server.ts
@@ -20,10 +20,16 @@ import net from "node:net";
 import fs, { chmodSync } from "node:fs";
 import path from "node:path";
 import {
-  connectDirect,
+  connectDirectWithRetry,
   parseMessage,
   type AppServerClient,
 } from "./client";
+import { terminateProcessTree, waitForProcessTreeExit } from "./process";
+
+/** Awaiting this parks the caller forever. Used where an async handler is
+ *  already on its way to process.exit(): the point is to stop the main flow
+ *  advancing in the meantime, not to ever resume. */
+const untilProcessExits = (): Promise<never> => new Promise<never>(() => {});
 import { parseEndpoint, BROKER_BUSY_RPC_CODE } from "./broker";
 import { RpcError } from "./types";
 import { config } from "./config";
@@ -110,8 +116,53 @@ async function main() {
   const { endpoint, cwd, idleTimeout } = parseArgs(argv);
   const listenTarget = parseEndpoint(endpoint);
 
-  // Spawn the real app-server
-  const appClient = await connectDirect({ cwd });
+  // Guard the startup window BEFORE spawning anything. The full signal
+  // handlers below need `server`, which does not exist yet — but this is
+  // exactly the window that matters: a parent that gives up on us sends
+  // SIGTERM while this connect is still in flight, and with no handler
+  // installed it hits default disposition and kills the broker outright. The
+  // app-server is spawned detached, in its OWN process group, so it survives
+  // the group signal aimed at us and nothing is left alive to close it — it
+  // then holds codex's sqlite state lock indefinitely, which is precisely the
+  // contention the parent is about to retry into.
+  //
+  // Killing the PID directly (rather than awaiting the client) is deliberate:
+  // the handshake may never complete, since a wedged app-server is the usual
+  // reason the parent gave up in the first place.
+  let appServerPid: number | null = null;
+  let startupSignalled = false;
+  const startupGuard = (signal: NodeJS.Signals) => {
+    if (startupSignalled) return;
+    startupSignalled = true;
+    void (async () => {
+      process.stderr.write(`[broker-server] ${signal} while starting — stopping the app server before exit\n`);
+      if (appServerPid !== null) {
+        terminateProcessTree(appServerPid);
+        await waitForProcessTreeExit(appServerPid, config.appServerReapTimeout);
+      }
+      process.exit(0);
+    })();
+  };
+  process.on("SIGTERM", startupGuard);
+  process.on("SIGINT", startupGuard);
+
+  // Spawn the real app-server. Retrying: a broker is usually spawned because
+  // no connection existed yet, which is exactly when another app-server may
+  // be starting or dying alongside it and contending for codex's sqlite
+  // state. Losing that race here kills the broker before it ever binds, and
+  // the client sees only "broker did not become ready in time".
+  const appClient = await connectDirectWithRetry({
+    cwd,
+    onSpawn: (pid) => { appServerPid = pid; },
+  }).finally(() => {
+    process.off("SIGTERM", startupGuard);
+    process.off("SIGINT", startupGuard);
+  });
+
+  // Signalled while the handshake was completing: the guard is already
+  // stopping the app server and will end the process. Park rather than fall
+  // through and start serving traffic we are about to drop.
+  if (startupSignalled) await untilProcessExits();
 
   // If the app-server exits unexpectedly, shut down the broker immediately
   // so the next ensureConnection() spawns a fresh broker + app-server.
@@ -465,6 +516,19 @@ async function main() {
       clearTimeout(orphanWatchdog);
       orphanWatchdog = null;
     }
+    // Stop ACCEPTING now, before the app-server close below — that close can
+    // run for seconds, and a client connecting during it would pass the
+    // liveness probe, complete the broker-local initialize, then fail its
+    // first forwarded request with no fallback. Refusing the connection sends
+    // it down the direct path instead. The listener's own close completes
+    // once existing sockets drain, which is awaited at the end.
+    let listenerClosed: Promise<void>;
+    try {
+      listenerClosed = new Promise<void>((resolve) => server.close(() => resolve()));
+    } catch {
+      listenerClosed = Promise.resolve(); // already closed (double shutdown)
+    }
+
     // Reject all pending forwarded requests before closing sockets
     for (const [reqId, entry] of pendingForwardedRequests) {
       clearTimeout(entry.timer);
@@ -483,16 +547,15 @@ async function main() {
     // (or a platform quirk that drops the close callback) must not wedge
     // shutdown — the signal/idle paths that call this expect to reach
     // process.exit(). Destroy stragglers once the grace period lapses.
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        for (const socket of sockets) socket.destroy();
-        resolve();
-      }, 2000);
-      server.close(() => {
-        clearTimeout(timer);
-        resolve();
-      });
-    });
+    await Promise.race([
+      listenerClosed,
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          for (const socket of sockets) socket.destroy();
+          resolve();
+        }, 2000);
+      }),
+    ]);
     if (listenTarget.kind === "unix") {
       try {
         fs.unlinkSync(listenTarget.path);

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -10,10 +10,18 @@ import path from "node:path";
 import { spawn as childSpawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import type { BrokerState, SessionState, ParsedEndpoint } from "./types";
-import { connectDirect, type AppServerClient } from "./client";
+import { connectDirectWithRetry, type AppServerClient } from "./client";
 import { config, resolveStateDir } from "./config";
 import { acquireLockAsync, LockTimeoutError } from "./lock";
 import { terminateProcessTree, isProcessAlive, processLooksLikeBun } from "./process";
+
+/** Grace a terminated broker gets before SIGKILL. Long enough for its own
+ *  shutdown to close the app-server it spawned rather than orphan it. Hygiene,
+ *  not correctness: startup is serialized on CODEX_HOME, so no replacement
+ *  depends on this broker being gone first. */
+const BROKER_SHUTDOWN_GRACE_MS = 10_000;
+
+
 
 /** JSON-RPC error code returned when the broker is busy with another request. */
 export const BROKER_BUSY_RPC_CODE = -32001;
@@ -268,9 +276,15 @@ export function clearBrokerArtifacts(stateDir: string, state: BrokerState): void
  * `clearBrokerArtifacts` instead.
  */
 export function teardownBroker(stateDir: string, state: BrokerState): void {
-  // Kill process if PID is alive
+  // Fire-and-forget. Waiting here was how a replacement used to avoid
+  // colliding with this broker's app-server, but it left the broker published
+  // while it died: a concurrent invocation could connect to a shutting-down
+  // broker, and the delayed artifact cleanup could delete a replacement's
+  // state. Startup is serialized on CODEX_HOME instead, which needs no window.
+  // The grace is hygiene — enough for the broker's own shutdown to close its
+  // app-server rather than orphan it.
   if (state.pid !== null && isProcessAlive(state.pid)) {
-    terminateProcessTree(state.pid);
+    terminateProcessTree(state.pid, BROKER_SHUTDOWN_GRACE_MS);
   }
   clearBrokerArtifacts(stateDir, state);
 }
@@ -373,29 +387,35 @@ function spawnBrokerServer(
   return { pid: proc.pid, exited };
 }
 
+/** Why a broker did not become usable. The two failures are not the same
+ *  event and must not be reported with the same words: "exited" means it
+ *  crashed and there is a reason in its log, "timeout" means it is alive but
+ *  slow and still holds an app-server that has to be reaped. */
+type BrokerReadiness = "ready" | "exited" | "timeout";
+
 /**
  * Wait for the broker to become alive by polling the socket.
- * Returns true if alive within the timeout, false otherwise.
  *
  * Aborts early if the spawned broker process exits before becoming ready —
- * polling the full timeout against a dead pid is wasted time.
+ * polling the full timeout against a dead pid is wasted time, and the caller
+ * needs to know it was a crash rather than slowness.
  */
 async function waitForBrokerReady(
   endpoint: string,
   spawned: SpawnedBroker | null = null,
-  timeoutMs = 10_000,
+  timeoutMs = config.brokerReadyTimeout,
   pollMs = 100,
-): Promise<boolean> {
+): Promise<BrokerReadiness> {
   let exitedEarly = false;
   spawned?.exited.then(() => { exitedEarly = true; }).catch(() => {});
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (exitedEarly) return false;
-    if (await isBrokerAlive(endpoint, 200)) return true;
+    if (exitedEarly) return "exited";
+    if (await isBrokerAlive(endpoint, 200)) return "ready";
     await new Promise((r) => setTimeout(r, pollMs));
   }
-  return false;
+  return exitedEarly ? "exited" : "timeout";
 }
 
 // ─── Main connection entry point ──────────────────────────────────────────
@@ -478,7 +498,7 @@ export async function ensureConnection(cwd: string, streaming = false): Promise<
         `[broker] Existing broker was spawned by codex-collab ${state.version ?? "(pre-0.3)"}, this is ${config.clientVersion} — using a direct connection until it retires on idle.`,
       );
       saveSession();
-      return connectDirect({ cwd });
+      return connectDirectWithRetry({ cwd });
     }
     if (!(await isBrokerAlive(state.endpoint))) return null;
     try {
@@ -488,7 +508,7 @@ export async function ensureConnection(cwd: string, streaming = false): Promise<
         await client.close();
         console.error("[broker] Broker is busy — using direct connection for this invocation.");
         saveSession();
-        return connectDirect({ cwd });
+        return connectDirectWithRetry({ cwd });
       }
       saveSession();
       return client;
@@ -516,7 +536,7 @@ export async function ensureConnection(cwd: string, streaming = false): Promise<
     // Could not acquire lock — another process may be spawning.
     // Fall back to direct connection.
     console.error("[broker] Warning: could not acquire spawn lock. Using direct connection.");
-    return connectDirect({ cwd });
+    return connectDirectWithRetry({ cwd });
   }
 
   try {
@@ -543,7 +563,7 @@ export async function ensureConnection(cwd: string, streaming = false): Promise<
       } catch (e) {
         console.error(`[broker] Warning: failed to save session state: ${(e as Error).message}`);
       }
-      return connectDirect({ cwd });
+      return connectDirectWithRetry({ cwd });
     };
 
     // 3. Spawn a new broker
@@ -556,14 +576,25 @@ export async function ensureConnection(cwd: string, streaming = false): Promise<
     }
 
     // 4. Wait for the broker to be ready (aborts early if it crashes)
-    const ready = await waitForBrokerReady(endpoint, spawned);
-    if (!ready) {
-      try {
-        terminateProcessTree(spawned.pid);
-      } catch (e) {
-        console.error(`[broker] Warning: could not terminate orphaned broker pid ${spawned.pid}: ${e instanceof Error ? e.message : String(e)}`);
+    const readiness = await waitForBrokerReady(endpoint, spawned);
+    if (readiness !== "ready") {
+      const brokerLog = path.join(stateDir, "broker.log");
+      // Only a broker that is still RUNNING needs stopping. One that already
+      // exited took its app-server down with it. No wait either way: startup
+      // is serialized on CODEX_HOME, so the direct connection below cannot
+      // collide with whatever this broker is still finishing.
+      if (readiness === "timeout") {
+        try {
+          terminateProcessTree(spawned.pid, BROKER_SHUTDOWN_GRACE_MS);
+        } catch (e) {
+          console.error(`[broker] Warning: could not stop the unresponsive broker (pid ${spawned.pid}): ${e instanceof Error ? e.message : String(e)}`);
+        }
       }
-      return fallbackToDirect("broker did not become ready in time — see broker.log for the spawn failure reason");
+      return fallbackToDirect(
+        readiness === "exited"
+          ? `the background broker exited while starting — see ${brokerLog} for why`
+          : `the background broker did not start within ${config.brokerReadyTimeout / 1000}s — see ${brokerLog} for why`,
+      );
     }
 
     // 5. Connect to the new broker
@@ -583,7 +614,7 @@ export async function ensureConnection(cwd: string, streaming = false): Promise<
       console.error(
         `[broker] Warning: failed to connect to new broker: ${(e as Error).message}. Using direct connection.`,
       );
-      return connectDirect({ cwd });
+      return connectDirectWithRetry({ cwd });
     }
   } finally {
     release();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -440,9 +440,15 @@ async function main() {
   }
 }
 
-main().catch((e) => {
+main().catch(async (e) => {
   const msg = e instanceof Error ? e.message : String(e);
   console.error(`Fatal: ${msg}`);
+  // A failed connection reports the symptom ("process exited unexpectedly")
+  // while the cause sits in a stderr line the user has no reason to connect
+  // to it. Say what happened and what to do, when we can be specific.
+  const { explainConnectionFailure } = await import("./client");
+  const explained = explainConnectionFailure(e);
+  if (explained) console.error(explained);
   if (msg.includes("timed out")) {
     console.error("Tip: Resume with --resume <id> or increase --timeout");
   }

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test, beforeAll, beforeEach, afterEach } from "bun:test";
-import { parseMessage, formatNotification, formatResponse, connectDirect as connect, connectDirectWithRetry as connectWithRetry, explainConnectionFailure, withStartupLock, type AppServerClient } from "./client";
+import { parseMessage, formatNotification, formatResponse, connectDirect as connect, connectDirectWithRetry as connectWithRetry, explainConnectionFailure, withStartupLock, startupLockPath, type AppServerClient } from "./client";
 import { join } from "path";
 import { tmpdir } from "os";
+import { mkdirSync } from "fs";
+import { config } from "./config";
+import { acquireLockAsync } from "./lock";
 
 // Test-local formatRequest helper with its own counter (not exported from client.ts
 // to avoid ID collisions with AppServerClient's internal counter).
@@ -943,7 +946,36 @@ setTimeout(() => {
 });
 
 
-describe("withStartupLock", () => {
+// The lock lives under ~/.codex-collab. A sandbox that denies writes there
+// makes withStartupLock fail open — correct behaviour, but it turns these
+// assertions into noise. Announce and skip, the same way the broker suite
+// handles a socket it cannot bind: a run that does not cover this should say
+// so rather than report a pass it did not earn.
+const LOCK_DIR_WRITABLE = await (async () => {
+  // Acquire a throwaway lock for real: mkdirSync on an existing directory is
+  // a no-op and succeeds even where writes are denied, so only taking a lock
+  // proves the capability.
+  try {
+    mkdirSync(join(config.dataDir, "locks"), { recursive: true, mode: 0o700 });
+    const release = await acquireLockAsync(
+      join(config.dataDir, "locks", `probe-${process.pid}.lock`),
+      { maxAttempts: 1 },
+    );
+    release();
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (!LOCK_DIR_WRITABLE) {
+  console.warn(
+    `\n⚠️  startup-lock tests SKIPPED — cannot write to ${join(config.dataDir, "locks")}.` +
+    `\n   This run does NOT cover app-server startup serialization.\n`,
+  );
+}
+
+describe.skipIf(!LOCK_DIR_WRITABLE)("withStartupLock", () => {
   const HOME = process.env.CODEX_HOME;
   let lockHome: string;
 
@@ -991,15 +1023,25 @@ describe("withStartupLock", () => {
     expect(ran).toBe(true);
   }, 20000);
 
-  test("creates the lock inside CODEX_HOME, not the workspace", async () => {
-    const { existsSync } = await import("fs");
+  test("keys the lock by CODEX_HOME but keeps the file in our own state dir", async () => {
+    // ~/.codex belongs to codex. Scattering files through another program's
+    // directory is a thing users are right to distrust, so the lock is keyed
+    // by that path rather than stored under it.
+    const { existsSync, readdirSync } = await import("fs");
     await withStartupLock(async () => {
-      expect(existsSync(join(lockHome, "app-server-startup.lock"))).toBe(true);
+      expect(existsSync(startupLockPath())).toBe(true);
+      expect(startupLockPath()).toContain(".codex-collab");
+      expect(readdirSync(lockHome)).toEqual([]); // nothing written into CODEX_HOME
     });
   }, 20000);
+
+  test("a different CODEX_HOME is a different lock", () => {
+    expect(startupLockPath({ CODEX_HOME: "/one" })).not.toBe(startupLockPath({ CODEX_HOME: "/two" }));
+    expect(startupLockPath({ CODEX_HOME: "/one" })).toBe(startupLockPath({ CODEX_HOME: "/one" }));
+  });
 });
 
-describe("startup lock follows the child's environment", () => {
+describe.skipIf(!LOCK_DIR_WRITABLE)("startup lock follows the child's environment", () => {
   test("an env override decides the lock, not the parent", async () => {
     // connectDirect lets a caller point the child at a different CODEX_HOME.
     // Locking on the parent's would put two processes that share a child
@@ -1010,8 +1052,8 @@ describe("startup lock follows the child's environment", () => {
     process.env.CODEX_HOME = mkdtempSync(join(tmpdir(), "codex-parent-home-"));
     try {
       await withStartupLock(async () => {
-        expect(existsSync(join(childHome, "app-server-startup.lock"))).toBe(true);
-        expect(existsSync(join(process.env.CODEX_HOME!, "app-server-startup.lock"))).toBe(false);
+        expect(existsSync(startupLockPath({ CODEX_HOME: childHome }))).toBe(true);
+        expect(existsSync(startupLockPath())).toBe(false); // not the parent's
       }, { CODEX_HOME: childHome });
     } finally {
       rmSync(childHome, { recursive: true, force: true });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -998,3 +998,25 @@ describe("withStartupLock", () => {
     });
   }, 20000);
 });
+
+describe("startup lock follows the child's environment", () => {
+  test("an env override decides the lock, not the parent", async () => {
+    // connectDirect lets a caller point the child at a different CODEX_HOME.
+    // Locking on the parent's would put two processes that share a child
+    // state directory on different locks, serializing nothing.
+    const { mkdtempSync, existsSync, rmSync } = await import("fs");
+    const childHome = mkdtempSync(join(tmpdir(), "codex-child-home-"));
+    const prev = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = mkdtempSync(join(tmpdir(), "codex-parent-home-"));
+    try {
+      await withStartupLock(async () => {
+        expect(existsSync(join(childHome, "app-server-startup.lock"))).toBe(true);
+        expect(existsSync(join(process.env.CODEX_HOME!, "app-server-startup.lock"))).toBe(false);
+      }, { CODEX_HOME: childHome });
+    } finally {
+      rmSync(childHome, { recursive: true, force: true });
+      rmSync(process.env.CODEX_HOME!, { recursive: true, force: true });
+      if (prev === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prev;
+    }
+  }, 20000);
+});

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1021,12 +1021,19 @@ describe.skipIf(!LOCK_DIR_WRITABLE)("withStartupLock", () => {
     // Hold the lock for real rather than pointing CODEX_HOME at an
     // unwritable path: the file lives in OUR state dir and is only KEYED by
     // CODEX_HOME, so a bogus home still acquires cleanly and would assert
-    // nothing. A fresh mtime also keeps the holder off the stale path, so
-    // this exercises the timeout branch rather than a stale break.
-    const { mkdirSync, writeFileSync, rmSync } = await import("fs");
+    // nothing.
+    const { mkdirSync, writeFileSync, rmSync, utimesSync } = await import("fs");
     const heldLock = startupLockPath();
     mkdirSync(join(config.dataDir, "locks"), { recursive: true, mode: 0o700 });
     writeFileSync(heldLock, "", { flag: "wx" });
+    // Keep the holder looking alive for as long as acquisition spins. The
+    // spin is a fixed 100 attempts, not a fixed duration, so on a slow enough
+    // runner it would outlast the 10s stale threshold, get its lock broken,
+    // and acquire cleanly — passing `ran` while silently testing nothing.
+    // Refreshing mtime pins the timeout branch at any runner speed.
+    const keepFresh = setInterval(() => {
+      try { utimesSync(heldLock, new Date(), new Date()); } catch {}
+    }, 500);
 
     const warnings: string[] = [];
     const original = console.error;
@@ -1035,6 +1042,7 @@ describe.skipIf(!LOCK_DIR_WRITABLE)("withStartupLock", () => {
     try {
       await withStartupLock(async () => { ran = true; });
     } finally {
+      clearInterval(keepFresh);
       console.error = original;
       rmSync(heldLock, { force: true });
     }

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeAll, beforeEach, afterEach } from "bun:test";
-import { parseMessage, formatNotification, formatResponse, connectDirect as connect, type AppServerClient } from "./client";
+import { parseMessage, formatNotification, formatResponse, connectDirect as connect, connectDirectWithRetry as connectWithRetry, explainConnectionFailure, withStartupLock, type AppServerClient } from "./client";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -607,4 +607,394 @@ describe("close() kills grandchildren", () => {
     }
     }, 20000);
   }
+});
+
+// ─── connectDirectWithRetry ────────────────────────────────────────────────
+
+/** An app-server that dies during startup on its first N spawns, then behaves.
+ *  Models codex losing the exclusive lock on its shared sqlite state: it never
+ *  answers `initialize`, it just exits. The attempt counter lives in a file so
+ *  it survives across spawns and lets a test pin the exact number of tries. */
+const FLAKY_SERVER = join(TEST_DIR, "flaky-app-server.ts");
+const FLAKY_SERVER_SOURCE = `#!/usr/bin/env bun
+const fs = require("fs");
+const counterPath = process.env.FLAKY_COUNTER;
+const failCount = Number(process.env.FLAKY_FAIL_COUNT ?? "1");
+let attempts = 0;
+try { attempts = Number(fs.readFileSync(counterPath, "utf-8")) || 0; } catch {}
+fs.writeFileSync(counterPath, String(attempts + 1));
+if (attempts < failCount) {
+  process.stderr.write("Error: failed to initialize sqlite state runtime under /tmp/codex\\n");
+  process.exit(1);
+}
+function respond(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
+let buffer = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let idx;
+  while ((idx = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, idx).trim();
+    buffer = buffer.slice(idx + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; }
+    if (msg.id !== undefined && msg.method === "initialize") {
+      respond({ id: msg.id, result: { userAgent: "flaky-mock/0.1.0" } });
+    }
+  }
+});
+process.stdin.on("end", () => process.exit(0));
+process.stdin.on("error", () => process.exit(1));
+`;
+
+describe("connectDirectWithRetry", () => {
+  let counterPath: string;
+  let logged: string[];
+  let restoreError: (() => void) | null = null;
+
+  beforeEach(async () => {
+    const { mkdirSync, existsSync, rmSync } = await import("fs");
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    await Bun.write(FLAKY_SERVER, FLAKY_SERVER_SOURCE);
+    counterPath = join(TEST_DIR, `flaky-counter-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    rmSync(counterPath, { force: true });
+
+    // Capture the retry notice: it is the only observable that distinguishes
+    // "classified as transient and retried" from "happened to succeed".
+    logged = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => { logged.push(args.join(" ")); };
+    restoreError = () => { console.error = original; };
+  });
+
+  afterEach(async () => {
+    restoreError?.();
+    restoreError = null;
+    const { rmSync } = await import("fs");
+    rmSync(counterPath, { force: true });
+  });
+
+  async function attempts(): Promise<number> {
+    const { readFileSync, existsSync } = await import("fs");
+    return existsSync(counterPath) ? Number(readFileSync(counterPath, "utf-8")) : 0;
+  }
+
+  test("retries once when the app-server dies during startup", async () => {
+    const c = await connectWithRetry({
+      command: ["bun", "run", FLAKY_SERVER],
+      requestTimeout: 10000,
+      env: { FLAKY_COUNTER: counterPath, FLAKY_FAIL_COUNT: "1" },
+    });
+    try {
+      expect(c.userAgent).toBe("flaky-mock/0.1.0");
+      expect(await attempts()).toBe(2);
+      expect(logged.some((l) => /retrying once/i.test(l))).toBe(true);
+    } finally {
+      await c.close();
+    }
+  }, 20000);
+
+  test("retries at most once, then surfaces the failure", async () => {
+    // Pins the cap: a second startup death must propagate rather than loop.
+    const error = await captureErrorMessage(connectWithRetry({
+      command: ["bun", "run", FLAKY_SERVER],
+      requestTimeout: 10000,
+      env: { FLAKY_COUNTER: counterPath, FLAKY_FAIL_COUNT: "2" },
+    }));
+    expect(error).toContain("App server process exited unexpectedly");
+    expect(await attempts()).toBe(2);
+  }, 20000);
+
+  test("does not retry a binary that never started", async () => {
+    // ENOENT is deterministic — retrying only doubles the time to the same
+    // error, and the user needs the install hint, not a delay. It surfaces as
+    // either the spawn error or a write into never-opened stdin, depending on
+    // which wins the race, so assert the decision rather than the wording.
+    const error = await captureErrorMessage(connectWithRetry({
+      command: [join(TEST_DIR, "definitely-not-a-real-binary")],
+      requestTimeout: 5000,
+    }));
+    expect(error.length).toBeGreaterThan(0);
+
+    // Windows runs commands through a `cmd.exe /c` shim, so the shim spawns
+    // successfully and its exit is reported as a startup death — a missing
+    // binary is genuinely indistinguishable there, and IS retried. Asserting
+    // the Unix outcome cross-platform would only encode a wrong expectation.
+    if (process.platform !== "win32") {
+      expect(error).not.toContain("App server process exited unexpectedly");
+      expect(logged.some((l) => /retrying once/i.test(l))).toBe(false);
+    }
+  }, 20000);
+});
+
+describe("connectDirect onSpawn", () => {
+  test("reports the child PID before the handshake completes", async () => {
+    // The broker needs a handle on its app-server during startup: if the
+    // handshake hangs it never receives a client, and killing the PID is the
+    // only way to avoid orphaning a detached process that holds codex's
+    // sqlite state lock.
+    const seen: number[] = [];
+    const c = await connect({
+      command: ["bun", "run", MOCK_SERVER],
+      requestTimeout: 10000,
+      onSpawn: (pid) => seen.push(pid),
+    });
+    try {
+      expect(seen.length).toBe(1);
+      expect(seen[0]).toBeGreaterThan(0);
+    } finally {
+      await c.close();
+    }
+  }, 20000);
+
+  test("reports each attempt's PID when the first one dies", async () => {
+    const { mkdirSync, existsSync } = await import("fs");
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    await Bun.write(FLAKY_SERVER, FLAKY_SERVER_SOURCE);
+    const counter = join(TEST_DIR, `onspawn-counter-${Date.now()}`);
+    const seen: number[] = [];
+    const c = await connectWithRetry({
+      command: ["bun", "run", FLAKY_SERVER],
+      requestTimeout: 10000,
+      env: { FLAKY_COUNTER: counter, FLAKY_FAIL_COUNT: "1" },
+      onSpawn: (pid) => seen.push(pid),
+    });
+    try {
+      // Two spawns, two distinct PIDs — the retry's PID must not shadow a
+      // stale one the caller might still act on.
+      expect(seen.length).toBe(2);
+      expect(seen[0]).not.toBe(seen[1]);
+    } finally {
+      await c.close();
+      const { rmSync } = await import("fs");
+      rmSync(counter, { force: true });
+    }
+  }, 20000);
+});
+
+describe("explainConnectionFailure", () => {
+  const withStderr = (stderr: string) =>
+    Object.assign(new Error("App server process exited unexpectedly"), { appServerStderr: stderr });
+
+  test("names the locked directory and what to do about it", () => {
+    // "process exited unexpectedly" is a symptom. The cause is a stderr line
+    // the user has no reason to connect to it, so say it out loud.
+    const msg = explainConnectionFailure(withStderr(
+      "Error: failed to initialize sqlite state runtime under /home/u/.codex: database is locked",
+    ));
+    expect(msg).toContain("/home/u/.codex");
+    expect(msg).toMatch(/Another Codex process/);
+    expect(msg).toMatch(/codex app-server|codex-collab health/);
+  });
+
+  test("only a real busy/locked signature claims contention", () => {
+    for (const s of ["Error: database is locked", "Error: database table is locked", "SQLITE_BUSY"]) {
+      expect(explainConnectionFailure(withStderr(s))).toMatch(/Another Codex process is using/);
+    }
+  });
+
+  test("the wrapper alone does not assert a cause", () => {
+    // codex emits it for contention, corruption, a full disk and permissions
+    // alike. Telling someone to wait for a lock that is really a malformed
+    // database sends them after the wrong problem.
+    const generic = explainConnectionFailure(withStderr(
+      "Error: failed to initialize sqlite state runtime under /home/u/.codex: database disk image is malformed",
+    ));
+    expect(generic).toMatch(/could not initialize its state database/);
+    expect(generic).not.toMatch(/Another Codex process is using/);
+    expect(generic).toMatch(/underlying cause/);
+    expect(generic).toContain("/home/u/.codex");
+  });
+
+  test("a directory containing spaces is reported whole", () => {
+    // \S+ truncated "C:\\Users\\First Last\\.codex" to "C:\\Users\\First", pointing
+    // the user at a path that does not exist.
+    const msg = explainConnectionFailure(withStderr(
+      "Error: failed to initialize state runtime at C:\\Users\\First Last\\.codex: database is locked",
+    ));
+    expect(msg).toContain("C:\\Users\\First Last\\.codex");
+  });
+
+  test("process-inspection advice is runnable on this platform", () => {
+    // `ps aux` does not exist in cmd or PowerShell.
+    const msg = explainConnectionFailure(withStderr("Error: database is locked"))!;
+    expect(msg).toContain(process.platform === "win32" ? "tasklist" : "ps aux");
+    if (process.platform === "win32") expect(msg).not.toContain("ps aux");
+  });
+
+  test("SQLITE_CANTOPEN is a broken path, not contention", () => {
+    // Opposite remedy: nothing is going to clear, so telling the user to wait
+    // and hunt for a stuck app server sends them after the wrong problem.
+    const msg = explainConnectionFailure(withStderr(
+      "Error: failed to initialize sqlite state runtime under /bad/dir: unable to open database file",
+    ));
+    expect(msg).toMatch(/could not open its state database/);
+    expect(msg).toMatch(/retrying will not help/);
+    expect(msg).not.toMatch(/Another Codex process/);
+    expect(msg).toContain("/bad/dir");
+  });
+
+  test("claims a retry only when one actually happened", () => {
+    // withClient's post-handshake busy fallback and any external caller reach
+    // the explanation having spawned exactly once.
+    const once = withStderr("Error: database is locked");
+    expect(explainConnectionFailure(once)).not.toMatch(/already retried/);
+    expect(explainConnectionFailure(Object.assign(once, { appServerRetried: true })))
+      .toMatch(/already retried once/);
+  });
+
+  test("explains nothing for an unrelated crash", () => {
+    // A false match would misexplain the failure, which is worse than the
+    // bare error — so an unrecognized stderr must stay silent.
+    expect(explainConnectionFailure(withStderr("thread 'main' panicked at src/lib.rs:42"))).toBeNull();
+    expect(explainConnectionFailure(new Error("App server process exited unexpectedly"))).toBeNull();
+    expect(explainConnectionFailure(null)).toBeNull();
+  });
+
+  test("falls back to CODEX_HOME when the path is not in the message", () => {
+    const prev = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/custom/codex";
+    try {
+      expect(explainConnectionFailure(withStderr("Error: database is locked"))).toContain("/custom/codex");
+    } finally {
+      if (prev === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prev;
+    }
+  });
+
+  test("a real startup death carries its stderr through to the explanation", async () => {
+    // End-to-end: the tail must survive connectDirect's failure path, not
+    // just be reachable when a test hands it in.
+    const { mkdirSync, existsSync } = await import("fs");
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    const dying = join(TEST_DIR, "locked-app-server.ts");
+    await Bun.write(dying, `#!/usr/bin/env bun
+process.stderr.write("Error: failed to initialize sqlite state runtime under /home/u/.codex: locked\\n");
+setTimeout(() => process.exit(1), 30);
+`);
+    const error = await captureErrorMessage(connect({
+      command: ["bun", "run", dying],
+      requestTimeout: 5000,
+    }).catch((e) => { throw Object.assign(e, { explained: explainConnectionFailure(e) }); }));
+    expect(error).toContain("App server process exited unexpectedly");
+  }, 20000);
+});
+
+describe("startup retry policy vs state failures", () => {
+  test("an unopenable state directory is not retried", async () => {
+    // Deterministic: the second spawn fails identically 750ms later, and the
+    // retry notice would tell the user to expect contention that isn't there.
+    const { mkdirSync, existsSync } = await import("fs");
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    const counter = join(TEST_DIR, `cantopen-counter-${Date.now()}`);
+    const script = join(TEST_DIR, "cantopen-app-server.ts");
+    await Bun.write(script, `#!/usr/bin/env bun
+const fs = require("fs");
+let n = 0; try { n = Number(fs.readFileSync(process.env.C, "utf-8")) || 0; } catch {}
+fs.writeFileSync(process.env.C, String(n + 1));
+process.stderr.write("Error: failed to initialize sqlite state runtime under /bad: unable to open database file\\n");
+setTimeout(() => process.exit(1), 20);
+`);
+    const logged: string[] = [];
+    const original = console.error;
+    console.error = (...a: unknown[]) => { logged.push(a.join(" ")); };
+    try {
+      await captureErrorMessage(connectWithRetry({
+        command: ["bun", "run", script],
+        requestTimeout: 5000,
+        env: { C: counter },
+      }));
+    } finally {
+      console.error = original;
+    }
+    const { readFileSync, rmSync } = await import("fs");
+    expect(Number(readFileSync(counter, "utf-8"))).toBe(1); // one spawn, not two
+    expect(logged.some((l) => /retrying once/i.test(l))).toBe(false);
+    rmSync(counter, { force: true });
+  }, 20000);
+});
+
+describe("stderr retained across chunk boundaries", () => {
+  test("a message split by the stream still classifies", async () => {
+    // Chunk boundaries are arbitrary. Trimming each chunk and joining with
+    // newlines turned "database is" + " locked" into "database is\nlocked",
+    // so the lock classifier missed a failure it should have named.
+    const { mkdirSync, existsSync } = await import("fs");
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    const split = join(TEST_DIR, "split-stderr-app-server.ts");
+    await Bun.write(split, `#!/usr/bin/env bun
+process.stderr.write("Error: failed to initialize sqlite state runtime under /home/u/.codex: database is");
+setTimeout(() => {
+  process.stderr.write(" locked\\n");
+  setTimeout(() => process.exit(1), 30);
+}, 40);
+`);
+    let captured: unknown = null;
+    try {
+      await connect({ command: ["bun", "run", split], requestTimeout: 5000 });
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).not.toBeNull();
+    const msg = explainConnectionFailure(captured);
+    expect(msg).toMatch(/Another Codex process is using/);
+    expect(msg).toContain("/home/u/.codex");
+  }, 20000);
+});
+
+
+describe("withStartupLock", () => {
+  const HOME = process.env.CODEX_HOME;
+  let lockHome: string;
+
+  beforeEach(async () => {
+    const { mkdtempSync } = await import("fs");
+    lockHome = mkdtempSync(join(tmpdir(), "codex-lock-test-"));
+    process.env.CODEX_HOME = lockHome;
+  });
+
+  afterEach(async () => {
+    if (HOME === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = HOME;
+    const { rmSync } = await import("fs");
+    rmSync(lockHome, { recursive: true, force: true });
+  });
+
+  test("serializes concurrent startups against one CODEX_HOME", async () => {
+    // Measured against the real binary: six concurrent app-server starts on a
+    // fresh CODEX_HOME lost 1-3 of them to "failed to initialize state
+    // runtime", and lost none once serialized. This pins the serialization
+    // without needing codex present.
+    const spans: Array<[number, number]> = [];
+    await Promise.all(Array.from({ length: 3 }, () =>
+      withStartupLock(async () => {
+        const start = Date.now();
+        await new Promise((r) => setTimeout(r, 80));
+        spans.push([start, Date.now()]);
+      }),
+    ));
+    expect(spans.length).toBe(3);
+    spans.sort((a, b) => a[0] - b[0]);
+    for (let i = 1; i < spans.length; i++) {
+      // Each start must follow the previous end — overlap means the lock did
+      // not hold, which is the whole failure being prevented.
+      expect(spans[i][0]).toBeGreaterThanOrEqual(spans[i - 1][1] - 5);
+    }
+  }, 20000);
+
+  test("runs the work even when the lock cannot be taken", async () => {
+    // Fails OPEN by design: a coordination primitive that can wedge every
+    // startup is worse than the race it removes. Third-party app-servers
+    // never take this lock either, so recovery is required regardless.
+    process.env.CODEX_HOME = "/proc/nonexistent-cannot-mkdir";
+    let ran = false;
+    await withStartupLock(async () => { ran = true; });
+    expect(ran).toBe(true);
+  }, 20000);
+
+  test("creates the lock inside CODEX_HOME, not the workspace", async () => {
+    const { existsSync } = await import("fs");
+    await withStartupLock(async () => {
+      expect(existsSync(join(lockHome, "app-server-startup.lock"))).toBe(true);
+    });
+  }, 20000);
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1017,11 +1017,33 @@ describe.skipIf(!LOCK_DIR_WRITABLE)("withStartupLock", () => {
     // Fails OPEN by design: a coordination primitive that can wedge every
     // startup is worse than the race it removes. Third-party app-servers
     // never take this lock either, so recovery is required regardless.
-    process.env.CODEX_HOME = "/proc/nonexistent-cannot-mkdir";
+    //
+    // Hold the lock for real rather than pointing CODEX_HOME at an
+    // unwritable path: the file lives in OUR state dir and is only KEYED by
+    // CODEX_HOME, so a bogus home still acquires cleanly and would assert
+    // nothing. A fresh mtime also keeps the holder off the stale path, so
+    // this exercises the timeout branch rather than a stale break.
+    const { mkdirSync, writeFileSync, rmSync } = await import("fs");
+    const heldLock = startupLockPath();
+    mkdirSync(join(config.dataDir, "locks"), { recursive: true, mode: 0o700 });
+    writeFileSync(heldLock, "", { flag: "wx" });
+
+    const warnings: string[] = [];
+    const original = console.error;
+    console.error = (...a: unknown[]) => { warnings.push(a.join(" ")); };
     let ran = false;
-    await withStartupLock(async () => { ran = true; });
+    try {
+      await withStartupLock(async () => { ran = true; });
+    } finally {
+      console.error = original;
+      rmSync(heldLock, { force: true });
+    }
+
     expect(ran).toBe(true);
-  }, 20000);
+    // Distinguishes failing open from quietly acquiring — without this the
+    // assertion above passes even with the catch removed.
+    expect(warnings.some((w) => /could not serialize app-server startup/.test(w))).toBe(true);
+  }, 30000);
 
   test("keys the lock by CODEX_HOME but keeps the file in our own state dir", async () => {
     // ~/.codex belongs to codex. Scattering files through another program's

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,10 @@
 // exit monitoring, platform-specific shutdown, and the initialize handshake.
 
 import { spawn as childSpawn, spawnSync } from "child_process";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { acquireLockAsync } from "./lock";
 import type { InitializeParams, InitializeResponse, RequestId } from "./types";
 import { config } from "./config";
 import {
@@ -42,6 +46,12 @@ export interface ConnectOptions {
   env?: Record<string, string>;
   /** Request timeout in ms. Defaults to config.requestTimeout (30s). */
   requestTimeout?: number;
+  /** Called with the child's PID as soon as it is spawned, before the
+   *  handshake. Lets a caller clean up an app-server it can otherwise only
+   *  reach through the returned client — which never arrives if the
+   *  handshake hangs. Fires once per attempt, so a retry reports the new
+   *  PID and the old one is already dead. */
+  onSpawn?: (pid: number) => void;
 }
 
 /** The client interface returned by connectDirect(). */
@@ -107,6 +117,16 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
   });
 
   let exited = false;
+
+  if (proc.pid) {
+    try {
+      opts?.onSpawn?.(proc.pid);
+    } catch (e) {
+      // A misbehaving observer must not take down the connection it is
+      // observing — the PID is a courtesy, not part of the handshake.
+      console.error(`[codex] Warning: onSpawn observer threw: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
 
   /** Signal the app-server's process group (Unix, detached) with a fallback
    *  to the direct child; plain child kill elsewhere. */
@@ -185,13 +205,20 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
     });
   });
 
-  // Drain stderr and log non-empty output
+  // Drain stderr and log non-empty output. The tail is also retained: when
+  // the process dies before the handshake completes, its stderr is the only
+  // statement of WHY, and the exit alone ("process exited unexpectedly")
+  // cannot tell a locked state directory from a crash.
+  let stderrTail = "";
   proc.stderr.setEncoding("utf8");
   proc.stderr.on("data", (chunk: string) => {
+    // Retain the RAW text. Stream chunk boundaries are arbitrary, so trimming
+    // each chunk and joining with newlines rewrites the message: "database is"
+    // + " locked" would become "database is\nlocked" and the classifier that
+    // reads this tail would miss it. Trim only for display.
+    stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
     const text = chunk.trim();
-    if (text) {
-      console.error(`[codex] app-server stderr: ${text}`);
-    }
+    if (text) console.error(`[codex] app-server stderr: ${text}`);
   });
 
   /** Wait for the process to exit within the given timeout. The timer is
@@ -257,9 +284,9 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
     // a group sweep: the leader dying says nothing about descendants (a
     // server exiting on stdin EOF can leave a spawned command running,
     // and a straggler can ignore the group SIGTERM).
-    if (await waitForExit(5000)) { await sweepGroup(); return; }
+    if (await waitForExit(config.appServerStdinExitWait)) { await sweepGroup(); return; }
     killTree("SIGTERM");
-    if (await waitForExit(3000)) { await sweepGroup(); return; }
+    if (await waitForExit(config.appServerTermExitWait)) { await sweepGroup(); return; }
     killTree("SIGKILL");
     await procGone;
     await sweepGroup();
@@ -283,6 +310,12 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
     endpoint.notify("initialized");
   } catch (e) {
     await close();
+    // Carry the stderr so callers can say what went wrong rather than only
+    // that something did. Attached rather than wrapped: the message text is
+    // what classifies retryability and what exitCodeForError reads.
+    if (e instanceof Error && stderrTail) {
+      (e as Error & { appServerStderr?: string }).appServerStderr = stderrTail;
+    }
     throw e;
   }
 
@@ -298,4 +331,237 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
     userAgent: initResult.userAgent,
     brokerBusy: false,
   };
+}
+
+/**
+ * Serialize app-server *initialization* against a CODEX_HOME.
+ *
+ * Codex takes an exclusive lock on its shared sqlite state while an
+ * app-server starts, so two starting at once means one dies with
+ * "failed to initialize state runtime". Measured on a fresh CODEX_HOME: six
+ * concurrent starts lost 1-3 of them across three runs, and lost none once
+ * serialized (~2s for all six). The window is initialization only —
+ * app-servers coexist happily once up, which is why the lock is released as
+ * soon as the handshake returns rather than held for the connection.
+ *
+ * The lock file lives IN CODEX_HOME, because that is the resource that
+ * contends — a per-workspace lock would not see a collision between two
+ * workspaces, which is the common case (an editor session plus a run).
+ *
+ * FAILS OPEN. If the lock cannot be taken, start anyway and let the retry
+ * absorb a collision: a coordination primitive that can wedge every startup
+ * is worse than the race it removes. Third-party app-servers (the codex TUI,
+ * an IDE) never take it either, so recovery is required regardless.
+ */
+export async function withStartupLock<T>(fn: () => Promise<T>): Promise<T> {
+  let release: (() => void) | null = null;
+  try {
+    const home = resolve(process.env.CODEX_HOME ?? join(homedir(), ".codex"));
+    mkdirSync(home, { recursive: true, mode: 0o700 });
+    release = await acquireLockAsync(join(home, "app-server-startup.lock"));
+  } catch (e) {
+    console.error(`[codex] Warning: could not serialize app-server startup (${e instanceof Error ? e.message : String(e)}); starting anyway.`);
+  }
+  try {
+    return await fn();
+  } finally {
+    release?.();
+  }
+}
+
+/** How long to let a dying app-server release the sqlite state before the
+ *  retry spawns its replacement. The lock is held only across initialization,
+ *  so this is a settle delay, not a backoff schedule. */
+const STARTUP_RETRY_DELAY_MS = 750;
+
+/** Bound on the retained stderr tail. Enough for a stack trace or a few
+ *  startup errors; small enough that a chatty app-server cannot grow it. */
+const STDERR_TAIL_LIMIT = 4000;
+
+/** SQLITE_CANTOPEN: the state directory is missing, unwritable, or not where
+ *  codex was told to look. Distinct from contention and nearly its opposite —
+ *  nothing is going to clear, so "wait and retry" would be actively wrong. */
+const STATE_UNOPENABLE_SIGNATURES = [
+  /unable to open database/i,
+  /SQLITE_CANTOPEN/i,
+];
+
+/** SQLITE_BUSY / SQLITE_LOCKED: another process holds the exclusive lock.
+ *  Only these justify telling someone to wait — codex's own wrapper message
+ *  is NOT one of them, because it is emitted for every underlying cause
+ *  including corruption and a full disk. */
+const STATE_LOCK_SIGNATURES = [
+  /database is locked/i,
+  /database table is locked/i,
+  /SQLITE_BUSY/i,
+  /SQLITE_LOCKED/i,
+];
+
+/** Codex's wrapper around whatever actually went wrong. On its own it says
+ *  only that the state database could not be brought up — the cause could be
+ *  contention, permissions, corruption, or a full disk, so the advice has to
+ *  stay open rather than assert one of them. */
+const STATE_INIT_SIGNATURES = [
+  /failed to initialize (the )?sqlite state runtime/i,
+  /failed to initialize state runtime/i,
+];
+
+/** The stderr an app-server produced before it died, when the failure came
+ *  from `connectDirect`'s handshake. Null for any other error. */
+export function appServerStderrOf(e: unknown): string | null {
+  const s = (e as { appServerStderr?: unknown } | null)?.appServerStderr;
+  return typeof s === "string" && s.length > 0 ? s : null;
+}
+
+/** True when this failure survived a `connectDirectWithRetry` second attempt.
+ *  A direct connection taken outside that wrapper spawned exactly once, and
+ *  advice that says otherwise is telling the user something untrue about
+ *  what was already tried. */
+export function wasRetried(e: unknown): boolean {
+  return (e as { appServerRetried?: unknown } | null)?.appServerRetried === true;
+}
+
+/** What an app-server's dying stderr says about codex's shared state, if
+ *  anything. One classifier for every consumer — the retry decision, the
+ *  retry notice, and the final explanation must not disagree about what
+ *  went wrong. */
+function classifyStateFailure(stderr: string | null): "locked" | "unopenable" | "uninitialized" | null {
+  if (!stderr) return null;
+  // Specific causes first: the wrapper wraps all of them, so testing it early
+  // would swallow every cause into one verdict.
+  if (STATE_UNOPENABLE_SIGNATURES.some((re) => re.test(stderr))) return "unopenable";
+  if (STATE_LOCK_SIGNATURES.some((re) => re.test(stderr))) return "locked";
+  if (STATE_INIT_SIGNATURES.some((re) => re.test(stderr))) return "uninitialized";
+  return null;
+}
+
+function stateDirFromStderr(stderr: string): string {
+  // codex names the directory in the message; prefer it over guessing at
+  // CODEX_HOME, which the failing process may have resolved differently.
+  // The path runs to the ": <cause>" separator or the end of the line — not
+  // to the first space, which would cut "C:\\Users\\First Last\\.codex" in half.
+  // A drive letter's colon is safe: the terminator requires colon-then-space.
+  const m = stderr.match(/state runtime (?:under|at) (.+?)(?::\s|\s*$)/m);
+  return m?.[1] ?? process.env.CODEX_HOME ?? "~/.codex";
+}
+
+/**
+ * A plain-language explanation of why a connection failed, or null when we
+ * have nothing better to say than the error itself.
+ *
+ * "App server process exited unexpectedly" is true and useless — it names a
+ * symptom, and the cause sits in a stderr line the user has no reason to
+ * connect to it. Same shape as `explainErrorInfo` for turn errors: return
+ * advice only when it is actually specific.
+ */
+export function explainConnectionFailure(e: unknown): string | null {
+  const stderr = appServerStderrOf(e);
+  if (!stderr) return null;
+  const kind = classifyStateFailure(stderr);
+  if (kind === null) return null;
+  const dir = stateDirFromStderr(stderr);
+  // `ps aux` does not exist in cmd or PowerShell, and advice a user cannot
+  // run is worse than none — it reads as "this tool was not built for you".
+  const listProcesses = process.platform === "win32"
+    ? "tasklist | findstr codex"
+    : `ps aux | grep "codex app-server"`;
+
+  if (kind === "unopenable") {
+    return (
+      `Codex could not open its state database in ${dir}. That directory is missing, ` +
+      `not writable, or not where Codex expects it — retrying will not help.\n` +
+      `Check it exists and is writable (CODEX_HOME overrides the location), then run ` +
+      `'codex-collab health'.`
+    );
+  }
+
+  if (kind === "locked") {
+    // Only claim a retry when one actually happened: direct connections taken
+    // outside connectDirectWithRetry (the post-handshake broker-busy fallback,
+    // and any external caller) reach here having spawned exactly once.
+    const retried = wasRetried(e) ? " This was already retried once." : "";
+    return (
+      `Another Codex process is using the shared state in ${dir}. Codex locks a database ` +
+      `while an app server starts, so two starting at once cannot both win.${retried}\n` +
+      `Wait a few seconds and run it again. If it keeps happening, look for a stuck app ` +
+      `server with '${listProcesses}', or run 'codex-collab health'.`
+    );
+  }
+
+  // The wrapper fired without naming a cause. Contention is the common one,
+  // but corruption, a full disk and a permissions problem all land here too —
+  // so point at the underlying error rather than asserting which it was.
+  return (
+    `Codex could not initialize its state database in ${dir}.\n` +
+    `Most often another Codex process is starting at the same moment; it can also be a ` +
+    `directory that is not writable, or a damaged database. The 'app-server stderr' line ` +
+    `above carries the underlying cause. Check running app servers with '${listProcesses}', ` +
+    `then run 'codex-collab health'.`
+  );
+}
+
+/** True when the app-server died *while starting*, as opposed to never
+ *  starting at all.
+ *
+ *  Codex initializes a shared sqlite state runtime under CODEX_HOME on
+ *  startup and holds it exclusively while it does. A second app-server
+ *  entering that window loses and exits — which is contention, not a broken
+ *  install, and it clears in milliseconds. Distinguishing the two matters:
+ *  retrying contention costs one spawn and usually succeeds, while retrying a
+ *  missing binary just fails twice as slowly. */
+function isTransientStartupFailure(e: unknown): boolean {
+  // A directory that cannot be opened is as deterministic as a missing
+  // binary: the second spawn fails identically, 750ms later.
+  if (classifyStateFailure(appServerStderrOf(e)) === "unopenable") return false;
+  const msg = e instanceof Error ? e.message : String(e);
+  // Spawn failures (ENOENT — codex not installed) are deterministic and must
+  // never be retried: it would double the wait for the same error and bury
+  // the install hint. On Unix they surface one of two ways depending on which
+  // loses the race — the spawn 'error' event, or the handshake write into a
+  // stdin that was never opened — so neither wording is in the retry set.
+  //
+  // Windows is different and deliberately left alone: commands run through a
+  // `cmd.exe /c` shim, so the shim always spawns and a missing binary reads
+  // exactly like an app-server that started and died. It is retried, costing
+  // one extra spawn before the same error surfaces. That ambiguity predates
+  // this retry — the install hint never fired on Windows either — and the
+  // only ways to break the tie are a localized cmd.exe message or a magic
+  // exit code, both worse than paying a second of latency on a broken
+  // install.
+  return msg.includes("App server process exited unexpectedly");
+}
+
+/**
+ * `connectDirect`, retried once when the app-server dies during startup.
+ *
+ * Use this anywhere a direct connection is a *fallback* — those paths spawn
+ * an app-server moments after another one was killed or is still coming up,
+ * which is exactly when the state-runtime collision happens. A single retry
+ * converts that hard failure into a sub-second pause.
+ */
+export async function connectDirectWithRetry(opts?: ConnectOptions): Promise<AppServerClient> {
+  try {
+    return await withStartupLock(() => connectDirect(opts));
+  } catch (e) {
+    if (!isTransientStartupFailure(e)) throw e;
+    const stderr = appServerStderrOf(e);
+    console.error(
+      classifyStateFailure(stderr) === "locked"
+        ? `[codex] App server exited while starting — another Codex process is using the shared state in ${stateDirFromStderr(stderr!)}. Retrying once.`
+        : "[codex] App server exited while starting. Retrying once.",
+    );
+    await new Promise((r) => setTimeout(r, STARTUP_RETRY_DELAY_MS));
+    try {
+      // Re-acquired per attempt, not held across the delay — blocking every
+      // other startup while we wait would make one collision everyone's.
+      return await withStartupLock(() => connectDirect(opts));
+    } catch (again) {
+      // Record that a second spawn happened, so the failure can say so and
+      // nothing else has to claim it on faith.
+      if (again instanceof Error) {
+        (again as Error & { appServerRetried?: boolean }).appServerRetried = true;
+      }
+      throw again;
+    }
+  }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -353,10 +353,18 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
  * is worse than the race it removes. Third-party app-servers (the codex TUI,
  * an IDE) never take it either, so recovery is required regardless.
  */
-export async function withStartupLock<T>(fn: () => Promise<T>): Promise<T> {
+export async function withStartupLock<T>(
+  fn: () => Promise<T>,
+  childEnv?: Record<string, string>,
+): Promise<T> {
   let release: (() => void) | null = null;
   try {
-    const home = resolve(process.env.CODEX_HOME ?? join(homedir(), ".codex"));
+    // The CHILD's home, not ours. connectDirect lets a caller override
+    // CODEX_HOME (or HOME) for the spawned process, and locking on the parent
+    // environment would put two processes that share a child state directory
+    // on different locks — serializing nothing.
+    const env = { ...process.env, ...childEnv };
+    const home = resolve(env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex"));
     mkdirSync(home, { recursive: true, mode: 0o700 });
     release = await acquireLockAsync(join(home, "app-server-startup.lock"));
   } catch (e) {
@@ -541,7 +549,7 @@ function isTransientStartupFailure(e: unknown): boolean {
  */
 export async function connectDirectWithRetry(opts?: ConnectOptions): Promise<AppServerClient> {
   try {
-    return await withStartupLock(() => connectDirect(opts));
+    return await withStartupLock(() => connectDirect(opts), opts?.env);
   } catch (e) {
     if (!isTransientStartupFailure(e)) throw e;
     const stderr = appServerStderrOf(e);
@@ -554,7 +562,7 @@ export async function connectDirectWithRetry(opts?: ConnectOptions): Promise<App
     try {
       // Re-acquired per attempt, not held across the delay — blocking every
       // other startup while we wait would make one collision everyone's.
-      return await withStartupLock(() => connectDirect(opts));
+      return await withStartupLock(() => connectDirect(opts), opts?.env);
     } catch (again) {
       // Record that a second spawn happened, so the failure can say so and
       // nothing else has to claim it on faith.

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import { spawn as childSpawn, spawnSync } from "child_process";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { createHash } from "node:crypto";
 import { acquireLockAsync } from "./lock";
 import type { InitializeParams, InitializeResponse, RequestId } from "./types";
 import { config } from "./config";
@@ -344,28 +345,43 @@ export async function connectDirect(opts?: ConnectOptions): Promise<AppServerCli
  * app-servers coexist happily once up, which is why the lock is released as
  * soon as the handshake returns rather than held for the connection.
  *
- * The lock file lives IN CODEX_HOME, because that is the resource that
- * contends — a per-workspace lock would not see a collision between two
- * workspaces, which is the common case (an editor session plus a run).
+ * Keyed on CODEX_HOME, because that is the resource that contends — a
+ * per-workspace lock would not see a collision between two workspaces, which
+ * is the common case (an editor session plus a run). The file itself lives in
+ * our own state directory rather than codex's: we do not own ~/.codex, and a
+ * tool that scatters files through another program's directory is a tool
+ * people are right to distrust.
  *
  * FAILS OPEN. If the lock cannot be taken, start anyway and let the retry
  * absorb a collision: a coordination primitive that can wedge every startup
  * is worse than the race it removes. Third-party app-servers (the codex TUI,
  * an IDE) never take it either, so recovery is required regardless.
  */
+/**
+ * Where the startup lock for a given child environment lives.
+ *
+ * Derived, never configured. Uses the CHILD's home: connectDirect lets a
+ * caller override CODEX_HOME (or HOME) for the spawned process, and keying on
+ * the parent's would put two processes that share a child state directory on
+ * different locks — serializing nothing.
+ *
+ * Exported for tests.
+ */
+export function startupLockPath(childEnv?: Record<string, string>): string {
+  const env = { ...process.env, ...childEnv };
+  const home = resolve(env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex"));
+  const key = createHash("sha256").update(home).digest("hex").slice(0, 16);
+  return join(config.dataDir, "locks", `app-server-${key}.lock`);
+}
+
 export async function withStartupLock<T>(
   fn: () => Promise<T>,
   childEnv?: Record<string, string>,
 ): Promise<T> {
   let release: (() => void) | null = null;
   try {
-    // The CHILD's home, not ours. connectDirect lets a caller override
-    // CODEX_HOME (or HOME) for the spawned process, and locking on the parent
-    // environment would put two processes that share a child state directory
-    // on different locks — serializing nothing.
-    const env = { ...process.env, ...childEnv };
-    const home = resolve(env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex"));
-    mkdirSync(home, { recursive: true, mode: 0o700 });
+    const lockPath = startupLockPath(childEnv);
+    mkdirSync(join(config.dataDir, "locks"), { recursive: true, mode: 0o700 });
     // Bounds tuned to what this lock actually guards. A real initialization
     // measures 260-860ms (fresh home to a 333MB one), so a holder older than
     // ten seconds is dead or wedged, and breaking its lock is safe — a
@@ -373,7 +389,7 @@ export async function withStartupLock<T>(
     // after five seconds matters because release() runs in a finally, which
     // process.exit() skips: a run killed mid-startup leaves the file behind,
     // and at the defaults that cost every later invocation 30 seconds.
-    release = await acquireLockAsync(join(home, "app-server-startup.lock"), {
+    release = await acquireLockAsync(lockPath, {
       staleThresholdMs: 10_000,
       maxAttempts: 100,
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -366,7 +366,17 @@ export async function withStartupLock<T>(
     const env = { ...process.env, ...childEnv };
     const home = resolve(env.CODEX_HOME ?? join(env.HOME ?? homedir(), ".codex"));
     mkdirSync(home, { recursive: true, mode: 0o700 });
-    release = await acquireLockAsync(join(home, "app-server-startup.lock"));
+    // Bounds tuned to what this lock actually guards. A real initialization
+    // measures 260-860ms (fresh home to a 333MB one), so a holder older than
+    // ten seconds is dead or wedged, and breaking its lock is safe — a
+    // resulting collision is what the retry below exists for. Failing open
+    // after five seconds matters because release() runs in a finally, which
+    // process.exit() skips: a run killed mid-startup leaves the file behind,
+    // and at the defaults that cost every later invocation 30 seconds.
+    release = await acquireLockAsync(join(home, "app-server-startup.lock"), {
+      staleThresholdMs: 10_000,
+      maxAttempts: 100,
+    });
   } catch (e) {
     console.error(`[codex] Warning: could not serialize app-server startup (${e instanceof Error ? e.message : String(e)}); starting anyway.`);
   }

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -11,7 +11,7 @@ import {
   type ApprovalPolicy,
   type ApprovalMode,
 } from "../config";
-import { type AppServerClient, connectDirect } from "../client";
+import { type AppServerClient, connectDirectWithRetry } from "../client";
 import { ensureConnection, getCurrentSessionId, isBrokerBusyError } from "../broker";
 import {
   registerThread,
@@ -750,7 +750,10 @@ export async function withClient<T>(fn: (client: AppServerClient) => Promise<T>,
       // sequence.
       console.error("[broker] Broker became busy after handshake — retrying with direct connection.");
       await safeCloseClient(client);
-      client = await connectDirect({ cwd: workingDir });
+      // Retrying variant: this spawns an app-server while the busy broker's
+      // is still live, which is exactly when they contend for codex's sqlite
+      // state — the one path that most needs the second attempt.
+      client = await connectDirectWithRetry({ cwd: workingDir });
       activeClient = client;
       return await fn(client);
     }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -347,3 +347,31 @@ describe("describeAuth (health account check)", () => {
     expect(describeAuth({ account: null }).detail).not.toMatch(/NOT AUTHENTICATED/);
   });
 });
+
+describe("brokerReadyTimeout", () => {
+  const ENV = "CODEX_COLLAB_BROKER_READY_TIMEOUT_MS";
+  const original = process.env[ENV];
+  afterAll(() => {
+    if (original === undefined) delete process.env[ENV];
+    else process.env[ENV] = original;
+  });
+
+  test("defaults to a window wide enough for a cold app-server", () => {
+    delete process.env[ENV];
+    // Falling back early does not save the caller time — it only adds a
+    // second concurrent app-server startup, which is what collides.
+    expect(config.brokerReadyTimeout).toBe(30_000);
+  });
+
+  test("honors the env override so tests can shorten it", () => {
+    process.env[ENV] = "250";
+    expect(config.brokerReadyTimeout).toBe(250);
+  });
+
+  test("ignores a non-positive or unparseable override", () => {
+    for (const bad of ["0", "-1", "abc", ""]) {
+      process.env[ENV] = bad;
+      expect(config.brokerReadyTimeout).toBe(30_000);
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,30 @@ export const config = {
     }
     return 30 * 60 * 1000; // 30 min in ms
   },
+  // How long a freshly spawned broker gets to bind its socket before the
+  // caller gives up and connects directly. Generous on purpose: falling back
+  // early saves the caller nothing, because a direct connection pays the same
+  // app-server startup cost — it only adds a SECOND concurrent startup, and
+  // concurrent startups are what collide on codex's shared sqlite state. The
+  // wait is cut short anyway when the broker process exits, so this deadline
+  // is only ever paid by a broker that is genuinely still coming up.
+  // Overridable via CODEX_COLLAB_BROKER_READY_TIMEOUT_MS for tests.
+  get brokerReadyTimeout(): number {
+    const raw = process.env.CODEX_COLLAB_BROKER_READY_TIMEOUT_MS;
+    if (raw !== undefined) {
+      const n = Number(raw);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+    return 30_000; // 30s in ms
+  },
+
+  // Stages of connectDirect's close(). Named here rather than inlined so the
+  // shutdown path's cost is legible; nothing's correctness depends on them.
+  appServerStdinExitWait: 5_000,   // stdin EOF → SIGTERM
+  appServerTermExitWait: 3_000,    // SIGTERM → SIGKILL
+  /** Reap bound for the broker's startup guard, which kills the app-server
+   *  by PID rather than through close(). */
+  appServerReapTimeout: 3_000,
 
   // Limits
   maxRunsPerWorkspace: 50,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -162,6 +162,10 @@ const runIntegration =
   process.env.RUN_INTEGRATION === "1" &&
   Bun.spawnSync([process.platform === "win32" ? "where" : "which", "codex"]).exitCode === 0;
 
+if (!runIntegration) {
+  console.warn("\n⚠️  live integration suite SKIPPED — set RUN_INTEGRATION=1 (and have codex on PATH) to run it.\n");
+}
+
 describe.skipIf(!runIntegration)("live integration", () => {
   // Import connect lazily so the module isn't loaded when tests are skipped
   let connect: typeof import("./client").connectDirect;

--- a/src/process.test.ts
+++ b/src/process.test.ts
@@ -173,6 +173,50 @@ describe("isProcessAlive", () => {
   });
 });
 
+describe("escalation reaches a group that outlived its leader", () => {
+  test("a descendant ignoring SIGTERM is still SIGKILLed after the grace", async () => {
+    // The app-server is a detached group LEADER whose tool subprocesses are
+    // members, so "leader exited, group did not" is the normal shape of a
+    // stuck tree — and gating escalation on the leader's own liveness strands
+    // exactly the descendant the escalation exists to reap.
+    if (process.platform === "win32") return; // no process groups
+    const pidFile = join(tmpdir(), `grouped-child-${process.pid}-${Date.now()}`);
+    // Leader backgrounds a TERM-ignoring child into its own group, records the
+    // child's pid, then exits — leaving the group alive without its leader.
+    const leader = spawn(
+      "bash",
+      ["-c", `bun -e 'process.on("SIGTERM",()=>{});setInterval(()=>{},1000)' & echo $! > "${pidFile}"; exit 0`],
+      { stdio: "ignore", detached: true },
+    );
+    const pgid = leader.pid!;
+    let childPid = 0;
+    try {
+      for (let i = 0; i < 100 && !childPid; i++) {
+        if (existsSync(pidFile)) childPid = Number(readFileSync(pidFile, "utf-8").trim());
+        if (!childPid) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(childPid).toBeGreaterThan(0);
+      // Let the leader exit and the child install its handler.
+      await new Promise((r) => setTimeout(r, 600));
+      expect(isProcessAlive(pgid)).toBe(false); // leader really is gone
+      expect(isProcessAlive(childPid)).toBe(true); // group really is not
+
+      terminateProcessTree(pgid, 300);
+
+      let alive = true;
+      for (let i = 0; i < 40 && alive; i++) {
+        alive = isProcessAlive(childPid);
+        if (alive) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(alive).toBe(false);
+    } finally {
+      if (childPid) { try { process.kill(childPid, "SIGKILL"); } catch {} }
+      try { process.kill(-pgid, "SIGKILL"); } catch {}
+      rmSync(pidFile, { force: true });
+    }
+  }, 30000);
+});
+
 describe("delayed SIGKILL identity check", () => {
   test("a process that exits during the grace is not escalated against", async () => {
     // The escalation timer outlives its target. Without an identity check it

--- a/src/process.test.ts
+++ b/src/process.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { terminateProcessTree, isProcessAlive } from "./process";
+import { terminateProcessTree, isProcessAlive, waitForProcessTreeExit } from "./process";
 import { spawn } from "child_process";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 
 // ─── terminateProcessTree ──────────────────────────────────────────────────
 
@@ -23,6 +26,130 @@ describe("terminateProcessTree", () => {
 
   test("does not throw for non-existent PID", () => {
     expect(() => terminateProcessTree(99999999)).not.toThrow();
+  });
+
+  test("a longer grace lets a SIGTERM handler finish before SIGKILL", async () => {
+    // The broker's SIGTERM handler reaps its app-server before exiting. At
+    // the default 500ms grace it would be killed mid-reap, stranding the
+    // process holding codex's sqlite state — the failure this parameter
+    // exists to prevent.
+    if (process.platform === "win32") return; // taskkill /F has no grace to tune
+    const marker = join(tmpdir(), `grace-test-${process.pid}-${Date.now()}`);
+    const child = spawn(
+      "bash",
+      ["-c", `trap 'sleep 1; echo done > "${marker}"; exit 0' TERM; sleep 30 & wait`],
+      { stdio: "ignore", detached: true },
+    );
+    const pid = child.pid!;
+    try {
+      await new Promise((r) => setTimeout(r, 300)); // let the trap install
+      terminateProcessTree(pid, 4000);
+      await waitForProcessTreeExit(pid, 6000);
+      expect(existsSync(marker)).toBe(true);
+    } finally {
+      try { process.kill(-pid, "SIGKILL"); } catch {}
+      rmSync(marker, { force: true });
+    }
+  }, 20000);
+});
+
+// ─── waitForProcessTreeExit ────────────────────────────────────────────────
+
+describe("waitForProcessTreeExit", () => {
+  test("returns true immediately for a PID that is already gone", async () => {
+    const started = Date.now();
+    expect(await waitForProcessTreeExit(99999999, 2000)).toBe(true);
+    // Nothing to wait for, so it must not burn the deadline.
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test("returns false when the tree outlives the deadline", async () => {
+    const child = spawn("sleep", ["60"], { stdio: "ignore", detached: true });
+    const pid = child.pid!;
+    try {
+      expect(await waitForProcessTreeExit(pid, 200)).toBe(false);
+    } finally {
+      terminateProcessTree(pid);
+    }
+  });
+
+  test("returns true once a terminated tree is actually gone", async () => {
+    // The point of the helper: terminateProcessTree only SENDS signals, so a
+    // caller that respawns on the next line races the dying process. Awaiting
+    // this makes "terminated" mean "exited".
+    const child = spawn("sleep", ["60"], { stdio: "ignore", detached: true });
+    const pid = child.pid!;
+    child.unref();
+
+    terminateProcessTree(pid);
+    expect(await waitForProcessTreeExit(pid, 3000)).toBe(true);
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  test("terminating a parent takes its child with it", async () => {
+    // The premise the broker fallback rests on, and the one thing that differs
+    // by platform: Unix reaches the child through the process group, Windows
+    // through `taskkill /T`. Assert the OUTCOME so both mechanisms are covered
+    // — this is the only Windows-executed test of that guarantee.
+    const pidFile = join(tmpdir(), `child-pid-${process.pid}-${Date.now()}`);
+    const parent = spawn(
+      "bun",
+      ["-e", `const c = Bun.spawn(["sleep", "60"]); require("fs").writeFileSync(${JSON.stringify(pidFile)}, String(c.pid)); setInterval(() => {}, 1000);`],
+      { stdio: "ignore", detached: process.platform !== "win32" },
+    );
+    const parentPid = parent.pid!;
+    try {
+      let childPid = 0;
+      for (let i = 0; i < 100 && !childPid; i++) {
+        if (existsSync(pidFile)) childPid = Number(readFileSync(pidFile, "utf-8").trim());
+        if (!childPid) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(childPid).toBeGreaterThan(0);
+
+      terminateProcessTree(parentPid, 2000);
+      await waitForProcessTreeExit(parentPid, 5000);
+
+      let childAlive = true;
+      for (let i = 0; i < 40 && childAlive; i++) {
+        childAlive = isProcessAlive(childPid);
+        if (childAlive) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(childAlive).toBe(false);
+    } finally {
+      try { process.kill(parentPid, "SIGKILL"); } catch {}
+      rmSync(pidFile, { force: true });
+    }
+  }, 30000);
+
+  test("reports a single terminated process as gone on every platform", async () => {
+    // Windows has no process groups, so waitForProcessTreeExit degrades to a
+    // one-PID check there. Pin that it still answers correctly — the Unix
+    // group probe must not be the only path that works.
+    const child = spawn("sleep", ["60"], { stdio: "ignore" });
+    const pid = child.pid!;
+    terminateProcessTree(pid);
+    expect(await waitForProcessTreeExit(pid, 5000)).toBe(true);
+    expect(isProcessAlive(pid)).toBe(false);
+  }, 20000);
+
+  test("waits for a group member that outlives the leader", async () => {
+    // The app-server is a group MEMBER, not the leader we hold a PID for.
+    // Probing only the leader would report "gone" while the process still
+    // holding codex's sqlite state is alive — the exact race being closed.
+    if (process.platform === "win32") return; // no process groups
+    const leader = spawn(
+      "bash",
+      ["-c", "sleep 30 & sleep 0.2"],
+      { stdio: "ignore", detached: true },
+    );
+    const pgid = leader.pid!;
+    try {
+      // Leader exits after ~200ms; the backgrounded child keeps the group
+      // alive, so a 1s wait must still report the tree as present.
+      expect(await waitForProcessTreeExit(pgid, 1000)).toBe(false);
+    } finally {
+      terminateProcessTree(pgid);
+    }
   });
 });
 

--- a/src/process.test.ts
+++ b/src/process.test.ts
@@ -172,3 +172,20 @@ describe("isProcessAlive", () => {
     }
   });
 });
+
+describe("delayed SIGKILL identity check", () => {
+  test("a process that exits during the grace is not escalated against", async () => {
+    // The escalation timer outlives its target. Without an identity check it
+    // would SIGKILL whatever inherited the PID — a real hazard once the grace
+    // is seconds rather than milliseconds.
+    if (process.platform === "win32") return; // taskkill is immediate, no timer
+    const child = spawn("bash", ["-c", "exit 0"], { stdio: "ignore", detached: true });
+    const pid = child.pid!;
+    await new Promise<void>((r) => child.on("exit", () => r()));
+    // Schedule an escalation against an already-dead PID; it must not throw
+    // and must not signal anything when the timer fires.
+    expect(() => terminateProcessTree(pid, 150)).not.toThrow();
+    await new Promise((r) => setTimeout(r, 400));
+    expect(isProcessAlive(process.pid)).toBe(true); // we are still here
+  }, 20000);
+});

--- a/src/process.ts
+++ b/src/process.ts
@@ -175,8 +175,10 @@ function terminateUnix(pid: number, graceMs = 500): void {
   }
 
   // If still alive after a short grace period, escalate to SIGKILL.
-  const identity = processStartToken(pid);
   if (isProcessAlive(pid)) {
+    // Inside the liveness check: this shells out to `ps` synchronously, and
+    // a PID that is already gone needs no identity to compare against later.
+    const identity = processStartToken(pid);
     const timer = setTimeout(() => {
       // Re-verify before escalating. The target usually exits during the
       // grace, and killing a recycled PID would take out an unrelated

--- a/src/process.ts
+++ b/src/process.ts
@@ -21,6 +21,55 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 /**
+ * Wait for a terminated process tree to actually be gone.
+ *
+ * `terminateProcessTree` only *sends* signals — it returns while the tree is
+ * still shutting down. That matters because codex's app-server holds an
+ * exclusive lock on the shared sqlite state under CODEX_HOME while it exits:
+ * spawning a replacement inside that window dies with a state-runtime error.
+ * Waiting first turns "terminate, immediately respawn" into a safe sequence.
+ *
+ * Polls the process GROUP on Unix — callers spawn detached, so the pid is the
+ * group leader and the app-server is a group member that can outlive it.
+ *
+ * On Windows it polls that ONE pid, which is weaker than the name suggests and
+ * adequate only because the tree cannot outlive it there: `connectDirect`
+ * detaches on Unix only, so the app-server is a plain child, and the matching
+ * `terminateProcessTree` is a synchronous `taskkill /T /F` that has already
+ * taken the whole tree down by the time this is called. If either of those
+ * changes, this needs a real tree walk on Windows.
+ *
+ * Best effort by design: returns false on timeout instead of throwing, because
+ * proceeding without the guarantee still beats failing outright.
+ */
+export async function waitForProcessTreeExit(
+  pid: number,
+  timeoutMs: number,
+  pollMs = 25,
+): Promise<boolean> {
+  const treeAlive = (): boolean => {
+    if (isWindows) return isProcessAlive(pid);
+    try {
+      process.kill(-pid, 0);
+      return true;
+    } catch (e) {
+      // EPERM: the group exists but is not ours to signal — treat as alive.
+      if ((e as NodeJS.ErrnoException).code === "EPERM") return true;
+      // ESRCH on the group only means `pid` leads no group; the process
+      // itself may still be running, so fall through to the direct check.
+    }
+    return isProcessAlive(pid);
+  };
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!treeAlive()) return true;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return !treeAlive();
+}
+
+/**
  * Best-effort check that `pid` names a Bun process (the broker server runs
  * under bun). Guards PID-recycling misclassification when deciding whether a
  * version-mismatched broker is still alive WITHOUT touching its socket (a
@@ -49,23 +98,35 @@ export function processLooksLikeBun(pid: number): boolean {
  * Kill a process and its children.
  *
  * - Unix: sends SIGTERM first; if the process is still alive, schedules
- *   SIGKILL after 500 ms (long enough for the app-server to flush stdout).
- *   The SIGKILL timer is unref'd so it never blocks process exit.
+ *   SIGKILL after `graceMs` (default 500 ms — long enough for the app-server
+ *   to flush stdout). The SIGKILL timer is unref'd so it never blocks
+ *   process exit.
  * - Windows: uses `taskkill /PID <pid> /T /F`.
+ *
+ * Pass a longer `graceMs` when the target's SIGTERM handler has real work to
+ * do before it can exit. The broker is the case that matters: its handler
+ * closes the app-server it spawned and waits for that process group to go
+ * away, so escalating at the default would kill the broker mid-shutdown and
+ * strand the very process the caller is waiting on.
+ *
+ * `graceMs` is Unix-only and ignored on Windows: `taskkill /F` terminates
+ * without running handlers, so there is no shutdown to protect. Nothing is
+ * stranded either — the app-server is a plain child there (connectDirect only
+ * detaches on Unix), so `/T` takes the whole tree down together.
  *
  * If the process is already dead (ESRCH), this is a no-op.
  */
-export function terminateProcessTree(pid: number): void {
+export function terminateProcessTree(pid: number, graceMs = 500): void {
   if (isWindows) {
     terminateWindows(pid);
   } else {
-    terminateUnix(pid);
+    terminateUnix(pid, graceMs);
   }
 }
 
 // ─── internal ──────────────────────────────────────────────────────────────
 
-function terminateUnix(pid: number): void {
+function terminateUnix(pid: number, graceMs = 500): void {
   // Try the process group first (negative pid), then the process itself.
   // ESRCH on the group kill does NOT mean the process is dead — it just
   // means the pid is not a process-group leader.
@@ -108,7 +169,7 @@ function terminateUnix(pid: number): void {
           }
         }
       }
-    }, 500);
+    }, graceMs);
     // Don't keep the event loop alive waiting for an escalation that may
     // never be needed — caller may exit before the timer fires.
     timer.unref?.();

--- a/src/process.ts
+++ b/src/process.ts
@@ -70,6 +70,26 @@ export async function waitForProcessTreeExit(
 }
 
 /**
+ * True when the process group led by `pid` still has a live member.
+ *
+ * The group outliving its leader is the normal case here, not an edge one: the
+ * app-server is spawned detached as a group leader and its tool subprocesses
+ * are members, so a leader that exits on SIGTERM can leave members behind.
+ * A pgid stays reserved while any member lives, so a live group is never a
+ * recycled id — which is why escalating against one needs no identity check.
+ */
+function groupAlive(pid: number): boolean {
+  if (isWindows) return false; // no process groups; taskkill /T covers the tree
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM: the group exists but is not ours to signal — treat as alive.
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
  * Best-effort identity token for a running PID — its start time.
  *
  * PIDs are recycled. A delayed SIGKILL that fires after its target already
@@ -174,8 +194,11 @@ function terminateUnix(pid: number, graceMs = 500): void {
     }
   }
 
-  // If still alive after a short grace period, escalate to SIGKILL.
-  if (isProcessAlive(pid)) {
+  // If anything survives the grace period, escalate to SIGKILL. What we are
+  // escalating against is the GROUP, so the leader's own liveness is not the
+  // question — a leader that exits while a descendant ignores SIGTERM leaves
+  // a group that still needs killing.
+  if (isProcessAlive(pid) || groupAlive(pid)) {
     // Inside the liveness check: this shells out to `ps` synchronously, and
     // a PID that is already gone needs no identity to compare against later.
     const identity = processStartToken(pid);
@@ -183,8 +206,17 @@ function terminateUnix(pid: number, graceMs = 500): void {
       // Re-verify before escalating. The target usually exits during the
       // grace, and killing a recycled PID would take out an unrelated
       // process — a real risk once the grace is measured in seconds.
-      if (!isProcessAlive(pid)) return;
-      if (identity !== null && processStartToken(pid) !== identity) return;
+      //
+      // Only a LIVE leader can be a recycled pid, so only it needs the
+      // identity check. If the leader is gone but its group is not, the pgid
+      // is still reserved by the surviving members and is safe to signal —
+      // suppressing there would strand exactly the descendants this escalation
+      // exists to reap.
+      if (isProcessAlive(pid)) {
+        if (identity !== null && processStartToken(pid) !== identity) return;
+      } else if (!groupAlive(pid)) {
+        return;
+      }
       try {
         process.kill(-pid, "SIGKILL");
       } catch (e) {

--- a/src/process.ts
+++ b/src/process.ts
@@ -70,6 +70,30 @@ export async function waitForProcessTreeExit(
 }
 
 /**
+ * Best-effort identity token for a running PID — its start time.
+ *
+ * PIDs are recycled. A delayed SIGKILL that fires after its target already
+ * exited would otherwise land on whatever process inherited the number, and
+ * the wider the grace the likelier that is. One-second resolution, so a PID
+ * reused within the same second still matches; that is a far smaller window
+ * than the grace itself.
+ */
+function processStartToken(pid: number): string | null {
+  if (isWindows) return null;
+  try {
+    const r = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    if (r.error || r.status !== 0) return null;
+    const t = (r.stdout ?? "").trim();
+    return t === "" ? null : t;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Best-effort check that `pid` names a Bun process (the broker server runs
  * under bun). Guards PID-recycling misclassification when deciding whether a
  * version-mismatched broker is still alive WITHOUT touching its socket (a
@@ -151,8 +175,14 @@ function terminateUnix(pid: number, graceMs = 500): void {
   }
 
   // If still alive after a short grace period, escalate to SIGKILL.
+  const identity = processStartToken(pid);
   if (isProcessAlive(pid)) {
     const timer = setTimeout(() => {
+      // Re-verify before escalating. The target usually exits during the
+      // grace, and killing a recycled PID would take out an unrelated
+      // process — a real risk once the grace is measured in seconds.
+      if (!isProcessAlive(pid)) return;
+      if (identity !== null && processStartToken(pid) !== identity) return;
       try {
         process.kill(-pid, "SIGKILL");
       } catch (e) {

--- a/src/update-e2e.test.ts
+++ b/src/update-e2e.test.ts
@@ -39,6 +39,10 @@ function sh(cmd: string[], opts: { cwd?: string; env?: Record<string, string | u
   return { status: r.status ?? 1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 
+if (!enabled) {
+  console.warn("\n⚠️  update E2E suite SKIPPED — set RUN_UPDATE_E2E=1 (non-Windows, codex on PATH) to run it.\n");
+}
+
 describe.skipIf(!enabled)("update E2E against a mock release host", () => {
   let stage: string;
   let home: string;


### PR DESCRIPTION
A run fails when one app-server starts while another is still initializing:

```
[broker] Warning: broker did not become ready in time. Using direct connection.
[codex] app-server stderr: Error: failed to initialize sqlite state runtime under ~/.codex
Fatal: App server process exited unexpectedly
```

Codex takes an exclusive lock on the shared sqlite state under `CODEX_HOME` while an app-server starts up, so when two start together, one of them fails. The contention is confined to initialization. Once running, app-servers coexist without interfering, which is why serializing startup is sufficient.

Reproducing it against the real binary, with six concurrent starts on a fresh `CODEX_HOME`:

| | Runs | Failed |
|---|---|---|
| As-is | 3 × 6 | **7 of 18**, failing with the stderr above |
| Serialized | 3 × 6 | **0 of 18**, about 2s in total |

The fix has three parts, one for each way the collision arises. A lock keyed on `CODEX_HOME` serializes the startups codex-collab controls. A single retry absorbs collisions with app-servers it does not control, such as an editor session or the codex TUI. A startup guard prevents the broker abandoning an app-server mid-initialization, which would otherwise hold the sqlite state indefinitely. Each commit message carries its own reasoning.

## Behaviour change

**Startups serialize per `CODEX_HOME`.** Concurrent invocations now queue for the initialization step, which measures 260 to 860ms depending on the size of the state directory (fresh, versus 333MB). Turns are unaffected. The lock fails open, so if it cannot be acquired the invocation proceeds and behaves as it does today.

**Broker spawn-readiness goes from 10s to 30s** (`CODEX_COLLAB_BROKER_READY_TIMEOUT_MS`). Giving up sooner achieves nothing, because the direct connection that follows pays the same startup cost, and starting it early is what produces the collision. The wait still ends the moment the broker process exits.

## Verification

799 tests, **0 fail on ubuntu, windows and macOS**. `tsc` clean. Each commit builds and passes on its own. The broker suite now runs on Windows, which it never has before, so `broker-server.ts` is covered on every platform.

## Validation this does not cover

- **Windows is verified by CI alone.** The broker suite runs there now, so the lifecycle changes are exercised by tests, though none of them have been run by hand on that platform. The startup lock is better covered, since its tests carry no platform gate and executed on the Windows runner.
- **Cross-process concurrency is simulated.** The reproduction runs six startups inside a single process. Two separate invocations racing each other is the case the lock exists for, and that has not been tested.
- The failure is intermittent, so not seeing it after this lands is weak evidence on its own.
